### PR TITLE
Add file path length restriction for standalone agent

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -21,7 +21,7 @@ Note the following restrictions for running standalone {agent}:
 versions automatically. When you upgrade the integration in {kib}, you'll
 need to update the standalone policy manually.
 
-* The file path where {agent} is installed cannot exceed 103 characters.
+* {agent} file paths cannot exceed 103 characters. This restriction applies to all paths, including the {agent} install directory and the data path used by any integrations.
 
 * You can install only a single {agent} per host.
 ====

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -13,11 +13,18 @@ We recommend using <<install-fleet-managed-elastic-agent,{fleet}-managed {agent}
 when possible, because it makes the management and upgrade of your agents
 considerably easier. 
 
-IMPORTANT: Standalone agents are unable to upgrade to new integration package
+[IMPORTANT]
+====
+Note the following restrictions for running standalone {agent}:
+
+* Standalone agents are unable to upgrade to new integration package
 versions automatically. When you upgrade the integration in {kib}, you'll
 need to update the standalone policy manually.
 
-NOTE: You can install only a single {agent} per host.
+* The file path where {agent} is installed cannot exceed 103 characters.
+
+* You can install only a single {agent} per host.
+====
 
 {agent} can monitor the host where it's deployed, and it can collect and forward
 data from remote services and hardware where direct deployment is not possible.


### PR DESCRIPTION
This PR:
 - Adds a note to the [Install standalone Elastic Agents](https://www.elastic.co/guide/en/fleet/current/install-standalone-elastic-agent.html) page indicating that the install path can't exceed 103 characters.
- Combines this with the other two notes at the top of that page into a single "restrictions" block.

Preview:
![Screenshot 2023-05-31 at 1 23 29 PM](https://github.com/elastic/ingest-docs/assets/41695641/e05b9010-71cf-45a6-8193-ac3dbe18db1d)

Closes: https://github.com/elastic/ingest-docs/issues/240