### PR TITLE
Update recommended Disk and RSS Mem Size settings for Elastic Agent

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -61,7 +61,7 @@ The {agent} used the default policy, running the system integration and self-mon
 // lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640 MB
-| **RSS Mem Size** | 300 MB
+| **Disk** | 1.7 GB
+| **RSS Mem Size** | 400 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
Updates the recommended minimums for Elastic Agent as shown (applicable to versions 8.8 and higher):
![Screenshot 2023-07-26 at 10 38 43 AM](https://github.com/elastic/ingest-docs/assets/41695641/0bf5b69e-1eaa-45fe-af39-5a8e9cfa2258)

Closes: https://github.com/elastic/ingest-docs/issues/347
