### PR TITLE
Add Fleet & Agent 8.8.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -47,9 +47,9 @@ Review important information about the {fleet} and {agent} 8.7.x release.
 * Include hidden data streams in package upgrade. {kibana-pull}158654[#158654]
 
 {agent}::
-* Fix potential deadlock issue in communication between updated components and RuntimeManager. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
+* Fix potential communication issue when a running component would lose connection to the {agent} and unable to re-connect because of a concurrent updated component model. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
 
-* Add a retry download step to the upgrade process. {agent-pull}2776[#2776] 
+* Retry download step during upgrade process. {agent-pull}2776[#2776] 
 
 // end 8.8.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -47,7 +47,7 @@ Review important information about the {fleet} and {agent} 8.7.x release.
 * Include hidden data streams in package upgrade. {kibana-pull}158654[#158654]
 
 {agent}::
-* Fix potential communication issue when a running component would lose connection to the {agent} and unable to re-connect because of a concurrent updated component model. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
+* Fix potential communication issue when a running component would lose connection to the {agent} and be unable to re-connect because of a concurrent updated component model. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
 
 * Retry download step during upgrade process. {agent-pull}2776[#2776] 
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -37,7 +37,7 @@ Review important information about the {fleet} and {agent} 8.7.x release.
 * Add {agent} UI instructions for Universal Profile. {kibana-pull}158936[#158936]
 
 {fleet-server}::
-* Add {fleet} configuration To {agent} Diagnostics. {fleet-server-pull}2632[#2632] {fleet-server-issue}2623[#2623]
+* Add {fleet} configuration file to {agent} diagnostics bundle. {fleet-server-pull}2632[#2632] {fleet-server-issue}2623[#2623]
 
 [discrete]
 [[bug-fixes-8.8.1]]
@@ -48,6 +48,8 @@ Review important information about the {fleet} and {agent} 8.7.x release.
 
 {agent}::
 * Fix potential deadlock issue in communication between updated components and RuntimeManager. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
+
+* Add a retry download step to the upgrade process. {agent-pull}2776[#2776] 
 
 // end 8.8.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -14,12 +14,42 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.8.1>>
 * <<release-notes-8.8.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.8.1 relnotes
+
+[[release-notes-8.8.1]]
+== {fleet} and {agent} 8.8.1
+
+Review important information about the {fleet} and {agent} 8.7.x release.
+
+[discrete]
+[[enhancements-8.8.1]]
+=== Enhancements
+
+{fleet}::
+* Add {agent} UI instructions for Universal Profile. {kibana-pull}158936[#158936]
+
+{fleet-server}::
+* Add {fleet} configuration To {agent} Diagnostics. {fleet-server-pull}2632[#2632] {fleet-server-issue}2623[#2623]
+
+[discrete]
+[[bug-fixes-8.8.1]]
+=== Bug fixes
+
+{fleet}::
+* Include hidden data streams in package upgrade. {kibana-pull}158654[#158654]
+
+{agent}::
+* Fix potential deadlock issue in communication between updated components and RuntimeManager. {agent-pull}2729[#2729] {agent-pull}2691[#2691]
+
+// end 8.8.1 relnotes
 
 // begin 8.8.0 relnotes
 


### PR DESCRIPTION
This adds the 8.8.1 Fleet & Agent Release Notes:

 - Fleet adds are from the [Kibana RN PR](https://github.com/elastic/kibana/pull/159159)
 - Fleet Server add are from the changelog PR: https://github.com/elastic/fleet-server/pull/2673 
 - Elastic Agent adds are from the changelog PR: https://github.com/elastic/elastic-agent/pull/2795

[Preview](https://ingest-docs_251.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.8.1.html) 