### PR TITLE
[8.8] Fix anchor allignment on Fleet settings page (#260)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -93,7 +93,7 @@ are configured outside of {fleet}. For more information, refer to
 
 [discrete]
 [[es-output-settings]]
-=== {es} output settings
+== {es} output settings
 
 Specify these settings to send data over a secure connection to {es}.
 
@@ -163,7 +163,7 @@ Sending monitoring data to a remote {es} cluster is currently not supported.
 
 [discrete]
 [[ls-output-settings]]
-=== {ls} output settings
+== {ls} output settings
 
 Specify these settings to send data over a secure connection to {ls}. You must
 also configure a {ls} pipeline that reads encrypted data from {agent}s and sends


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Fix anchor allignment on Fleet settings page (#260)](https://github.com/elastic/ingest-docs/pull/260)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)