### PR TITLE
Add Fleet & Agent 8.8.2 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -47,13 +47,15 @@ Review important information about the {fleet} and {agent} 8.8.2 release.
 [[bug-fixes-8.8.2]]
 === Bug fixes
 
+
+
 {fleet}::
 * Fixes usage of AsyncLocalStorage for audit log. {kibana-pull}159807[#159807]
 * Fixing issue of returning output API key. {kibana-pull}159179[#159179]
 
 {agent}::
 * Explicitly specify timeout units as seconds in the Endpoint spec file. {agent-pull}2870[#2870]  {agent-issue}2863[#2863]
-
+* Fix logs collection In diagnostics when {agent} is running on K8s. {agent-pull}2905[#2905]  {agent-issue}2899[#2899]
 
 // end 8.8.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -55,7 +55,7 @@ Review important information about the {fleet} and {agent} 8.8.2 release.
 
 {agent}::
 * Explicitly specify timeout units as seconds in the Endpoint spec file. {agent-pull}2870[#2870]  {agent-issue}2863[#2863]
-* Fix logs collection In diagnostics when {agent} is running on K8s. {agent-pull}2905[#2905]  {agent-issue}2899[#2899]
+* Fix logs collection in diagnostics when {agent} is running on Kubernetes. {agent-pull}2905[#2905]  {agent-issue}2899[#2899]
 
 // end 8.8.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>
 * <<release-notes-8.8.0>>
 
@@ -22,12 +23,40 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.8.2 relnotes
+
+[[release-notes-8.8.2]]
+== {fleet} and {agent} 8.8.2
+
+Review important information about the {fleet} and {agent} 8.8.2 release.
+
+[discrete]
+[[enhancements-8.8.2]]
+=== Enhancements
+
+{agent}::
+* Updated Golang version to 1.19.10. {agent-pull}2846[#2846] 
+
+[discrete]
+[[bug-fixes-8.8.2]]
+=== Bug fixes
+
+{fleet}::
+* Fixes usage of AsyncLocalStorage for audit log. {kibana-pull}159807[#159807]
+* Fixing issue of returning output API key. {kibana-pull}159179[#159179]
+
+{agent}::
+* Explicitly specify timeout units as seconds in the Endpoint spec file. {agent-pull}2870[#2870]  {agent-issue}2863[#2863]
+* Log start and stop operations from service runtime at `INFO` rather than `DEBUG`` level. {agent-pull}2879[#2879] {agent-issue}2864[#2864]
+
+// end 8.8.2 relnotes
+
 // begin 8.8.1 relnotes
 
 [[release-notes-8.8.1]]
 == {fleet} and {agent} 8.8.1
 
-Review important information about the {fleet} and {agent} 8.7.x release.
+Review important information about the {fleet} and {agent} 8.8.1 release.
 
 [discrete]
 [[enhancements-8.8.1]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -31,11 +31,17 @@ Also see:
 Review important information about the {fleet} and {agent} 8.8.2 release.
 
 [discrete]
+[[security-updates-8.8.2]]
+=== Security updates
+
+{agent}::
+* Updated Go version to 1.19.10. {agent-pull}2846[#2846] 
+
+[discrete]
 [[enhancements-8.8.2]]
 === Enhancements
 
-{agent}::
-* Updated Golang version to 1.19.10. {agent-pull}2846[#2846] 
+* Log start and stop operations from service runtime at `INFO` rather than `DEBUG` level. {agent-pull}2879[#2879] {agent-issue}2864[#2864]
 
 [discrete]
 [[bug-fixes-8.8.2]]
@@ -47,7 +53,7 @@ Review important information about the {fleet} and {agent} 8.8.2 release.
 
 {agent}::
 * Explicitly specify timeout units as seconds in the Endpoint spec file. {agent-pull}2870[#2870]  {agent-issue}2863[#2863]
-* Log start and stop operations from service runtime at `INFO` rather than `DEBUG`` level. {agent-pull}2879[#2879] {agent-issue}2864[#2864]
+
 
 // end 8.8.2 relnotes
 


### PR DESCRIPTION
This adds the 8.8.2 Fleet & Agent Release Notes:

 - Fleet adds are from the [Kibana 8.8.2 release notes PR](https://github.com/elastic/kibana/pull/160211)
 - Fleet Server [no fragments to add](https://github.com/elastic/fleet-server/tree/b8b0124f40de8bd1d5ceae2c45ed0e1b122360a2/changelog/fragments)
 - Elastic Agent additions are from the changelog PR: https://github.com/elastic/elastic-agent/pull/2939

[Preview](https://ingest-docs_275.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.8.2.html)