### PR TITLE
Add mergify config for automated backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,109 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+    actions:
+      comment:
+        message: |
+          This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+          ```
+          git fetch <remote-repo>
+          git checkout -b {{head}} <remote-repo>/{{head}}
+          git merge <remote-repo>/{{base}}
+          git push <remote-repo> {{head}}
+          ```
+  - name: backport patches to 8.9 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.9
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.9"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.8 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.8
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.8"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.7 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.7
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.7"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 7.17 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-7.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.17"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-/d./d` is the label to automatically backport to the `/d./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip
+  - name: remove backport-skip label
+    conditions:
+      - label~=^backport-\d
+      - -merged
+      - -closed
+    actions:
+      label:
+        remove:
+          - backport-skip
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+      - "#assignee>=1"
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # ingest-docs
 Home for Elastic ingest documentation
+
+## Backporting
+
+Pull requests should be tagged with the target version of the Elastic Stack along with any relevant backport labels. In general, we only backport documentation changes to [live stack versions](https://github.com/elastic/docs/blob/master/conf.yaml#L80). For manual backports, we recommend using the [backport tool](https://github.com/sqren/backport) to easily open backport PRs. If you need help, ping **[ingest-docs](https://github.com/orgs/elastic/teams/ingest-docs)** and we'd be happy to handle the backport process for you.


### PR DESCRIPTION
The stack-docs, security, and observability repos use Mergify to automate backports. This PR copies the method used in observability-docs (https://github.com/elastic/observability-docs/blob/main/.mergify.yml) using backport-specific labels (backport-x.y)

I've created the associated backport labels, and we can merge the PR. However, Mergify must be enabled on the repo before it'll begin automating backports. I have an open request to enable Mergify on the repo here: https://elasticco.atlassian.net/browse/SRE-364 (sorry --- internal link)

Related: #210