### PR TITLE
Adding generic_logs template for hints autodiscovery

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -139,7 +139,10 @@ NOTE: The {agent} can load multiple configuration files from `{path.config}/inpu
 
 
 [discrete]
-== Example: Hints autodiscovery
+== Examples: 
+
+[discrete]
+=== Hints autodiscovery for redis
 
 Enabling hints allows users deploying Pods on the cluster to automatically turn on Elastic
 monitoring at Pod deployment time.
@@ -166,6 +169,143 @@ metadata:
 After deploying this Pod, the data will start flowing in automatically. You can find it on the index `metrics-redis.info-default`.
 
 NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis integration are not installed. You need to explicitly <<install-uninstall-integration-assets,install them through {kib}>>.
+
+
+[discrete]
+=== Hints autodiscovery for kubernetes log collection
+
+The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/generic_logs.yml[generic_logs.yml template]. Users need to emit a generic_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
+
+Enabling hints in the kubernetes standalone manifest: 
+[source,yaml]
+----
+providers.kubernetes:
+  node: ${NODE_NAME}
+  scope: node
+  hints:
+    enabled: true
+----
+
+Example to manually mount the needed generic_logs template under the inputs.d folder of Elastic Agent
+[source,yaml]
+----
+volumeMounts:
+- name: external-inputs
+  mountPath: /etc/elastic-agent/inputs.d/generic_logs.yml
+...
+volumes:
+- name: external-inputs
+  hostPath:
+    path: /var/log/test/generic_logs.yml
+...
+----
+
+Apply elastic-agent-standalone manifest:
+
+[source,bash]
+----
+kubectl apply -f elastic-agent-standalone-kubernetes.yml
+----
+
+The previous default behaviour can be disabled with `hints.default_container_logs: false`. 
+So this will disable the automatic logs collection from all discovered pods. Users need specifically to annotate their pod with following annotations:
+
+[source,yaml]
+----
+annotations:
+  co.elastic.hints/package: "generic_logs.container_logs"
+----
+
+
+[source,yaml]
+----
+providers.kubernetes:
+  node: ${NODE_NAME}
+  scope: node
+  hints:
+    enabled: true
+    default_container_logs: false 
+...
+----
+
+In the following sample nginx manifest, we additionally provide stream annotations:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        co.elastic.hints/package: "generic_logs.container_logs"
+        co.elastic.hints/stream: "stderr"
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+...
+----
+
+Users can monitor the final rendered Elastic Agent configuration:
+
+[source,bash]
+----
+kubectl exec -ti -n kube-system elastic-agent-7fkzm -- bash
+
+
+/usr/share/elastic-agent# /elastic-agent inspect -v --variables --variables-wait 2s
+
+inputs:
+- data_stream.namespace: default
+  id: hints-container-logs-3f69573a1af05c475857c1d0f98fc55aa01b5650f146d61e9653a966cd50bd9c-kubernetes-1780aca0-3741-4c8c-aced-b9776ba3fa81.nginx
+  name: filestream-generic
+  original_id: hints-container-logs-3f69573a1af05c475857c1d0f98fc55aa01b5650f146d61e9653a966cd50bd9c
+  [output truncated ....]
+  streams:
+  - data_stream:
+      dataset: kubernetes.container_logs
+      type: logs
+    exclude_files: []
+    exclude_lines: []
+    parsers:
+    - container:
+        format: auto
+        stream: stderr
+    paths:
+    - /var/log/containers/*3f69573a1af05c475857c1d0f98fc55aa01b5650f146d61e9653a966cd50bd9c.log
+    prospector:
+      scanner:
+        symlinks: true
+    tags: []
+  type: filestream
+  use_output: default
+outputs:
+  default:
+    hosts:
+    - https://elasticsearch:9200
+    password: changeme
+    type: elasticsearch
+    username: elastic
+providers:
+  kubernetes:
+    hints:
+      default_container_logs: false
+      enabled: true
+    node: control-plane
+    scope: node
+----
+
 
 
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -174,7 +174,7 @@ NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis 
 [discrete]
 === Hints autodiscovery for kubernetes log collection
 
-The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/generic_logs.yml[generic_logs.yml template]. Users need to emit a generic_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
+The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml[container_logs.yml template]. Users need to emit a caontainer_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
 
 Enabling hints in the kubernetes standalone manifest: 
 [source,yaml]
@@ -213,7 +213,7 @@ So this will disable the automatic logs collection from all discovered pods. Use
 [source,yaml]
 ----
 annotations:
-  co.elastic.hints/package: "generic_logs.container_logs"
+  co.elastic.hints/package: "container_logs"
 ----
 
 
@@ -248,7 +248,7 @@ spec:
       labels:
         app: nginx
       annotations:
-        co.elastic.hints/package: "generic_logs.container_logs"
+        co.elastic.hints/package: "container_logs"
         co.elastic.hints/stream: "stderr"
     spec:
       containers:

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -174,7 +174,7 @@ NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis 
 [discrete]
 === Hints autodiscovery for kubernetes log collection
 
-The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml[container_logs.yml template]. Users need to emit a caontainer_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
+The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml[container_logs.yml template]. Users need to emit a container_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
 
 Enabling hints in the kubernetes standalone manifest: 
 [source,yaml]

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -174,38 +174,12 @@ NOTE: All assets (dashboards, ingest pipelines, and so on) related to the Redis 
 [discrete]
 === Hints autodiscovery for kubernetes log collection
 
-The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml[container_logs.yml template]. Users need to emit a container_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
+The log collection for Kubernetes autodiscovered pods can be supported by using  https://github.com/elastic/elastic-agent/tree/main/deploy/kubernetes/elastic-agent-standalone/templates.d/container_logs.yml[container_logs.yml template]. Elastic Agent needs to emit a container_logs mapping so as to start collecting logs for all the discovered containers *even if no annotations are present in the containers*. 
 
-Enabling hints in the kubernetes standalone manifest: 
-[source,yaml]
-----
-providers.kubernetes:
-  node: ${NODE_NAME}
-  scope: node
-  hints:
-    enabled: true
-----
-
-Example to manually mount the needed container_logs template under the inputs.d folder of Elastic Agent
-[source,yaml]
-----
-volumeMounts:
-- name: external-inputs
-  mountPath: /etc/elastic-agent/inputs.d/container_logs.yml
-...
-volumes:
-- name: external-inputs
-  hostPath:
-    path: /var/log/test/container_logs.yml
-...
-----
-
-Apply elastic-agent-standalone manifest:
-
-[source,bash]
-----
-kubectl apply -f elastic-agent-standalone-kubernetes.yml
-----
+1. Follow steps described above to enable Hints Autodiscover
+2. Make sure that relevant `container_logs.yml` template will be mounted under /etc/elastic-agent/inputs.d/ folder of Elastic Agent
+3. Deploy Elastic Agent Manifest
+4. Elastic Agent should be able to discover all containers inside kuernetes cluster and to collect available logs.
 
 The previous default behaviour can be disabled with `hints.default_container_logs: false`. 
 So this will disable the automatic logs collection from all discovered pods. Users need specifically to annotate their pod with following annotations:
@@ -228,7 +202,7 @@ providers.kubernetes:
 ...
 ----
 
-In the following sample nginx manifest, we additionally provide stream annotations:
+In the following sample nginx manifest, we will additionally provide specific stream annotation, in order to configure the filestream input to read only stderr stream:
 
 [source,yaml]
 ----
@@ -305,8 +279,6 @@ providers:
     node: control-plane
     scope: node
 ----
-
-
 
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -81,7 +81,7 @@ and avoid placing passwords in plain text.
 
 The stream to use for logs collection, for example, stdout/stderr.
 
-If the specified package has no logs support, a generic container's logs input will be used as a fallback.
+If the specified package has no logs support, a generic container's logs input will be used as a fallback. See example `Hints autodiscovery for kubernetes log collection` below.
 
 [discrete]
 == Available packages that support hints autodiscovery
@@ -186,17 +186,17 @@ providers.kubernetes:
     enabled: true
 ----
 
-Example to manually mount the needed generic_logs template under the inputs.d folder of Elastic Agent
+Example to manually mount the needed container_logs template under the inputs.d folder of Elastic Agent
 [source,yaml]
 ----
 volumeMounts:
 - name: external-inputs
-  mountPath: /etc/elastic-agent/inputs.d/generic_logs.yml
+  mountPath: /etc/elastic-agent/inputs.d/container_logs.yml
 ...
 volumes:
 - name: external-inputs
   hostPath:
-    path: /var/log/test/generic_logs.yml
+    path: /var/log/test/container_logs.yml
 ...
 ----
 

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -81,7 +81,7 @@ and avoid placing passwords in plain text.
 
 The stream to use for logs collection, for example, stdout/stderr.
 
-If the specified package has no logs support, a generic container's logs input will be used as a fallback. See example `Hints autodiscovery for kubernetes log collection` below.
+If the specified package has no logs support, a generic container's logs input will be used as a fallback. See the `Hints autodiscovery for kubernetes log collection` example below.
 
 [discrete]
 == Available packages that support hints autodiscovery


### PR DESCRIPTION
Adding Documentation for generic_logs template for Elastic Agent Hints Autodiscovery scenario in order to collect logs from k8s pods