### PR TITLE
Add Fleet & Agent 7.17.10 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.10>>
+
 * <<release-notes-7.17.9>>
 
 * <<release-notes-7.17.8>>
@@ -38,6 +40,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.10 relnotes
+
+[[release-notes-7.17.10]]
+== {fleet} and {agent} 7.17.10
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.10 relnotes
 
 // begin 7.17.9 relnotes
 


### PR DESCRIPTION
This adds the 7.17.10 Fleet & Agent Release Notes:

 - Fleet: No adds from the Kibana RN PR
 - Fleet Server: **TBD**
 - Elastic Agent: **TBD**