### PR TITLE
Update recommended Disk and RSS Mem Size settings - v8.2

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -66,7 +66,7 @@ The {agent} used the default policy, running the system integration and self-mon
 // lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640 MB
-| **RSS Mem Size** | 300 MB
+| **Disk** | 420 MB
+| **RSS Mem Size** | 700 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
Updates the recommended minimums for Elastic Agent as shown (version 8.2):

![Screenshot 2023-07-26 at 11 15 37 AM](https://github.com/elastic/ingest-docs/assets/41695641/3d8fbf91-7672-4321-a1a7-429c17e51729)

Rel: https://github.com/elastic/ingest-docs/issues/347