### PR TITLE
[8.8] Endpoint security supports the FQDN feature in 8.8. (#235)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -30,7 +30,7 @@ When enabled, information provided about the current host through the <<host-pro
 +
 preview::[]
 +
-NOTE: FQDN reporting is not currently supported in {endpoint-sec} or APM.
+NOTE: FQDN reporting is not currently supported in APM.
 +
 For FQDN reporting to work as expected, the hostname of the current host must either:
 +

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -301,7 +301,7 @@ These settings control the format of information provided about the current host
 
 preview::[]
 
-NOTE: FQDN reporting is not currently supported in {endpoint-sec} or APM.
+NOTE: FQDN reporting is not currently supported in APM.
 
 For FQDN reporting to work as expected, the hostname of the current host must either:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Endpoint security supports the FQDN feature in 8.8. (#235)](https://github.com/elastic/ingest-docs/pull/235)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)