### PR TITLE
Add Fleet & Agent 7.17.12 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.12>>
+
 * <<release-notes-7.17.11>>
 
 * <<release-notes-7.17.10>>
@@ -42,6 +44,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.12 relnotes
+
+[[release-notes-7.17.12]]
+== {fleet} and {agent} 7.17.12
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.12 relnotes
 
 // begin 7.17.11 relnotes
 


### PR DESCRIPTION
This adds the 7.17.12 Fleet & Agent Release Notes:

 - Fleet: https://github.com/elastic/kibana/pull/162123 (no RN entries)
 - Fleet Server: https://github.com/elastic/fleet-server/tree/305aee56a8b631bf76d23ff7993f451608d12822/changelog/fragments (no fragments)
 - Elastic Agent: https://staging.elastic.co/7.17.12-41e66b3b/summary-7.17.12.html (no changelog)
