### PR TITLE
Fix links pointing to 'master'

### DIFF
--- a/docs/en/ingest-management/elastic-agent/run-container-common/kibana-fleet-data.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-container-common/kibana-fleet-data.asciidoc
@@ -9,7 +9,7 @@ include::{observability-docs-root}/docs/en/shared/open-kibana/widget.asciidoc[]
 [role="screenshot"]
 image::images/kibana-fleet-agents-overview.png[{agent}s {fleet} page]
 
-. To view data flowing in, go to *Analytics -> Discover* and select the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, https://www.elastic.co/guide/en/kibana/master/data-views.html[create a data view] for them.
+. To view data flowing in, go to *Analytics -> Discover* and select the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, {kibana-ref}/data-views.html[create a data view] for them.
 
 . To view predefined dashboards, either select *Analytics->Dashboard* or <<view-integration-assets,install assets through an integration>>.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -68,7 +68,7 @@ include::run-container-common/deploy-elastic-agent.asciidoc[]
 include::{observability-docs-root}/docs/en/shared/open-kibana/widget.asciidoc[]
 --
 
-. You can see data flowing in by going to *Analytics -> Discover* and selecting the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, https://www.elastic.co/guide/en/kibana/master/data-views.html[create a data view] for them.
+. You can see data flowing in by going to *Analytics -> Discover* and selecting the index `metrics-*`, or even more specific, `metrics-kubernetes.*`. If you can't see these indexes, {kibana-ref}/data-views.html[create a data view] for them.
 
 . You can see predefined dashboards by selecting *Analytics->Dashboard*, or by <<view-integration-assets,installing assets through an integration>>.
 


### PR DESCRIPTION
This pre-emptively fixes some links that will break if we rename `master` to `main` in the docs builds.