### PR TITLE
[8.8] Update commands.asciidoc (#214)

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -126,6 +126,8 @@ to start the agent from a terminal.
 [discrete]
 === Synopsis
 
+// tag::enroll[]
+
 To enroll the {agent} in {fleet}:
 
 [source,shell]
@@ -142,6 +144,8 @@ elastic-agent enroll --url <string>
                      [--tag <string>]
                      [global-flags]
 ----
+
+// end::enroll[]
 
 To enroll the {agent} in {fleet} and set up {fleet-server}:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Update commands.asciidoc (#214)](https://github.com/elastic/ingest-docs/pull/214)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)