### PR TITLE
Add Fleet & Agent 7.17.10 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -46,7 +46,14 @@ Also see:
 [[release-notes-7.17.10]]
 == {fleet} and {agent} 7.17.10
 
-There are no bug fixes for {fleet} or {agent} in this release.
+Review important information about the {fleet} and {agent} 7.17.10 release.
+
+[discrete]
+[[bug-fixes-7.17.10]]
+=== Bug fixes
+
+{fleet-server}::
+* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operations would fail when an error was returned by Elastic in a raw string instead of JSON format. {fleet-server-pull}2079[#2079]
 
 // end 7.17.10 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.10>>
+
 * <<release-notes-7.17.9>>
 
 * <<release-notes-7.17.8>>
@@ -38,6 +40,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.10 relnotes
+
+[[release-notes-7.17.10]]
+== {fleet} and {agent} 7.17.10
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.10 relnotes
 
 // begin 7.17.9 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -46,14 +46,7 @@ Also see:
 [[release-notes-7.17.10]]
 == {fleet} and {agent} 7.17.10
 
-Review important information about the {fleet} and {agent} 7.17.10 release.
-
-[discrete]
-[[bug-fixes-7.17.10]]
-=== Bug fixes
-
-{fleet-server}::
-* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operations would fail when an error was returned by Elastic in a raw string instead of JSON format. {fleet-server-pull}2079[#2079]
+There are no bug fixes for {fleet} or {agent} in this release.
 
 // end 7.17.10 relnotes
 


### PR DESCRIPTION
This adds the 7.17.10 Fleet & Agent Release Notes:

 - Fleet: No PRs from the [Kibana 7.17.10 release notes PR](https://github.com/elastic/kibana/pull/155188)
 - Fleet Server: [No BC1 changelog for 7.17.10](https://github.com/elastic/fleet-server/tree/affa52ad114d0376e174902cbb1520f83dbd1b2f/changelog/fragments)
 - Elastic Agent: [No changes listed in the 7.17.10 BC1 summary](https://staging.elastic.co/7.17.10-e7809e80/summary-7.17.10.html)

**Preview**
![Screenshot 2023-04-24 at 9 09 46 AM](https://user-images.githubusercontent.com/41695641/234006046-45073340-f482-41b1-b8c1-70f585430630.png)

