### PR TITLE
Change the known issue number to pint to the correct one

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -90,13 +90,13 @@ For more information, refer to {agent-issue}2103[#2103].
 Ensure that the application used to install {agent} (for example, the Terminal or custom package) has Full Disk Access before running `sudo ./elastic-agent install`.
 ====
 
-[[known-issue-issue-2342-8.6.2]]
+[[known-issue-issue-2343-8.6.2]]
 .{agent} upgrades scheduled for a future time do not run.
 [%collapsible]
 ====
 *Details* +
 A known issue in {agent} may prevent upgrades scheduled to execute at a later time from running.
-For more information refer to {agent-issue}2342[#2342].
+For more information refer to {agent-issue}2343[#2343].
 
 *Impact* +
 {kib} may show an agent as being stuck with the `Updating` status.
@@ -279,13 +279,13 @@ For more information, refer to {agent-issue}2103[#2103].
 Ensure that the application used to install {agent} (for example, the Terminal or custom package) has Full Disk Access before running `sudo ./elastic-agent install`.
 ====
 
-[[known-issue-issue-2342-8.6.1]]
+[[known-issue-issue-2343-8.6.1]]
 .{agent} upgrades scheduled for a future time do not run.
 [%collapsible]
 ====
 *Details* +
 A known issue in {agent} may prevent upgrades scheduled to execute at a later time from running.
-For more information refer to {agent-issue}2342[#2342].
+For more information refer to {agent-issue}2343[#2343].
 
 *Impact* +
 {kib} may show an agent as being stuck with the `Updating` status.
@@ -437,13 +437,13 @@ For more information, refer to {agent-issue}2086[#2086].
 event data to {es} or Logstash.
 ====
 
-[[known-issue-issue-2342-8.6.0]]
+[[known-issue-issue-2343-8.6.0]]
 .{agent} upgrades scheduled for a future time do not run.
 [%collapsible]
 ====
 *Details* +
 A known issue in {agent} may prevent upgrades scheduled to execute at a later time from running.
-For more information refer to {agent-issue}2342[#2342].
+For more information refer to {agent-issue}2343[#2343].
 
 *Impact* +
 {kib} may show an agent as being stuck with the `Updating` status.


### PR DESCRIPTION
The known issue that "may prevent upgrades scheduled to execute at a later time from running" is pointing to the wrong GH issue.

The original PR https://github.com/elastic/observability-docs/pull/2726 correctly states:
> Add https://github.com/elastic/elastic-agent/issues/2343 as a known issue for 8.6.x releases

but  https://github.com/elastic/elastic-agent/issues/2342 was used instead.

This PR fixes that.