### PR TITLE
Fix Fleet Server pull and issue attributes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -1,0 +1,362 @@
+// Use these for links to issue and pulls.
+:kib-issue: https://github.com/elastic/kibana/issues/
+:kib-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.17.10>>
+
+* <<release-notes-7.17.9>>
+
+* <<release-notes-7.17.8>>
+
+* <<release-notes-7.17.7>>
+
+* <<release-notes-7.17.6>>
+
+* <<release-notes-7.17.5>>
+
+* <<release-notes-7.17.4>>
+
+* <<release-notes-7.17.3>>
+
+* <<release-notes-7.17.2>>
+
+* <<release-notes-7.17.1>>
+
+* <<release-notes-7.17.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.10 relnotes
+
+[[release-notes-7.17.10]]
+== {fleet} and {agent} 7.17.10
+
+Review important information about the {fleet} and {agent} 7.17.10 release.
+
+[discrete]
+[[bug-fixes-7.17.10]]
+=== Bug fixes
+
+{fleet-server}::
+* Accept raw errors as a fallback to detailed error type. This fixes a bug that enrollment or other operations would fail when an error was returned by Elastic in a raw string instead of JSON format. {fleet-server-pull}2079[#2079]
+
+// end 7.17.10 relnotes
+
+// begin 7.17.9 relnotes
+
+[[release-notes-7.17.9]]
+== {fleet} and {agent} 7.17.9
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.9 relnotes
+
+// begin 7.17.8 relnotes
+
+[[release-notes-7.17.8]]
+== {fleet} and {agent} 7.17.8
+
+Review important information about the {fleet} and {agent} 7.17.8 release.
+
+[discrete]
+[[breaking-changes-7.17.8]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-PR32493X]]
+.{fleet-server} now rejects certificates signed with SHA-1
+[%collapsible]
+====
+*Details* +
+With the upgrade to Go 1.18, {fleet-server} now rejects certificates signed with
+SHA-1. For more information, refer to the Go 1.18
+https://tip.golang.org/doc/go1.18#sha1[release notes].
+
+*Impact* +
+Do not sign certificates with SHA-1. If you are using old certificates signed
+with SHA-1, update them now.
+====
+
+// end 7.17.8 relnotes
+
+// begin 7.17.7 relnotes
+
+[[release-notes-7.17.7]]
+== {fleet} and {agent} 7.17.7
+
+Review important information about the {fleet} and {agent} 7.17.7 release.
+
+[discrete]
+[[breaking-changes-7.17.7]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-PR32493]]
+.{agent} now rejects certificates signed with SHA-1
+[%collapsible]
+====
+*Details* +
+With the upgrade to Go 1.18, {fleet-server} now rejects certificates signed with
+SHA-1. For more information, refer to the Go 1.18
+https://tip.golang.org/doc/go1.18#sha1[release notes].
+
+*Impact* +
+Do not sign certificates with SHA-1. If you are using old certificates signed
+with SHA-1, update them now.
+====
+
+[discrete]
+[[bug-fixes-7.17.7]]
+=== Bug fixes
+
+{fleet}::
+No bug fixes for this release.
+
+{agent}::
+Fix `add_fields` processor on Docker provider {beats-pull}33269[#33269]
+
+// end 7.17.7 relnotes
+
+// begin 7.17.6 relnotes
+
+[[release-notes-7.17.6]]
+== {fleet} and {agent} 7.17.6
+
+Review important information about the {fleet} and {agent} 7.17.6 release.
+
+[discrete]
+[[bug-fixes-7.17.6]]
+=== Bug fixes
+
+{fleet}::
+* Invalidate api keys in agents `default_api_key_history` on force unenroll
+{kib-pull}135910[#135910]
+
+{agent}::
+* Allow colon (`:`) characters in dynamic variables {agent-issue}624[#624]
+{beats-pull}32407[#32407]
+* Allow dash (`-`) characters in variable names in EQL expressions
+{agent-issue}709[#709] {beats-pull}32350[#32350]
+* Allow slash (`/`) characters in variable names in EQL and transpiler
+{agent-issue}715[#715] {beats-pull}32528[#32528]
+* Fix problem with {agent} incorrectly creating a {filebeat} `redis` input when
+a policy contains a {packetbeat} `redis` input {agent-issue}427[#427]
+{beats-pull}32361[#32361]
+
+// end 7.17.6 relnotes
+
+// begin 7.17.5 relnotes
+
+[[release-notes-7.17.5]]
+== {fleet} and {agent} 7.17.5
+
+Review important information about the {fleet} and {agent} 7.17.5 release.
+
+[discrete]
+[[bug-fixes-7.17.5]]
+=== Bug fixes
+
+{agent}::
+* Bulk reassign kuery optimize {kib-pull}134673[#134673]
+
+// end 7.17.5 relnotes
+
+// begin 7.17.4 relnotes
+
+[[release-notes-7.17.4]]
+== {fleet} and {agent} 7.17.4
+
+Review important information about the {fleet} and {agent} 7.17.4 release.
+
+[discrete]
+[[bug-fixes-7.17.4]]
+=== Bug fixes
+
+{agent}::
+* Increase the download artifact timeout to 10 mins and add log download
+statistics. {beats-pull}31461[#31461]
+
+// end 7.17.4 relnotes
+
+// begin 7.17.3 relnotes
+
+[[release-notes-7.17.3]]
+== {fleet} and {agent} 7.17.3
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.3 relnotes
+
+// begin 7.17.2 relnotes
+
+[[release-notes-7.17.2]]
+== {fleet} and {agent} 7.17.2
+
+Review important information about the {fleet} and {agent} 7.17.2 release.
+
+[discrete]
+[[bug-fixes-7.17.2]]
+=== Bug fixes
+
+{fleet}::
+* Use validated fields for `default_fields` index setting. {kib-pull}128094[#128094]
+* Fix links to Agent logs for APM, Endpoint, synthetics, and osquery. {kib-pull}127480[#127480]
+* Make input IDs unique in agent policy yaml. {kib-pull}127343[#127343]
+
+{agent}::
+* Propagate input ID from the Agent policy into the Filebeat configuration. Note
+that no validation is performed on this field. {beats-pull}30386[#30386]
+* Fix the start sequence of Beats that was non-deterministic making Beats missing their
+configuration from Agent and not sending events. {beats-pull}30694[#30694]
+
+// end 7.17.2 relnotes
+
+// begin 7.17.1 relnotes
+
+[[release-notes-7.17.1]]
+== {fleet} and {agent} 7.17.1
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.1 relnotes
+
+// begin 7.17.0 relnotes
+
+[[release-notes-7.17.0]]
+== {fleet} and {agent} 7.17.0
+
+The Docker base image has changed from CentOS 7 to Ubuntu 20.04. {beats-issue}29681[#29681]
+
+// end 7.17.0 relnotes
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 7.17.x relnotes
+
+//[[release-notes-7.17.x]]
+//== {fleet} and {agent} 7.17.x
+
+//Review important information about the {fleet} and {agent} 7.17.x release.
+
+//[discrete]
+//[[security-updates-7.17.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-7.17.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-7.17.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-7.17.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 7.17.x, and will be removed in
+//8.0.0. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 7.17.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-7.17.x]]
+//=== New features
+
+//The 7.17.x release adds the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-7.17.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-7.17.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 7.17.x relnotes


### PR DESCRIPTION
These attributes are currently pointing to the elastic/beats repo, which I assume was a copy & paste error.

I noticed this in the 7.17 branch (where it breaks the Release Notes link to a PR) so this will need to be backported to all available branches.