### PR TITLE
[Docs] Add missing Fleet scalability options

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -173,7 +173,7 @@ Burst of file end upload requests to accomodate before falling back to the rate 
 Maximum size in bytes of the uploadEnd API request body.
 
 `upload_chunk_limit.max`:::
-Maximum number of agents that can call the uploadChunk API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+Maximum number of agents that can call the uploadChunk API concurrently. This setting allows the user to avoid overloading the Fleet Server from uploadChunk API calls.
 
 `upload_chunk_limit.interval`:::
 How frequently agents can submit file chunk upload requests to the Fleet Server.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -161,7 +161,7 @@ Burst of file start upload requests to accomodate before falling back to the rat
 Maximum size in bytes of the uploadStart API request body.
 
 `upload_end_limit.max`:::
-Maximum number of agents that can call the uploadEnd API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+Maximum number of agents that can call the uploadEnd API concurrently. This setting allows the user to avoid overloading the Fleet Server from uploadEnd API calls.
 
 `upload_end_limit.interval`:::
 How frequently agents can submit file end upload requests to the Fleet Server.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -149,7 +149,7 @@ Burst of status requests to accomodate before falling back to the rate defined b
 Maximum size in bytes of the status API request body.
 
 `upload_start_limit.max`:::
-Maximum number of agents that can call the uploadStart API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+Maximum number of agents that can call the uploadStart API concurrently. This setting allows the user to avoid overloading the Fleet Server from uploadStart API calls.
 
 `upload_start_limit.interval`:::
 How frequently agents can submit file start upload requests to the Fleet Server.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -76,6 +76,9 @@ this setting may improve performance.
 `policy_throttle`:::
 How often a new policy is rolled out to the agents.
 
+`checkin_limit.max`:::
+Maximum number of agents.
+
 `checkin_limit.interval`:::
 How fast the agents can check in to the {fleet-server}.
 
@@ -83,8 +86,8 @@ How fast the agents can check in to the {fleet-server}.
 Burst of check-ins allowed before falling back to the rate defined by
 `interval`.
 
-`checkin_limit.max`:::
-Maximum number of agents.
+`checkin_limit.max_body_byte_size`:::
+Maximum size in bytes of the checkin API request body.
 
 `artifact_limit.max`:::
 Maximum number of agents that can call the artifact API concurrently. It allows
@@ -98,8 +101,11 @@ rolled out per second.
 Number of transactions allowed for a burst, controlling oversubscription on
 outbound buffer.
 
+`artifact_limit.max_body_byte_size`:::
+Maximum size in bytes of the artficact API request body.
+
 `ack_limit.max`:::
-Maximum number of agents that can call the Ack API concurrently. It allows the
+Maximum number of agents that can call the ack API concurrently. It allows the
 user to avoid overloading the {fleet-server} from Ack API calls.
 
 `ack_limit.interval`:::
@@ -110,8 +116,11 @@ ACKs per second to be sent.
 Burst of ACKs to accommodate (default of 20) before falling back to the rate
 defined in `interval`.
 
+`ack_limit.max_body_byte_size`:::
+Maximum size in bytes of the ack API request body.
+
 `enroll_limit.max`:::
-Maximum number of agents that can call the Enroll API concurrently. This setting
+Maximum number of agents that can call the enroll API concurrently. This setting
 allows the user to avoid overloading the {fleet-server} from Enrollment API
 calls.
 
@@ -123,6 +132,57 @@ system health. Default value of `100ms` allows 10 enrollments per second.
 `enroll_limit.burst`:::
 Burst of enrollments to accept before falling back to the rate defined by
 `interval`.
+
+`enroll_limit.max_body_byte_size`:::
+Maximum size in bytes of the enroll API request body.
+
+`status_limit.max`:::
+Maximum number of agents that can call the status API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+
+`status_limit.interval`:::
+How frequently agents can submit status requests to the Fleet Server.
+
+`status_limit.burst`:::
+Burst of status requests to accomodate before falling back to the rate defined by interval.
+
+`status_limit.max_body_byte_size`:::
+Maximum size in bytes of the status API request body.
+
+`upload_start_limit.max`:::
+Maximum number of agents that can call the uploadStart API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+
+`upload_start_limit.interval`:::
+How frequently agents can submit file start upload requests to the Fleet Server.
+
+`upload_start_limit.burst`:::
+Burst of file start upload requests to accomodate before falling back to the rate defined by interval.
+
+`upload_start_limit.max_body_byte_size`:::
+Maximum size in bytes of the uploadStart API request body.
+
+`upload_end_limit.max`:::
+Maximum number of agents that can call the uploadEnd API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+
+`upload_end_limit.interval`:::
+How frequently agents can submit file end upload requests to the Fleet Server.
+
+`upload_end_limit.burst`:::
+Burst of file end upload requests to accomodate before falling back to the rate defined by interval.
+
+`upload_end_limit.max_body_byte_size`:::
+Maximum size in bytes of the uploadEnd API request body.
+
+`upload_chunk_limit.max`:::
+Maximum number of agents that can call the uploadChunk API concurrently. This setting allows the user to avoid overloading the Fleet Server from status API calls.
+
+`upload_chunk_limit.interval`:::
+How frequently agents can submit file chunk upload requests to the Fleet Server.
+
+`upload_chunk_limit.burst`:::
+Burst of file chunk upload requests to accomodate before falling back to the rate defined by interval.
+
+`upload_chunk_limit.max_body_byte_size`:::
+Maximum size in bytes of the uploadChunk API request body.
 
 [discrete]
 [[scaling-recommendations]]

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -77,7 +77,7 @@ this setting may improve performance.
 How often a new policy is rolled out to the agents.
 
 `checkin_limit.max`:::
-Maximum number of agents.
+Maximum number of agents that can call the checkin API concurrently.
 
 `checkin_limit.interval`:::
 How fast the agents can check in to the {fleet-server}.


### PR DESCRIPTION
Some scalability settings are missing in the docs from the [Advanced Fleet server options](https://www.elastic.co/guide/en/fleet/current/fleet-server-scalability.html#fleet-server-configuration) list. This adds the missing settings based on the contents of [limits.go](https://github.com/elastic/fleet-server/blob/main/internal/pkg/config/limits.go) (thanks @juliaElastic for pointing to that file!).

Reviewers, I wasn't 100% sure about the settings descriptions so please check carefully and let me know if we need more detail for any of them.

Closes: https://github.com/elastic/observability-docs/issues/2758

[Preview](https://ingest-docs_239.docs-preview.app.elstc.co/guide/en/fleet/master/fleet-server-scalability.html#fleet-server-configuration)