### PR TITLE
[8.8] Update links to ingest/getting started content (#247)

### DIFF
--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -44,5 +44,5 @@ policy.
 If you haven't deployed any {agent}s yet or set up agent policies, start with
 one of our quick start guides:
 
-* {observability-guide}/ingest-logs-metrics-uptime.html[Ingest logs, metrics, and uptime data with {agent}]
-* {observability-guide}/ingest-traces.html[Ingest application traces with {agent}]
+* {observability-guide}/logs-metrics-get-started.html[Get started with logs and metrics]
+* {observability-guide}/ingest-traces.html[Get started with application traces and APM]

--- a/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
+++ b/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
@@ -93,11 +93,9 @@ development environment before deploying across your infrastructure.
 You can continue to run {beats} alongside {agent} until you're satisfied with
 the data its sending to {es}.
 
-Read our {observability-guide}/ingest-logs-metrics-uptime.html[quick start
-guide] to learn how to deploy an {agent}. (Skip the step about setting up
-{fleet-server} if it's already running.) To save time, return to this page when
-the {agent} is deployed, healthy, and successfully sending data. You don't have
-to complete all the steps in the quick start.
+Read <<elastic-agent-installation>> to learn how to deploy an {agent}. To
+save time, return to this page when the {agent} is deployed, healthy, and
+successfully sending data.
 
 Here's a high-level overview to help you understand the deployment process.
 

--- a/docs/en/ingest-management/quick-starts.asciidoc
+++ b/docs/en/ingest-management/quick-starts.asciidoc
@@ -1,9 +1,8 @@
 [[fleet-elastic-agent-quick-start]]
 = Quick starts
 
-Want to get up and running with {fleet} and {agent} quickly? Read our quick
-start guides:
+Want to get up and running with {fleet} and {agent} quickly? Read our getting
+started guides:
 
-* {observability-guide}/ingest-logs-metrics-uptime.html[Ingest logs, metrics, and uptime data with {agent}]
-
-* {observability-guide}/ingest-traces.html[Ingest application traces with {agent}]
+* {observability-guide}/logs-metrics-get-started.html[Get started with logs and metrics]
+* {observability-guide}/ingest-traces.html[Get started with application traces and APM]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Update links to ingest/getting started content (#247)](https://github.com/elastic/ingest-docs/pull/247)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)