### PR TITLE
We are missing the mentioning of artifacts.elastic.co in our overview docs

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -76,12 +76,14 @@ integrations are updated and released periodically. You can find more informatio
 environments in the section about {fleet-guide}/air-gapped.html[Air-gapped environments].
 
 [discrete]
-[[communication-urls-needed]]
-== {agent} {fleet-server} {integrations}
+[[artifact-registry-intro]]
+== Elastic Artifact Registry
 
-Multiple public URLs need to be resolved in order to have {fleet} and {agent} working properly. First of, the {agent} running on any of your internal hosts should have access to `artifacts.elastic.co` as well as `artifacts.security.elastic.co`, this is needed for {agent} updates and security artifacts when leveraging Elastic Defend.
+{fleet} and {agent} require access to the public Elastic Artifact Registry. The {agent} running on any of your internal hosts should have access to `artifacts.elastic.co` in order to perform self-upgrades and install of certain components which are needed for some of the data integrations.
 
-You can find more information about running most of the above mentioned resources in air-gapped
+Additionally, access to `artifacts.security.elastic.co` is needed for {agent} updates and security artifacts when using {elastic-defend}.
+
+You can find more information about running the above mentioned resources in air-gapped
 environments in the section about {fleet-guide}/air-gapped.html[Air-gapped environments].
 
 [discrete]

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -76,6 +76,15 @@ integrations are updated and released periodically. You can find more informatio
 environments in the section about {fleet-guide}/air-gapped.html[Air-gapped environments].
 
 [discrete]
+[[communication-urls-needed]]
+== {agent} {fleet-server} {integrations}
+
+Multiple public URLs need to be resolved in order to have {fleet} and {agent} working properly. First of, the {agent} running on any of your internal hosts should have access to `artifacts.elastic.co` as well as `artifacts.security.elastic.co`, this is needed for {agent} updates and security artifacts when leveraging Elastic Defend.
+
+You can find more information about running most of the above mentioned resources in air-gapped
+environments in the section about {fleet-guide}/air-gapped.html[Air-gapped environments].
+
+[discrete]
 [[central-management]]
 == Central management in {fleet}
 
@@ -156,3 +165,4 @@ The data collected by {agent} is stored in indices that are more granular than
 you'd get by default with the {beats} shippers or APM Server. This gives you more visibility into the
 sources of data volume, and control over lifecycle management policies and index
 permissions. These indices are called <<data-streams,_data streams_>>.
+


### PR DESCRIPTION
hi,

I hope i did it correct. We are missing the mentioning of `artifacts.elastic.co` as well as `artifacts.security.elastic.co` in our overview. We mention `epr.elastic.co`. I think it deserves to be in the overview page.

happy to take any suggestions for a better title.