### PR TITLE
[8.8] Revert "Add file path length restriction for standalone agent (#241)" (#244)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -13,18 +13,11 @@ We recommend using <<install-fleet-managed-elastic-agent,{fleet}-managed {agent}
 when possible, because it makes the management and upgrade of your agents
 considerably easier. 
 
-[IMPORTANT]
-====
-Note the following restrictions for running standalone {agent}:
-
-* Standalone agents are unable to upgrade to new integration package
+IMPORTANT: Standalone agents are unable to upgrade to new integration package
 versions automatically. When you upgrade the integration in {kib}, you'll
 need to update the standalone policy manually.
 
-* {agent} file paths cannot exceed 103 characters. This restriction applies to all paths, including the {agent} install directory and the data path used by any integrations.
-
-* You can install only a single {agent} per host.
-====
+NOTE: You can install only a single {agent} per host.
 
 {agent} can monitor the host where it's deployed, and it can collect and forward
 data from remote services and hardware where direct deployment is not possible.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Revert "Add file path length restriction for standalone agent (#241)" (#244)](https://github.com/elastic/ingest-docs/pull/244)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)