### PR TITLE
[8.8] Update content.asciidoc (#182)

### DIFF
--- a/docs/en/ingest-management/tab-widgets/run-agent-image/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/run-agent-image/content.asciidoc
@@ -28,14 +28,16 @@ docker run \
   --env FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host> \ <2>
   --env FLEET_SERVER_SERVICE_TOKEN=<service-token> \ <3>
   --env FLEET_SERVER_POLICY_ID=<fleet-server-policy> \ <4>
-  --rm docker.elastic.co/beats/elastic-agent:{version} <5>
+  -p 8220:8220 \ <5>
+  --rm docker.elastic.co/beats/elastic-agent:{version} <6>
 ----
 
 <1> Set to 1 to bootstrap Fleet Server on this Elastic Agent.
 <2> Your cluster's {es} host URL.
 <3> The {fleet} service token. <<create-fleet-enrollment-tokens,Generate one in the {fleet} UI>> if you don't have one already.
 <4> ID of the {fleet-server} policy. We recommend only having one fleet-server policy. To learn how to create a policy, refer to <<create-a-policy-no-ui>>.
-<5> If you want to run *elastic-agent-complete* image, replace `elastic-agent` to `elastic-agent-complete`. Use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetic tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.
+<5> publish container port 8220 to host.
+<6> If you want to run the *elastic-agent-complete* image, replace `elastic-agent` with `elastic-agent-complete`. Use the `elastic-agent` user instead of root to run Synthetics Browser tests. Synthetic tests cannot run under the root user. Refer to {observability-guide}/uptime-set-up.html[Synthetics {fleet} Quickstart] for more information.
 
 Refer to <<agent-environment-variables>> for all available options.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Update content.asciidoc (#182)](https://github.com/elastic/ingest-docs/pull/182)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)