### PR TITLE
Sensitive information is already being redacted from diagnostics

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -309,6 +309,9 @@ This archive collects the following information:
 
 Note that the diagnostics bundle is intended for debugging purposes only, its structure may change between releases.
 
+IMPORTANT: {agent} attempts to automatically redact credentials and API keys when creating diagnostics. 
+Please review the contents of the archive before sharing to ensure there are no credentials in plain text.
+
 [discrete]
 [[not-installing-no-logs-in-terminal]]
 == Some problems occur so early that insufficient logging is available

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -310,7 +310,7 @@ This archive collects the following information:
 Note that the diagnostics bundle is intended for debugging purposes only, its structure may change between releases.
 
 IMPORTANT: {agent} attempts to automatically redact credentials and API keys when creating diagnostics. 
-Please review the contents of the archive before sharing to ensure there are no credentials in plain text.
+Please review the contents of the archive before sharing to ensure that there are no credentials in plain text.
 
 [discrete]
 [[not-installing-no-logs-in-terminal]]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -309,9 +309,6 @@ This archive collects the following information:
 
 Note that the diagnostics bundle is intended for debugging purposes only, its structure may change between releases.
 
-IMPORTANT: The configuration files in the archive may have credentials in *plain text*.
-These will need to be manually redacted before the archive is shared.
-
 [discrete]
 [[not-installing-no-logs-in-terminal]]
 == Some problems occur so early that insufficient logging is available


### PR DESCRIPTION
The troubleshooting guide needs to be updated due to this merge: https://github.com/elastic/elastic-agent/pull/566


Replaces https://github.com/elastic/observability-docs/pull/2849.