### PR TITLE
Fleet Server Scaling should contain the note about max 500 policies

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -208,3 +208,9 @@ on the number of agents required by your deployment:
 | 100,000          | 8GB x2                | 8 vCPU x2           | 256GB x2 RAM \| 64 vCPU x2
 |===
 
+[discrete]
+[[agent-policy-scale]]
+== Policy scaling recommendations
+
+A single instance of {fleet} supports a maximum of 500 {agent} policies. If more policies are configured, UI performance might be impacted.
+

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -209,7 +209,7 @@ on the number of agents required by your deployment:
 |===
 
 [discrete]
-[[agent-policy-scale]]
+[[agent-policy-scaling-recommendations]]
 == Policy scaling recommendations
 
 A single instance of {fleet} supports a maximum of 500 {agent} policies. If more policies are configured, UI performance might be impacted.


### PR DESCRIPTION
Hi,

> Policy scaling recommendations
> [edit](https://github.com/elastic/ingest-docs/edit/8.8/docs/en/ingest-management/agent-policies.asciidoc)
> A single instance of Fleet supports a maximum of 500 Elastic Agent policies. If more policies are configured, UI performance might be impacted.

This information is burried way too deep and while yes it makes sense to have it at the agent policies, I honestly never scrolled down that far, because it's just a 101 of how to create a policy. We have a fleet server scaling doc. I think the 500 policies note should be part of that page.