### PR TITLE
Update certificates.asciidoc

### DIFF
--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -231,7 +231,7 @@ Where:
 `fleet-server-service-token`::
 Service token to use to communicate with {es}.
 `fleet-server-es-ca`::
-CA certificate that the current fleet server uses to connect to {es}.
+CA certificate that the current {fleet-server} uses to connect to {es}.
 `certificate-authorities`::
 List of paths to PEM encoded CA certificate files that should be trusted 
 for the other Elastic Agents uses to connect to this {fleet-server}

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -87,7 +87,7 @@ traffic between {agent}s and {fleet-server}.
 [discrete]
 == Encrypt traffic between {agent}s, {fleet-server}, and {es}
 
-{fleet-server} needs a CA certificate or the CA fingerprint to connect securely to {es}. It also
+{fleet-server} needs a CA certificate or the CA n to connect securely to {es}. It also
 needs to expose a {fleet-server} certificate so other {agent}s can connect to it
 securely.
 
@@ -142,8 +142,8 @@ the *Action* column.
 {es}:
 
 // lint ignore elasticsearch
-* If you have a CA trusted fingerprint, specify it in the
-*Elasticsearch CA trusted fingerprint* field. To learn more, refer to the
+* If you have a valid HEX encoded SHA-256 CA trusted fingerprint from root CA, 
+specify it in the *Elasticsearch CA trusted fingerprint* field. To learn more, refer to the
 {ref}/configuring-stack-security.html[{es} security documentation].
 
 * Otherwise, under *Advanced YAML configuration*, set
@@ -231,13 +231,17 @@ Where:
 `fleet-server-service-token`::
 Service token to use to communicate with {es}.
 `fleet-server-es-ca`::
-CA certificate to use to connect to {es}.
+CA certificate that the current fleet server uses to connect to {es}.
 `certificate-authorities`::
-CA certificate to use to connect to {fleet-server}.
+List of paths to PEM encoded CA certificate files that should be trusted 
+for the other Elastic Agents uses to connect to this {fleet-server}
 `fleet-server-cert`::
-Certificate to use for the exposed {fleet-server} HTTPS endpoint.
+Specifies the path for the PEM encoded certificate (or certificate chain) 
+which is associated with the fleet-server-cert-key to expose this {fleet-server} HTTPS endpoint 
+to the other Elastic Agents
 `fleet-server-cert-key`::
-Private key to use for the exposed {fleet-server} HTTPS endpoint.
+Private key to use to expose this {fleet-server} HTTPS endpoint 
+to the other Elastic Agents
 
 Note that additionally an optional passphrase for the private key may be specified with:
 

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -241,7 +241,7 @@ which is associated with the fleet-server-cert-key to expose this {fleet-server}
 to the other {agents}
 `fleet-server-cert-key`::
 Private key to use to expose this {fleet-server} HTTPS endpoint 
-to the other Elastic Agents
+to the other {agents}
 
 Note that additionally an optional passphrase for the private key may be specified with:
 

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -236,9 +236,9 @@ CA certificate that the current {fleet-server} uses to connect to {es}.
 List of paths to PEM-encoded CA certificate files that should be trusted 
 for the other {agents} to connect to this {fleet-server}
 `fleet-server-cert`::
-Specifies the path for the PEM encoded certificate (or certificate chain) 
+The path for the PEM-encoded certificate (or certificate chain) 
 which is associated with the fleet-server-cert-key to expose this {fleet-server} HTTPS endpoint 
-to the other Elastic Agents
+to the other {agents}
 `fleet-server-cert-key`::
 Private key to use to expose this {fleet-server} HTTPS endpoint 
 to the other Elastic Agents

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -233,8 +233,8 @@ Service token to use to communicate with {es}.
 `fleet-server-es-ca`::
 CA certificate that the current {fleet-server} uses to connect to {es}.
 `certificate-authorities`::
-List of paths to PEM encoded CA certificate files that should be trusted 
-for the other Elastic Agents uses to connect to this {fleet-server}
+List of paths to PEM-encoded CA certificate files that should be trusted 
+for the other {agents} to connect to this {fleet-server}
 `fleet-server-cert`::
 Specifies the path for the PEM encoded certificate (or certificate chain) 
 which is associated with the fleet-server-cert-key to expose this {fleet-server} HTTPS endpoint 

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -87,7 +87,7 @@ traffic between {agent}s and {fleet-server}.
 [discrete]
 == Encrypt traffic between {agent}s, {fleet-server}, and {es}
 
-{fleet-server} needs a CA certificate or the CA n to connect securely to {es}. It also
+{fleet-server} needs a CA certificate or the CA fingerprint to connect securely to {es}. It also
 needs to expose a {fleet-server} certificate so other {agent}s can connect to it
 securely.
 


### PR DESCRIPTION
This is the document ER for https://www.elastic.co/guide/en/fleet/master/secure-connections.html.

Self-managed Fleet Server is the most complicated component when setting TLS/SSL between Fleet Server and Elasticsearch. Because the Fleet Server can be the TLS/SSL server that need be exposed the endpoint to other Elastic Agents which communicate with this Fleet Server. The current documentation has no specific comment on this and users got lots of confusion. The fix will give more clear explanation to avoid confusion. And it will
- clarify which format of fingerprint should be created from which CA if the user has root + intermediate CA
- add the clarification of which component is using the certificate in the options.

Feel free to change the wording if you have better suggestions.

After changing the content, we also need to change https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-install-command (`docs/en/ingest-management/commands.asciidoc`) to align with the changes.