### PR TITLE
IngestArch: Differentiate between proxies

### DIFF
--- a/docs/en/ingest-arch/14-ea-ls-es.asciidoc
+++ b/docs/en/ingest-arch/14-ea-ls-es.asciidoc
@@ -1,5 +1,5 @@
 [[ls-networkbridge]]
-=== {agent} to {ls} to {es}: {ls} as proxy to bridge networks
+=== {agent} to {ls} to {es}: {ls} as a proxy
 
 image::images/ea-ls-bridge.png[Image showing {agent}s collecting data and sending to {ls} for proxying before sending on to {es}]
 

--- a/docs/en/ingest-arch/14-ea-ls-es.asciidoc
+++ b/docs/en/ingest-arch/14-ea-ls-es.asciidoc
@@ -1,5 +1,5 @@
 [[ls-networkbridge]]
-=== {agent} to {ls} to {es}: {ls} to bridge networks
+=== {agent} to {ls} to {es}: {ls} as proxy to bridge networks
 
 image::images/ea-ls-bridge.png[Image showing {agent}s collecting data and sending to {ls} for proxying before sending on to {es}]
 

--- a/docs/en/ingest-arch/15-proxy.asciidoc
+++ b/docs/en/ingest-arch/15-proxy.asciidoc
@@ -6,8 +6,7 @@ image::images/ea-proxy-fs-es.png[Image showing connections between {agent} and {
 image::images/ea-fs-proxy-es.png[Image showing connections between {agent} and {es} using a proxy]
 
 TIP: This architecture works with a variety of proxying tools to allow for more flexibility in your environment.
-Consider using <<ls-networkbridge,{ls} as proxy>> when it is feasable for your use case.
-{ls} and the rest of the {stack} are designed and tested to work together, and can be easier to support. 
+Consider using <<ls-networkbridge,{ls} as a proxy>>, as {ls} and the rest of the {stack} are designed and tested to work together, and can be easier to support.  
 
 Ingest model::
  +

--- a/docs/en/ingest-arch/15-proxy.asciidoc
+++ b/docs/en/ingest-arch/15-proxy.asciidoc
@@ -5,6 +5,10 @@ image::images/ea-proxy-fs-es.png[Image showing connections between {agent} and {
 
 image::images/ea-fs-proxy-es.png[Image showing connections between {agent} and {es} using a proxy]
 
+TIP: This architecture works with a variety of proxying tools to allow for more flexibility in your environment.
+Consider using <<ls-networkbridge,{ls} as proxy>> when it is feasable for your use case.
+{ls} and the rest of the {stack} are designed and tested to work together, and can be easier to support. 
+
 Ingest model::
  +
 Control path for {fleet-server} on {ecloud}: {agent} to proxy to {fleet-server} to {es} +
@@ -14,6 +18,7 @@ Data path: {agent} to proxy to {es}
 Use when::
 * Network restrictions prevent connection between {agent} network and network where {fleet-server} and {stack} are deployed, as when {fleet-server} is deployed on {ecloud}
 * Network restrictions prevent connection between {agent} and {fleet-server} network and the network where {stack} is deployed, as when {stack} is deployed on {ecloud}
+* Using <<ls-networkbridge,{ls} as proxy>> is not feasible. 
 
 
 [discrete]


### PR DESCRIPTION
Closes #70

Sets up  distinction between "Logstash as proxy" and generic proxy.