### PR TITLE
Fix anchor alignment on Fleet settings page

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -93,7 +93,7 @@ are configured outside of {fleet}. For more information, refer to
 
 [discrete]
 [[es-output-settings]]
-=== {es} output settings
+== {es} output settings
 
 Specify these settings to send data over a secure connection to {es}.
 
@@ -163,7 +163,7 @@ Sending monitoring data to a remote {es} cluster is currently not supported.
 
 [discrete]
 [[ls-output-settings]]
-=== {ls} output settings
+== {ls} output settings
 
 Specify these settings to send data over a secure connection to {ls}. You must
 also configure a {ls} pipeline that reads encrypted data from {agent}s and sends


### PR DESCRIPTION
On the [Fleet UI settings page](https://www.elastic.co/guide/en/fleet/8.8/fleet-settings.html), The anchors for "Elasticsearch output settings" and "Logstash output settings" don't line up with the actual text, causing the section titles to cut off.

This is a known Asciidoctor limitation for pages that are at the 5th level and below in the navigation tree. Technically, these two sections are subsections of the "Output settings" section on the page, but the usability is not good, and it's reasonable for users to expect the two problem sections to be at the same navigation level as "Fleet Server host settings" and "Agent binary download settings", as reflected in the settings file.

Before (section title is cut off):
![Screenshot 2023-06-12 at 5 48 12 PM](https://github.com/elastic/ingest-docs/assets/41695641/8917b8ee-4ca6-42ec-8c15-d250f92efc30)

After (section title is visible):
![Screenshot 2023-06-12 at 5 48 43 PM](https://github.com/elastic/ingest-docs/assets/41695641/44dea92e-473f-4929-9f36-166dd7ce228f)




Closes: #230 