### PR TITLE
Update recommended Disk and RSS Mem Size settings - v8.5

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -51,7 +51,7 @@ The {agent} used the default policy, running the system integration and self-mon
 // lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640 MB
-| **RSS Mem Size** | 300 MB
+| **Disk** | 420 MB
+| **RSS Mem Size** | 700 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
Updates the recommended minimums for Elastic Agent as shown (version 8.6):

![Screenshot 2023-07-26 at 11 01 19 AM](https://github.com/elastic/ingest-docs/assets/41695641/272dbd41-8293-432b-8bb2-8acea8859caa)

Rel: https://github.com/elastic/ingest-docs/issues/347