### PR TITLE
Add note on location of proxy settings for artifact download

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
@@ -27,7 +27,7 @@ Configure proxy settings for {agent} when it must connect through a proxy server
 to:
 
 * Download artifacts from `artifacts.elastic.co` for subprocesses or binary
-upgrades
+upgrades (use <<fleet-agent-binary-download-settings>>)
 * Send data to {es}
 * Retrieve agent policies from {fleet-server}
 * Retrieve agent policies from {es} (only needed for agents running {fleet-server})
@@ -131,6 +131,8 @@ HTTP_PROXY=http://my.proxy:8080
 ----
 
 After adding environment variables, restart the service.
+
+NOTE: If you use a proxy server to download artifacts from `artifacts.elastic.co`, configure <<fleet-agent-binary-download-settings>>.
 
 [discrete]
 [[proxy-settings-in-agent-policy]]

--- a/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-support.asciidoc
@@ -132,7 +132,7 @@ HTTP_PROXY=http://my.proxy:8080
 
 After adding environment variables, restart the service.
 
-NOTE: If you use a proxy server to download artifacts from `artifacts.elastic.co`, configure <<fleet-agent-binary-download-settings>>.
+NOTE: If you use a proxy server to download new agent versions from `artifacts.elastic.co` for upgrading, configure <<fleet-agent-binary-download-settings>>. 
 
 [discrete]
 [[proxy-settings-in-agent-policy]]


### PR DESCRIPTION
This PR replaces https://github.com/elastic/observability-docs/pull/2844.