### PR TITLE
Update recommended Disk and RSS Mem Size settings - v8.6

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -54,7 +54,7 @@ The {agent} used the default policy, running the system integration and self-mon
 // lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640 MB
-| **RSS Mem Size** | 300 MB
+| **Disk** | 1.2 GB
+| **RSS Mem Size** | 800 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
Updates the recommended minimums for Elastic Agent as shown (version 8.6):

![Screenshot 2023-07-26 at 10 51 41 AM](https://github.com/elastic/ingest-docs/assets/41695641/8197f984-ff8c-4a05-95b1-529eb0b3082e)
