### PR TITLE
Fix link to loadbalance in Filebeat ref

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -168,7 +168,7 @@ configuration experience.
 queues by an end user. You can configure the output queue settings in standalone
 {agents}.
 
-|{filebeat-ref}/load-balancing.html[Load balance output hosts]
+|{filebeat-ref}/elasticsearch-output.html#_loadbalance[Load balance output hosts]
 |Within the {fleet} UI, you can add YAML settings to configure multiple hosts
 per output type, which enables load balancing.
 


### PR DESCRIPTION
PR https://github.com/elastic/beats/pull/35271 removes a page about load balancing which appears only in the Filebeat docs. This fixes the link from the Fleet and Agent docs to point to the load balancing description under the Filebeat Elasticsearch output type.

Rel: https://github.com/elastic/beats/pull/35271