### PR TITLE
Add known issue for 8.8.0 stalled upgrade

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -73,7 +73,6 @@ Review important information about the {fleet} and {agent} 8.8.0 release.
 {agent} upgrades can sometimes stall without returning an error message, and without the agent upgrade process restarting automatically.
 
 *Impact* +
-
 As a workaround, if the upgrade hasn't completed within about an hour you can trigger the upgrade manually.
 
 This issue is specific to version 8.8.0 and is resolved in version 8.8.1.

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -64,6 +64,21 @@ Review important information about the {fleet} and {agent} 8.8.0 release.
 [[known-issues-8.8.0]]
 === Known issues
 
+[[known-issue-issue-upgrade-20230608]]
+.{agent} upgrade process can sometimes stall.
+[%collapsible]
+====
+
+*Details* +
+{agent} upgrades can sometimes stall without returning an error message, and without the agent upgrade process restarting automatically.
+
+*Impact* +
+
+As a workaround, if the upgrade hasn't completed within about an hour you can trigger the upgrade manually.
+
+This issue is specific to version 8.8.0 and is resolved in version 8.8.1.
+====
+
 [[known-issue-issue-2749]]
 .{agent} can fail when file paths generated to represent Unix sockets exceed 103 characters.
 [%collapsible]


### PR DESCRIPTION
This updates the 8.8.0 Release Notes with a known issue about stalled upgrades.

Preview:
![Screenshot 2023-06-08 at 1 51 55 PM](https://github.com/elastic/ingest-docs/assets/41695641/d390cae5-cf44-4228-afb0-c17770493ffd)
