### PR TITLE
Add decode duration and move fields processors to docs

### DIFF
--- a/docs/en/ingest-management/processors/processor-decode_duration.asciidoc
+++ b/docs/en/ingest-management/processors/processor-decode_duration.asciidoc
@@ -1,0 +1,31 @@
+[[decode_duration-processor]]
+= Decode duration
+
+++++
+<titleabbrev>decode_duration</titleabbrev>
+++++
+
+The `decode_duration` processor decodes a Go-style duration string into a specific `format`.
+
+For more information about the Go `time.Duration` string style, refer to the https://pkg.go.dev/time#Duration[Go documentation].
+[discrete]
+== Example
+
+[source,yaml]
+----
+processors:
+  - decode_duration:
+      field: "app.rpc.cost"
+      format: "milliseconds"
+----
+
+[discrete]
+== Configuration settings
+
+[options="header"]
+|======
+| Name             | Required | Default                  | Description                                                   |
+| `field`          | yes      |                          | Which field of event needs to be decoded as `time.Duration`   |
+| `format`         | yes      | `milliseconds`           | Supported formats: `milliseconds`/`seconds`/`minutes`/`hours` |
+|======
+

--- a/docs/en/ingest-management/processors/processor-move_fields.asciidoc
+++ b/docs/en/ingest-management/processors/processor-move_fields.asciidoc
@@ -1,0 +1,97 @@
+[[move_fields-processor]]
+= Move fields
+
+++++
+<titleabbrev>move_fields</titleabbrev>
+++++
+
+The `move_fields` processor moves event fields from one object into another. It can also rearrange fields or add a prefix to fields.
+
+The processor extracts fields from `from`, then uses `fields` and `exclude` as filters to choose which fields to move into the `to` field.
+
+[discrete]
+== Example
+
+For example, given the following event:
+
+[source,json]
+----
+{
+  "app": {
+    "method": "a",
+    "elapsed_time": 100,
+    "user_id": 100,
+    "message": "i'm a message"
+  }
+}
+----
+
+To move `method` and `elapsed_time` into another object, use this configuration:
+
+[source,yaml]
+----
+processors:
+  - move_fields:
+      from: "app"
+      fields: ["method", "elapsed_time"],
+      to: "rpc."
+----
+
+Your final event will be:
+
+[source,json]
+----
+{
+  "app": {
+    "user_id": 100,
+    "message": "i'm a message",
+    "rpc": {
+      "method": "a",
+      "elapsed_time": 100
+    }
+  }
+}
+----
+
+
+To add a prefix to the whole event:
+
+[source,json]
+----
+{
+  "app": { "method": "a"},
+  "cost": 100
+}
+----
+
+Use this configuration:
+
+[source,yaml]
+----
+processors:
+  - move_fields:
+      to: "my_prefix_"
+----
+
+Your final event will be:
+
+[source,json]
+----
+{
+  "my_prefix_app": { "method": "a"},
+  "my_prefix_cost": 100
+}
+----
+
+[discrete]
+== Configuration settings
+
+[options="header"]
+|======
+| Name                    | Required | Default                  | Description                                                                                           |
+| `from`                  | no       |                          | Which field you want extract. This field and any nested fields will be moved into `to` unless they are filtered out. If empty, indicates event root.         |
+| `fields`                | no       |                          | Which fields to extract from `from` and move to `to`. An empty list indicates all fields.                   |
+| `ignore_missing`        | no       | false                    | Ignore "not found" errors when extracting fields.                                |
+| `exclude`               | no       |                          | A list of fields to exclude and not move.                                               |
+| `to`                    | yes      |                          | These fields extract from `from` destination field prefix the `to` will base on fields root.          |
+|======

--- a/docs/en/ingest-management/processors/processors-list.asciidoc
+++ b/docs/en/ingest-management/processors/processors-list.asciidoc
@@ -38,6 +38,8 @@ include::processor-decode_cef.asciidoc[leveloffset=+1]
 
 include::processor-decode_csv_fields.asciidoc[leveloffset=+1]
 
+include::processor-decode_duration.asciidoc[leveloffset=+1]
+
 include::processor-decode_json_fields.asciidoc[leveloffset=+1]
 
 include::processor-decode_xml.asciidoc[leveloffset=+1]
@@ -61,6 +63,8 @@ include::processor-extract_array.asciidoc[leveloffset=+1]
 include::processor-fingerprint.asciidoc[leveloffset=+1]
 
 include::processor-include_fields.asciidoc[leveloffset=+1]
+
+include::processor-move_fields.asciidoc[leveloffset=+1]
 
 include::processor-parse_aws_vpc_flow_log.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR closes [Issue 2545](https://github.com/elastic/observability-docs/issues/2545)

The decode_duration and move_fields processors were added to Beats in 8.6. This PR adds them to the[ processors section](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) of the Fleet and Elastic Agent Guide.