### PR TITLE
[8.7] Add preview notice for FQDN feature (#211)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -28,6 +28,10 @@ You can specify the following settings in the Feature Flag section of the
 Fully qualified domain name (FQDN)::
 When enabled, information provided about the current host through the <<host-provider,host.name>> key, in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
 +
+preview::[]
++
+NOTE: FQDN reporting is not currently supported in {endpoint-sec} or APM.
++
 For FQDN reporting to work as expected, the hostname of the current host must either:
 +
 --

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -299,6 +299,10 @@ These settings control the format of information provided about the current host
 
 | When this setting is selected, information about the current host is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. The fully qualified hostname allows each host to be more easily identified when viewed in {kib}, for example.
 
+preview::[]
+
+NOTE: FQDN reporting is not currently supported in {endpoint-sec} or APM.
+
 For FQDN reporting to work as expected, the hostname of the current host must either:
 
 * Have a CNAME entry defined in DNS.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Add preview notice for FQDN feature (#211)](https://github.com/elastic/ingest-docs/pull/211)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)