### PR TITLE
[7.12] fix doc build

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -3,7 +3,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 :doctype: book
 :beats-repo-dir: {beats-root}
-:fleet-repo-dir: {observability-docs-root}/docs/en/ingest-management
+:fleet-repo-dir: {ingest-docs-root}/docs/en/ingest-management
 :apm-repo-dir: {apm-server-root}/docs
 :forum: https://discuss.elastic.co/
 :tab-widgets: {fleet-repo-dir}/tab-widgets


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.12`:
 - [fix doc build](https://github.com/elastic/ingest-docs/pull/78)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)