### PR TITLE
Revert "Add instructions on customizing installation base path for Elastic Agent"

### DIFF
--- a/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
@@ -1,6 +1,7 @@
 [[installation-layout]]
 = Installation layout
 
-{agent} files are installed in the following locations.
+{agent} files are installed in the following locations. You cannot override
+these installation paths because they are required for upgrades.
 
 include::{tab-widgets}/install-layout-widget.asciidoc[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -14,8 +14,6 @@ Log files for {beats} shippersfootnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
-You can install {agent} in a custom base path other than `/Library`.  When installing {agent} with the `./elastic-agent install`
-command, use the `--base-path` CLI option to specify the custom base path.
 // end::mac[]
 
 // tag::linux[]
@@ -33,8 +31,6 @@ Log files for {beats} shippers
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
-You can install {agent} in a custom base path other than `/opt`.  When installing {agent} with the `./elastic-agent install`
-command, use the `--base-path` CLI option to specify the custom base path.
 // end::linux[]
 
 // tag::win[]
@@ -50,8 +46,6 @@ Log files for {agent}footnote:lognumbering[]
 `C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\default\*-json.log*`::
 Log files for {beats} shippers
 
-You can install {agent} in a custom base path other than `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
-command, use the `--base-path` CLI option to specify the custom base path.
 // end::win[]
 
 // tag::deb[]


### PR DESCRIPTION
Reverts elastic/ingest-docs#160

Unfortunately, installing Elastic Agent in a custom base path does not work with Endpoint (yet).  As such we've decided to disallow users from using this feature until we have a clear path forward on how to make this feature work with Endpoint.

