### PR TITLE
Add docs for upgrade package verification with alternate PGP keys

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -825,8 +825,20 @@ The version of {agent} to upgrade to.
 The source URI to download the new version from. By default, {agent} uses the
 Elastic Artifacts URL.
 
+`--skip-verify`::
+Skip the package verification process. This option is not recommended as it is insecure.
+
+`--pgp-path <string>`::
+Use a locally stored copy of the PGP key to verify the upgrade package.
+
+`--pgp-uri <string>`::
+Use the specified online PGP key to verify the upgrade package.
+
 `--help`::
 Show help for the `upgrade` command.
+
+For details about using the `--skip-verify`, `--pgp-path <string>`, and `--pgp-uri <string>`
+package verification options, refer to <<upgrade-standalone-verify-package>>.
 
 {global-flags-link}
 

--- a/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
@@ -34,18 +34,18 @@ The basic upgrade scenario should work for most use cases. However, in an air-ga
 As an alterative, you can do one of the following:
 
 * <<fleet-agent-proxy-support,Configure a proxy server>> for standalone {agent} to access the {artifact-registry}.
-* <<host-artifact-registry,Host your own artifact registry for binary downloads>>
+* <<host-artifact-registry,Host your own artifact registry>> for standalone {agent} to access binary downloads.
 
-To learn more, refer to <<air-gapped,Air-gapped environments>> for more details.
+Refer to <<air-gapped,Air-gapped environments>> for more details.
 
 [[upgrade-standalone-verify-package]]
 == Verifying {agent} package signatures
 
-Standalone {agent} verifies each package that it downloads using publically available SHA hash and .asc PGP signature files. The SHA file is used to verify that the package has not been modified, and the .asc file is used to verify that the package was released by Elastic. For this purpose, the Elastic public key is embedded in {agent} itself.
+Standalone {agent} verifies each package that it downloads using publically available SHA hash and .asc PGP signature files. The SHA file is used to verify that the package has not been modified, and the .asc file is used to verify that the package was released by Elastic. For this purpose, the Elastic public GPG key is embedded in {agent} itself.
 
 At times, the Elastic private GPG key may need to be rotated, either due to the key expiry or due to the private key having been exposed. In this case, standalone {agent} upgrades can fail because the embedded public key no longer works.
 
-In the event of a private key rotation, you can use the following options with the <<elastic-agent-upgrade-command,`upgrade`>> command to force {agent} to use a new public key for verification:
+In the event of a private GPG key rotation, you can use the following options with the <<elastic-agent-upgrade-command,`upgrade`>> command to either skip the verification process (not recommended) or force {agent} to use a new public key for verification:
 
 `--skip-verify`::
 Skip the package verification process. This option is not recommended as it is insecure.

--- a/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
@@ -10,13 +10,13 @@ To upgrade a standalone agent running on an edge node:
 upgrade to a new version. Not sure where the agent is
 installed? Refer to <<installation-layout>>.
 +
-For example, on macOS, to upgrade the agent from version 7.10.0 to 7.10.1, you
+For example, on macOS, to upgrade the agent from version 8.8.0 to 8.8.1, you
 would run:
 +
 [source,shell]
 ----
 cd /Library/Elastic/Agent/
-sudo elastic-agent upgrade 7.10.1
+sudo elastic-agent upgrade 8.8.1
 ----
 
 This command upgrades the binary. Your agent policy should continue to work,
@@ -24,3 +24,66 @@ but you might need to upgrade it to use new features and capabilities.
 
 For more command-line options, see the help for the
 <<elastic-agent-upgrade-command,`upgrade`>> command.
+
+
+[[upgrade-standalone-air-gapped]]
+== Upgrading standalone {agent} in an air-gapped environmment
+
+The basic upgrade scenario should work for most use cases. However, in an air-gapped environment {agent} is not able to access the {artifact-registry} at `artifacts.elastic.co` directly.
+
+As an alterative, you can do one of the following:
+
+* <<fleet-agent-proxy-support,Configure a proxy server>> for standalone {agent} to access the {artifact-registry}.
+* <<host-artifact-registry,Host your own artifact registry for binary downloads>>
+
+To learn more, refer to <<air-gapped,Air-gapped environments>> for more details.
+
+[[upgrade-standalone-verify-package]]
+== Verifying {agent} package signatures
+
+Standalone {agent} verifies each package that it downloads using publically available SHA hash and .asc PGP signature files. The SHA file is used to verify that the package has not been modified, and the .asc file is used to verify that the package was released by Elastic. For this purpose, the Elastic public key is embedded in {agent} itself.
+
+At times, the Elastic private GPG key may need to be rotated, either due to the key expiry or due to the private key having been exposed. In this case, standalone {agent} upgrades can fail because the embedded public key no longer works.
+
+In the event of a private key rotation, you can use the following options with the <<elastic-agent-upgrade-command,`upgrade`>> command to force {agent} to use a new public key for verification:
+
+`--skip-verify`::
+Skip the package verification process. This option is not recommended as it is insecure.
++
+Example:
++
+[source,yaml,subs="attributes"]
+----
+./elastic-agent upgrade 8.8.0 --skip-verify
+----
+
+`--pgp-path <string>`::
+Use a locally stored copy of the PGP key to verify the upgrade package.
++
+Example:
++
+[source,yaml,subs="attributes"]
+----
+./elastic-agent upgrade 8.8.0 --pgp-path /home/elastic-agent/GPG-KEY-elasticsearch
+----
+
+`--pgp-uri <string>`::
+Use the specified online PGP key to verify the upgrade package.
++
+Example:
++
+[source,yaml,subs="attributes"]
+----
+./elastic-agent upgrade 8.7.0-SNAPSHOT --pgp-uri "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+----
+
+Under the basic upgrade scenario standalone {agent} will automatically fetch the most current public key, however in an air-gapped environment or in the event that the {artifact-registry} is otherwise inaccessible, these commands can be used instead.
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This adds docs for the new commands to force standalone agent to use a new public GPG key to verify upgrade packages. I also added some brief mention of air-gapped upgrades since it's essential background.

**Preview**

* [Upgrade standalone agents](https://ingest-docs_334.docs-preview.app.elstc.co/guide/en/fleet/master/upgrade-standalone.html#upgrade-standalone) (I've added new sections "Upgrading standalone Elastic Agent in an air-gapped environmment" and "Verifying Elastic Agent package signatures")
* [elastic-agent upgrade command](https://ingest-docs_334.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-cmd-options.html#elastic-agent-upgrade-command) (I've added the new options to this page)

Closes: #335
Rel: https://github.com/elastic/elastic-agent/pull/2246