### PR TITLE
Add issue template for docs requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-request.yaml
+++ b/.github/ISSUE_TEMPLATE/docs-request.yaml
@@ -1,0 +1,45 @@
+name: "[Internal] Dcumentation request"
+description: Request a documentation change or enhancement for any supported release (Elastic employees).
+title: "[REQUEST]: "
+labels: ["request", "Team:Docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this request! This form will create an issue that the Platform Docs team will triage and prioritize.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what needs to be documented.
+      placeholder: I need...
+    validations:
+      required: true
+  - type: textarea
+    id: related
+    attributes:
+      label: Resources
+      description: Please link to as many related resources as possible. Think about issues, PRs, demos, Slack threads, existing or related docs pages, etc.
+      placeholder: How can the docs team learn more about this feature?
+    validations:
+      required: true
+  - type: dropdown
+    id: collaboration
+    attributes:
+      label: Collaboration
+      description: Choose the expected collaboration model
+      options:
+        - "The documentation team will investigate the issue and create the initial content."
+        - "The product team will provide the initial content."
+        - "TBD. The docs and product team will work together to determine the best path forward."
+        - "Other (please describe below in the Point of contact section)."
+    validations:
+      required: true
+  - type: textarea
+    id: contact
+    attributes:
+      label: Point of contact.
+      description: Please assign at least one point of contact using the GitHub `@` mention. Add as many stakeholders as you'd like.
+      value: "**Main contact:** @\n\n**Stakeholders:**\n"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs-request.yaml
+++ b/.github/ISSUE_TEMPLATE/docs-request.yaml
@@ -29,6 +29,7 @@ body:
       label: Collaboration
       description: Choose the expected collaboration model
       options:
+        - "Please choose a preferred collaboration model."
         - "The documentation team will investigate the issue and create the initial content."
         - "The product team will provide the initial content."
         - "TBD. The docs and product team will work together to determine the best path forward."


### PR DESCRIPTION
Adds a general purpose issue template for docs requests. When someone creates an issue using the template, it presents an issue form. The form captures all information required for the issue to be ready for work by a tech writer.

The template is copied and slightly modified from the [Obs docs repo](https://github.com/elastic/observability-docs/blob/main/.github/ISSUE_TEMPLATE/other-request.yaml).

### Issue form example

<img width="1250" alt="Screenshot 2023-06-09 at 3 57 49 PM" src="https://github.com/elastic/ingest-docs/assets/40268737/5943ed54-3eb6-48ff-beb9-180148c019a3">

