### PR TITLE
Add precedent info for service token path and value in agent container

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -172,7 +172,8 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token"]
 `FLEET_SERVER_SERVICE_TOKEN`
 
-| (string) Service token to use for communication with {es}.
+| (string) Service token to use for communication with {es} and {kib} if <<kibana-fleet-setup>> is enabled.
+If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none
 
@@ -185,7 +186,8 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token-path"]
 `FLEET_SERVER_SERVICE_TOKEN_PATH`
 
-| (string) The path to the service token file to use for communication with {es}.
+| (string) The path to the service token file to use for communication with {es} and {kib} if <<kibana-fleet-setup>> is enabled.
+If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -172,7 +172,7 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token"]
 `FLEET_SERVER_SERVICE_TOKEN`
 
-| (string) Service token to use for communication with {es} and {kib} if <<kibana-fleet-setup>> is enabled.
+| (string) Service token to use for communication with {es} and {kib} if <<env-prepare-kibana-for-fleet,`KIBANA_FLEET_SETUP`>> is enabled.
 If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none
@@ -186,7 +186,7 @@ If the service token value and service token path are specified the value may be
 [id="env-{type}-fleet-server-service-token-path"]
 `FLEET_SERVER_SERVICE_TOKEN_PATH`
 
-| (string) The path to the service token file to use for communication with {es} and {kib} if <<kibana-fleet-setup>> is enabled.
+| (string) The path to the service token file to use for communication with {es} and {kib} if <<env-prepare-kibana-for-fleet,`KIBANA_FLEET_SETUP`>> is enabled.
 If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none


### PR DESCRIPTION
Add a description of how the service token value and path env vars are used in agent container mode.

Follow up to: https://github.com/elastic/elastic-agent/pull/2576