### PR TITLE
Remove Subcategories feature from 8.7 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -135,7 +135,6 @@ The 8.7.0 release adds the following new and notable features.
 * Enable diagnostics feature flag and change query for files to use upload_id {kibana-pull}149575[#149575]
 * Add experimental toggles for doc-value-only {kibana-pull}149131[#149131]
 * Display agent metrics, CPU and memory in the agent list table and agent details page {kibana-pull}149119[#149119]
-* Implement subcategories in integrations UI {kibana-pull}148894[#148894]
 * Add rollout period to upgrade action {kibana-pull}148240[#148240]
 * Add per-policy inactivity timeout and use runtime fields for agent status {kibana-pull}147552[#147552]
 * Show dataset combo box for input packages {kibana-pull}147015[#147015]


### PR DESCRIPTION
Removes the Subcategories feature from the 8.7 Release Notes since the feature is deferred to 8.8.

Closes: #162