### PR TITLE
[8.8] Add Fleet & Agent 8.8.2 release notes (#275)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.8.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>
 * <<release-notes-8.8.0>>
 
@@ -22,12 +23,48 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.8.2 relnotes
+
+[[release-notes-8.8.2]]
+== {fleet} and {agent} 8.8.2
+
+Review important information about the {fleet} and {agent} 8.8.2 release.
+
+[discrete]
+[[security-updates-8.8.2]]
+=== Security updates
+
+{agent}::
+* Updated Go version to 1.19.10. {agent-pull}2846[#2846] 
+
+[discrete]
+[[enhancements-8.8.2]]
+=== Enhancements
+
+* Log start and stop operations from service runtime at `INFO` rather than `DEBUG` level. {agent-pull}2879[#2879] {agent-issue}2864[#2864]
+
+[discrete]
+[[bug-fixes-8.8.2]]
+=== Bug fixes
+
+
+
+{fleet}::
+* Fixes usage of AsyncLocalStorage for audit log. {kibana-pull}159807[#159807]
+* Fixing issue of returning output API key. {kibana-pull}159179[#159179]
+
+{agent}::
+* Explicitly specify timeout units as seconds in the Endpoint spec file. {agent-pull}2870[#2870]  {agent-issue}2863[#2863]
+* Fix logs collection in diagnostics when {agent} is running on Kubernetes. {agent-pull}2905[#2905]  {agent-issue}2899[#2899]
+
+// end 8.8.2 relnotes
+
 // begin 8.8.1 relnotes
 
 [[release-notes-8.8.1]]
 == {fleet} and {agent} 8.8.1
 
-Review important information about the {fleet} and {agent} 8.7.x release.
+Review important information about the {fleet} and {agent} 8.8.1 release.
 
 [discrete]
 [[enhancements-8.8.1]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Add Fleet & Agent 8.8.2 release notes (#275)](https://github.com/elastic/ingest-docs/pull/275)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)