### PR TITLE
[8.8] Add precedent info for service token path and value in agent container (#188)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -172,7 +172,8 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token"]
 `FLEET_SERVER_SERVICE_TOKEN`
 
-| (string) Service token to use for communication with {es}.
+| (string) Service token to use for communication with {es} and {kib} if <<env-prepare-kibana-for-fleet,`KIBANA_FLEET_SETUP`>> is enabled.
+If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none
 
@@ -185,7 +186,8 @@ Overrides `FLEET_TOKEN_POLICY_NAME` when set.
 [id="env-{type}-fleet-server-service-token-path"]
 `FLEET_SERVER_SERVICE_TOKEN_PATH`
 
-| (string) The path to the service token file to use for communication with {es}.
+| (string) The path to the service token file to use for communication with {es} and {kib} if <<env-prepare-kibana-for-fleet,`KIBANA_FLEET_SETUP`>> is enabled.
+If the service token value and service token path are specified the value may be used for setup and the path is passed to the agent in the container.
 
 *Default:* none
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Add precedent info for service token path and value in agent container (#188)](https://github.com/elastic/ingest-docs/pull/188)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)