### PR TITLE
Update agent recommended disk to 2 GB

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -61,7 +61,7 @@ The {agent} used the default policy, running the system integration and self-mon
 // lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640 MB
+| **Disk** | 2 GB
 | **RSS Mem Size** | 300 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
This updates the recommended disk space for Elastic Agent to 2 GB. This change should be backported to 8.6.

![Screenshot 2023-07-20 at 10 05 18 AM](https://github.com/elastic/ingest-docs/assets/41695641/60d9c1d3-2c75-44df-8510-7c812300226a)


