### PR TITLE
Add known issue for file path length

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -37,9 +37,8 @@ Review important information about the {fleet} and {agent} 8.8.0 release.
 [%collapsible]
 ====
 
-*Details*
-
-* When an internally generated file path exceeds this length it is truncated using a hash, and the newly constructed path might not be accessible to the agent.
+*Details* +
+When an internally generated file path exceeds this length it is truncated using a hash, and the newly constructed path might not be accessible to the agent.
 
 To identify the problem, check the output of `elastic-agent status --output=yaml` or the `state.yaml` file in a diagnostics bundle for output like the following:
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -29,6 +29,58 @@ Also see:
 Review important information about the {fleet} and {agent} 8.8.0 release.
 
 [discrete]
+[[known-issues-8.8.0]]
+=== Known issues
+
+[[known-issue-issue-2749]]
+.{agent} can fail when file paths generated to represent Unix sockets exceed 103 characters.
+[%collapsible]
+====
+
+*Details*
+
+* When an internally generated file path exceeds this length it is truncated using a hash, and the newly constructed path might not be accessible to the agent.
+
+To identify the problem, check the output of `elastic-agent status --output=yaml` or the `state.yaml` file in a diagnostics bundle for output like the following:
+
+[source,console]
+----
+- id: kubernetes/metrics-60f88f50-c873-11ed-9baf-09fb5640c56a
+  state:
+    state: 4
+    message: 'Failed: pid ''3770789'' exited with code ''1'''
+    units:
+      ? unittype: 1
+        unitid: kubernetes/metrics-60f88f50-c873-11ed-9baf-09fb5640c56a
+      : state: 4
+        message: 'Failed: pid ''3770789'' exited with code ''1'''
+      ? unittype: 0
+        unitid: kubernetes/metrics-60f88f50-c873-11ed-9baf-09fb5640c56a-kubernetes/metrics-kubelet-0d1f291d-9b2e-4f44-a0dc-82ebee865799
+      : state: 4
+        message: 'Failed: pid ''3770789'' exited with code ''1'''
+      ? unittype: 0
+        unitid: kubernetes/metrics-60f88f50-c873-11ed-9baf-09fb5640c56a-kubernetes/metrics-kube-proxy-0d1f291d-9b2e-4f44-a0dc-82ebee865799
+      : state: 4
+        message: 'Failed: pid ''3770789'' exited with code ''1'''
+    features_idx: 0
+    version_info:
+      name: ""
+      version: ""
+----
+
+This is accompanied by an error message in the logs:
+
+[source,console]
+----
+logs/elastic-agent-20230530-23.ndjson:{"log.level":"error","@timestamp":"2023-05-30T11:42:46.776Z","message":"Exiting: could not start the HTTP server for the API: listen unix /tmp/elastic-agent/6dd26cab2bb93d6254d75a9ef22c5fb5d3c5ffbd8866f26288d86d2f672d2ae6.sock: bind: no such file or directory","component":{"binary":"metricbeat","dataset":"elastic_agent.metricbeat","id":"kubernetes/metrics-60f88f50-c873-11ed-9baf-08ec5473d24b","type":"kubernetes/metrics"},"log":{"source":"kubernetes/metrics-60e22e52-d872-12dc-4adf-09fb5242c26b"},"log.origin":{"file.line":1142,"file.name":"instance/beat.go"},"service.name":"metricbeat","ecs.version":"1.6.0","ecs.version":"1.6.0"}
+----
+
+*Impact* +
+
+This issue is being investigated. Until it's resolved, as a workaround you can reduce the length of the agent output name until the problem stops occurring.
+====
+
+[discrete]
 [[new-features-8.8.0]]
 === New features
 


### PR DESCRIPTION
This updates the [8.8.0 release notes](https://www.elastic.co/guide/en/fleet/8.8/release-notes-8.8.0.html) with a known issue about file length limits.

Rel: https://github.com/elastic/ingest-docs/issues/240

[Preview](https://ingest-docs_246.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.8.0.html)

---
**collapsed**
![Screenshot 2023-06-02 at 5 17 08 PM](https://github.com/elastic/ingest-docs/assets/41695641/84288978-3297-4d45-9a30-884ac75667a4)

---

**expanded**
![Screenshot 2023-06-02 at 5 27 21 PM](https://github.com/elastic/ingest-docs/assets/41695641/fbe65e1a-0513-4ff4-b8ad-743179aee97d)


