### PR TITLE
Add known issue for agent 8.6.2 about not migrating unencrypted config

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -117,11 +117,11 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.2]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2.x or earlier.
 [%collapsible]
 ====
 *Details* +
-{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2.x or earlier
 This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
 For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 
@@ -326,11 +326,11 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.1]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2.x or earlier.
 [%collapsible]
 ====
 *Details* +
-{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2.x or earlier
 This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
 For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 
@@ -505,11 +505,11 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.0]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2.x or earlier.
 [%collapsible]
 ====
 *Details* +
-{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2.x or earlier
 This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
 For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -122,7 +122,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 *Details* +
 {agent} will not load `fleet.yml` information after upgrading to a version that uses encrypted configuration (> 8.3).
-For a managed agent the symptom manifests as the inability to connect back to fleet after upgrade and the following log:
+For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 
 [source,shell]
 ----

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -116,6 +116,25 @@ Custom yaml settings are silently ignored by {fleet}.
 Settings with input blocks, such as Max agents are still effective.
 ====
 
+[[known-issue-issue-2249-8.6.2]]
+.{agent} does not load fleet configuration after upgrade from unencrypted config
+[%collapsible]
+====
+*Details* +
+{agent} will not load `fleet.yml` information after upgrading to a version that uses encrypted configuration (> 8.3).
+For a managed agent the symptom manifests as the inability to connect back to fleet after upgrade and the following log:
+
+[source,shell]
+----
+Error: fleet configuration is invalid: empty access token
+...
+----
+For more information refer to {agent-issue}2249[#2249].
+
+*Impact* +
+{agent} loses the ability to connect back to {fleet} after upgrade.
+Fix for this issue is available in version 8.7.0 and higher, for versions 8.3-8.6 a re-enroll is necessary for the agent to connect back to {fleet}
+====
 
 [discrete]
 [[enhancements-8.6.2]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -117,7 +117,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.2]]
-.{agent} does not load {fleet} configuration after upgrading from {agent} version 8.2 or earlier
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -117,7 +117,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.2]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
 [%collapsible]
 ====
 *Details* +
@@ -326,7 +326,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.1]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
 [%collapsible]
 ====
 *Details* +
@@ -505,7 +505,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.0]]
-.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier.
 [%collapsible]
 ====
 *Details* +

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -325,6 +325,27 @@ Custom yaml settings are silently ignored by {fleet}.
 Settings with input blocks, such as Max agents are still effective.
 ====
 
+[[known-issue-issue-2249-8.6.1]]
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
+[%collapsible]
+====
+*Details* +
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
+This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
+For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
+
+[source,shell]
+----
+Error: fleet configuration is invalid: empty access token
+...
+----
+For more information refer to {agent-issue}2249[#2249].
+
+*Impact* +
+{agent} loses the ability to connect back to {fleet} after upgrade.
+Fix for this issue is available in version 8.7.0 and higher, for version 8.6 a re-enroll is necessary for the agent to connect back to {fleet}
+====
+
 [discrete]
 [[bug-fixes-8.6.1]]
 === Bug fixes
@@ -481,6 +502,27 @@ For more information refer to {fleet-server-issue}2303[#2303].
 *Impact* +
 Custom yaml settings are silently ignored by {fleet}.
 Settings with input blocks, such as Max agents are still effective.
+====
+
+[[known-issue-issue-2249-8.6.0]]
+.{agent} does not load {fleet} configuration when upgrading to {agent} version 8.6.x from version 8.2 or earlier
+[%collapsible]
+====
+*Details* +
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
+This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
+For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
+
+[source,shell]
+----
+Error: fleet configuration is invalid: empty access token
+...
+----
+For more information refer to {agent-issue}2249[#2249].
+
+*Impact* +
+{agent} loses the ability to connect back to {fleet} after upgrade.
+Fix for this issue is available in version 8.7.0 and higher, for version 8.6 a re-enroll is necessary for the agent to connect back to {fleet}
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -117,11 +117,12 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.2]]
-.{agent} does not load {fleet} configuration after upgrade from unencrypted config
+.{agent} does not load {fleet} configuration after upgrading from {agent} version 8.2 or earlier
 [%collapsible]
 ====
 *Details* +
-{agent} will not load `fleet.yml` information after upgrading to a version that uses encrypted configuration (> 8.3).
+{agent} will not load `fleet.yml` information after upgrading from a version up to 8.2 to 8.6.
+This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
 For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 
 [source,shell]
@@ -133,7 +134,7 @@ For more information refer to {agent-issue}2249[#2249].
 
 *Impact* +
 {agent} loses the ability to connect back to {fleet} after upgrade.
-Fix for this issue is available in version 8.7.0 and higher, for versions 8.3-8.6 a re-enroll is necessary for the agent to connect back to {fleet}
+Fix for this issue is available in version 8.7.0 and higher, for version 8.6 a re-enroll is necessary for the agent to connect back to {fleet}
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -121,7 +121,7 @@ Settings with input blocks, such as Max agents are still effective.
 [%collapsible]
 ====
 *Details* +
-{agent} will not load `fleet.yml` information after upgrading from a version up to 8.2 to 8.6.
+{agent} will not load `fleet.yml` information after upgrading to {agent} version 8.6.x from version 8.2 or earlier
 This is due to the unencrypted config stored in `fleet.yml` not being migrated correctly to the encrypted config store `fleet.enc`.
 For a managed agent the symptom manifests as the inability to connect to {fleet} after upgrade with the following log:
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.6.asciidoc
@@ -117,7 +117,7 @@ Settings with input blocks, such as Max agents are still effective.
 ====
 
 [[known-issue-issue-2249-8.6.2]]
-.{agent} does not load fleet configuration after upgrade from unencrypted config
+.{agent} does not load {fleet} configuration after upgrade from unencrypted config
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
Create a new entry for a known issue of agent not loading fleet configuration when upgrading from a version using unencrypted config `fleet.yml` to encrypted one `fleet.enc`