### PR TITLE
[8.8] Update fleet-settings.asciidoc (#303)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -97,6 +97,8 @@ are configured outside of {fleet}. For more information, refer to
 
 Specify these settings to send data over a secure connection to {es}.
 
+TIP: {es} output must match only the cluster with which {fleet-server} is associated. It's not possible to reference URLs belonging to other {es} clusters.
+
 [cols="2*<a"]
 |===
 |


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Update fleet-settings.asciidoc (#303)](https://github.com/elastic/ingest-docs/pull/303)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)