### PR TITLE
TEST: Docs CI checks

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -12,6 +12,8 @@
 [[release-notes]]
 = Release notes
 
+//test
+
 This section summarizes the changes in each release.
 
 * <<release-notes-8.7.1>>


### PR DESCRIPTION
TEST ONLY

This is to check if the docs CI checks are failing generally, or only for the 8.8.0 Release Notes PR.