### PR TITLE
Add note about root/admin privilege to install / uninstall agents

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -5,8 +5,8 @@ NOTE: You can install only a single {agent} per host. Due to the fact that the {
 are only accessible by a superuser, {agent} will therefore also need to be executed with superuser permissions.
 
 NOTE: You might need to log in as a root user (or Administrator on Windows) to
-run the install and uninstall commands. After the {agent} service is installed and running, make
-sure you run these commands without prepending them with `./` to avoid
+run the commands described here. After the {agent} service is installed and running,
+make sure you run these commands without prepending them with `./` to avoid
 invoking the wrong binary.
 
 You have a few options for installing and managing an {agent}:

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -4,6 +4,11 @@
 NOTE: You can install only a single {agent} per host. Due to the fact that the {agent} may read data sources that 
 are only accessible by a superuser, {agent} will therefore also need to be executed with superuser permissions.
 
+NOTE: You might need to log in as a root user (or Administrator on Windows) to
+run the install and uninstall commands. After the {agent} service is installed and running, make
+sure you run these commands without prepending them with `./` to avoid
+invoking the wrong binary.
+
 You have a few options for installing and managing an {agent}:
 
 * **Install a {fleet}-managed {agent} (recommended)**


### PR DESCRIPTION
Right at the top of the Agent & Fleet [Command Reference main page](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html) we have a note about needing root / Administrator privileges to run commands. We should have a similar note at the top of the Install [Elastic Agents main page](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html), since that's where users planning to install Agent are most likely to see it.

Preview:
![Screenshot 2023-05-08 at 9 09 14 AM](https://user-images.githubusercontent.com/41695641/236833934-c8fa4914-9868-44be-b26b-8e230206c9d8.png)
