### PR TITLE
Add instructions on customizing installation base path for Elastic Agent

### DIFF
--- a/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
@@ -1,7 +1,6 @@
 [[installation-layout]]
 = Installation layout
 
-{agent} files are installed in the following locations. You cannot override
-these installation paths because they are required for upgrades.
+{agent} files are installed in the following locations.
 
 include::{tab-widgets}/install-layout-widget.asciidoc[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -14,6 +14,8 @@ Log files for {beats} shippersfootnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
+You can install {agent} in a custom base path that's different from `/Library`.  When installing {agent} with the `./elastic-agent install`
+command, provide the custom base path via the `--base-path` CLI option.
 // end::mac[]
 
 // tag::linux[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -50,6 +50,8 @@ Log files for {agent}footnote:lognumbering[]
 `C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\default\*-json.log*`::
 Log files for {beats} shippers
 
+You can install {agent} in a custom base path that's different from `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
+command, provide the custom base path via the `--base-path` CLI option.
 // end::win[]
 
 // tag::deb[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -33,8 +33,8 @@ Log files for {beats} shippers
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
-You can install {agent} in a custom base path that's different from `/opt`.  When installing {agent} with the `./elastic-agent install`
-command, provide the custom base path via the `--base-path` CLI option.
+You can install {agent} in a custom base path other than `/opt`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::linux[]
 
 // tag::win[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -50,8 +50,8 @@ Log files for {agent}footnote:lognumbering[]
 `C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\default\*-json.log*`::
 Log files for {beats} shippers
 
-You can install {agent} in a custom base path that's different from `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
-command, provide the custom base path via the `--base-path` CLI option.
+You can install {agent} in a custom base path other than `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::win[]
 
 // tag::deb[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -33,6 +33,8 @@ Log files for {beats} shippers
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
+You can install {agent} in a custom base path that's different from `/opt`.  When installing {agent} with the `./elastic-agent install`
+command, provide the custom base path via the `--base-path` CLI option.
 // end::linux[]
 
 // tag::win[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -14,8 +14,8 @@ Log files for {beats} shippersfootnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
-You can install {agent} in a custom base path that's different from `/Library`.  When installing {agent} with the `./elastic-agent install`
-command, provide the custom base path via the `--base-path` CLI option.
+You can install {agent} in a custom base path other than `/Library`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::mac[]
 
 // tag::linux[]


### PR DESCRIPTION
This PR modifies the Installation Layout documentation for Elastic Agent.  It adds instructions to the MacOS, Linux, and Windows tabs on customizing the installation base path. 

As of this writing, we do not have a way to customize the installation base path for Debian or RPM packaged Elastic Agents.  So the instructions in those two tabs remain unchanged.

Corresponding implementation PR: https://github.com/elastic/elastic-agent/pull/2500