### PR TITLE
[8.8] Add Fleet & Agent 8.8.0 release notes (#219)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -179,7 +179,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.7.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.8.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.7.asciidoc
@@ -46,6 +46,9 @@ The 8.7.1 release adds the following new and notable features.
 {fleet}::
 * The agent policy `Host name format` selector is now enabled by default {kibana-pull}154563[#154563]
 
+{agent}::
+* Diagnostics now preserve the Elastic Agent upgrade watcher logs, allowing upgrades that were rolled back to be debugged {agent-pull}2518[#2518] {agent-issue}2262[#2262]
+
 [discrete]
 [[bug-fixes-8.7.1]]
 === Bug fixes
@@ -57,7 +60,7 @@ The 8.7.1 release adds the following new and notable features.
 
 {agent}::
 * Fix parsing of paths from the `container-paths.yml` file used internally when `elastic-agent container` is run {agent-pull}2340[#2340]
-* Fix action acknowledgements taking up to 5 minutes. Fixed OSQuery live query results taking up to five minutes to show up in Kibana.{agent-pull}2406[#2406] {agent-issue}2410[#2410]
+* Fix action acknowledgements taking up to 5 minutes. Fixed OSQuery live query results taking up to five minutes to show up in Kibana {agent-pull}2406[#2406] {agent-issue}2410[#2410]
 * Fixes a bug that `logging.level` settings were not being respected, coming either from Fleet UI or a config file {agent-pull}2456[#2456] {agent-issue}2450[#2450]
 * Fixes a bug that caused an empty proxy from a Fleet managed {agent} policy to override the proxy set by `--proxy-url` {agent-pull}2468[#2468] {agent-issue}2304[#2304] {agent-issue}2447[#2447]
 * Ensure that the `/usr/local/bin` directory exists on MacOS during {agent} installation {agent-pull}2490[#2490] {agent-issue}2487[#2487]

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -1,0 +1,221 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.8.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.8.0 relnotes
+
+[[release-notes-8.8.0]]
+== {fleet} and {agent} 8.8.0
+
+Review important information about the {fleet} and {agent} 8.8.0 release.
+
+[discrete]
+[[new-features-8.8.0]]
+=== New features
+
+The 8.8.0 release Added the following new and notable features.
+
+{fleet}::
+* Added audit logging for core CRUD operations {kibana-pull}152118[#152118]
+* Added modal to display versions changelog {kibana-pull}152082[#152082]
+
+{fleet-server}::
+* Documented how to run the fleet server locally {fleet-server-pull}2212[#2212] {fleet-server-issue}1423[#1423]
+* {fleet-server} now supports file uploads for a limited subset of integrations {fleet-server-pull}1902[#1902]
+* Extended the {fleet-server} actions schema to support signed actions passing to the agent as a part of the agent tamper protection. {fleet-server-pull}2353[#2353]
+* {fleet-server} can now be run in stand-alone mode without needing to check into {kib} {fleet-server-pull}2359[#2359] {fleet-server-issue}2351[#2351]
+* Added support for gathering secret values from files {fleet-server-pull}2459[#2459]
+* Added action APM metadata to help debug agent actions {fleet-server-pull}2472[#2472]
+
+{agent}::
+* Added a specification file for the link:https://www.elastic.co/observability/universal-profiling[Universal Profiling Symbolizer] {agent-pull}2401[#2401]
+* Added a specification file for the link:https://www.elastic.co/observability/universal-profiling[Universal Profiling Collector] {agent-pull}2407[#2407]
+* Added support to specify the {fleet-server} `service_token` through a file specified with `service_token_file` {agent-pull}2424[#2424]
+
+[discrete]
+[[enhancements-8.8.0]]
+=== Enhancements
+
+{fleet}::
+* Added overview dashboards in fleet {kibana-pull}154914[#154914]
+* Added raw status to Agent details UI {kibana-pull}154826[#154826]
+* Added support for dynamic_namespace and dynamic_dataset {kibana-pull}154732[#154732]
+* Added the ability to show pipelines and mappings editor for input packages {kibana-pull}154077[#154077]
+* Added placeholder to integration select field {kibana-pull}153927[#153927]
+* Added the ability to show integration subcategories {kibana-pull}153591[#153591]
+* Added the ability to create and update the package policy API return 409 conflict when names are not unique {kibana-pull}153533[#153533]
+* Added the ability to display policy changes in Agent activity {kibana-pull}153237[#153237]
+* Added the ability to display errors in Agent activity with link to Logs {kibana-pull}152583[#152583]
+* Added support for select type in integrations {kibana-pull}152550[#152550]
+* Added the ability to make spaces plugin optional {kibana-pull}152115[#152115]
+* Added proxy ssl key and certificate to agent policy {kibana-pull}152005[#152005]
+* Added `_meta` field `has_experimental_data_stream_indexing_features` {kibana-pull}151853[#151853]
+* Added the ability to create templates and pipelines when updating package of a single package policy from type integration to input {kibana-pull}150199[#150199]
+* Added user's secondary authorization to Transforms {kibana-pull}154665[#154665]
+* Added support for the Cloud Defend application to {agent} {fleet-server-pull}2477[#2477]
+* Disabled signature validation in {agent} so that only {endpoint-sec} validates policies and actions {fleet-server-pull}2562[#2562]
+
+{fleet-server}::
+* Replaced upgrade expiration and `minimum_execution_duration` with rollout_duration_seconds` {fleet-server-pull}2243[#2243]
+* Added a `poll_timeout` attribute to check in requests that the client can use to inform {fleet-server} of how long the client will hold the polling connection open for {fleet-server-pull}2491[#2491] {fleet-server-issue}2337[#2337]
+* Added a `memory_limit` configuration setting to help prevent OOM errors {fleet-server-pull}2514[#2514]
+
+{agent}::
+* Make download of {agent} upgrade artifacts asynchronous during Fleet-managed upgrade and increase the download timeout to 2 hours {agent-pull}2205[#2205] {agent-issue}1706[#1706]
+* Make the language used in CLI commands more consistent {fleet-server-pull}2496[#2496]
+
+[discrete]
+[[bug-fixes-8.8.0]]
+=== Bug fixes
+
+{fleet}::
+* Fixes package license check to use new `conditions.elastic.subscription` field {kibana-pull}154831[#154831]
+* Fixes the OpenAPI spec from `/agent/upload` to `/agent/uploads` for Agent uploads API {kibana-pull}151722[#151722]
+
+{fleet-server}::
+* Filter out unused `UPDATE_TAGS` and `FORCE_UNENROLL` actions from being delivered to {agent} {fleet-server-pull}2200[#2200]
+* Ignore the `unenroll_timeout` field on agent policies as it has been replaced by a configurable inactivity timeout {fleet-server-pull}2096[#2096] {fleet-server-issue}2063[#2063]
+* Fixed {fleet-server} discarding duplicate `server` keys input when creating configuration from a policy {fleet-server-pull}2354[#2354] {fleet-server-issue}2303[#2303]
+* {fleet-server} will no longer restart subsystems like API listeners and the {es} client when the log level changes {fleet-server-pull}2454[#2454] {fleet-server-issue}2453[#2453]
+
+{agent}::
+* Fixed the formatting of system metricsets in example {agent} configuration file {agent-pull}2338[#2338]
+* Fixed the parsing of paths from the `container-paths.yml` file {agent-pull}2340[#2340]
+* Added a check to ensure that {agent} was bootstrapped with the `--fleet-server-*` options {agent-pull}2505[#2505] {agent-issue}2170[#2170]
+* Fixed an issue where inspect and diagnostics didn't include the local {agent} configuration {agent-pull}2529[#2529] {agent-issue}2390[#2390]
+* Fixed a bug that caused heap profiles captured in the agent diagnostics to be unusable {agent-pull}2549[#2549] {agent-issue}2530[#2530]
+* Fix an issue that occurs when specifing a `FLEET_SERVER_SERVICE_TOKEN_PATH` with the agent running in a Docker container where both the token value and path are passed in the enroll section of the agent setup {agent-pull}2576[#2576]
+
+// end 8.8.0 relnotes
+
+
+
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.7.x relnotes
+
+//[[release-notes-8.7.x]]
+//== {fleet} and {agent} 8.7.x
+
+//Review important information about the {fleet} and {agent} 8.7.x release.
+
+//[discrete]
+//[[security-updates-8.7.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.7.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.7.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.7.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.7.x, and will be removed in
+//8.7.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.7.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.7.x]]
+//=== New features
+
+//The 8.7.x release Added the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.7.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.7.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.7.x relnotes


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Add Fleet & Agent 8.8.0 release notes (#219)](https://github.com/elastic/ingest-docs/pull/219)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)