### PR TITLE
Create .backportrc.json

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,18 @@
+{
+  // Required
+  "repoOwner": "elastic",
+  "repoName": "ingest-docs",
+
+  // the branches available to backport to
+  "targetBranchChoices": ["main", "8.7", "8.6", "7.17"],
+
+  // Optional: automatically merge backport PR
+  "autoMerge": true,
+  "autoMergeMethod": "squash",
+
+  // Optional: Automatically detect which branches a pull request should be backported to based on the pull request labels.
+  // In this case, adding the label "auto-backport-to-production" will backport the PR to the "production" branch
+  "branchLabelMapping": {
+    "^auto-backport-to-(.+)$": "$1"
+  }
+}


### PR DESCRIPTION
Adds the ability to just run `npx backport` to backport any PR to multiple branches.