### PR TITLE
Update 8.8.0 known issue for stalled upgrade

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -73,7 +73,7 @@ Review important information about the {fleet} and {agent} 8.8.0 release.
 {agent} upgrades can sometimes stall without returning an error message, and without the agent upgrade process restarting automatically.
 
 *Impact* +
-As a workaround, if the upgrade hasn't completed within about an hour you can trigger the upgrade manually.
+In this situation the agent returns from `Updating` to a `Healthy` state, but without the new version having been installed. To address this, you can trigger a new upgrade manually.
 
 This issue is specific to version 8.8.0 and is resolved in version 8.8.1.
 ====


### PR DESCRIPTION
This updates the description of the stalled upgrade [known issue](https://www.elastic.co/guide/en/fleet/current/release-notes-8.8.0.html#known-issues-8.8.0) in 8.8.0 to mention the return to a healthy state.

Rel: #253 


![Screenshot 2023-06-09 at 9 40 36 AM](https://github.com/elastic/ingest-docs/assets/41695641/656b4473-6006-4c9c-a1ef-df5ee05378c0)

