### PR TITLE
Update recommended Disk and RSS Mem Size settings - v8.1

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -61,7 +61,7 @@ The {agent} used the default policy, running the system integration and self-mon
 
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 640MB
-| **RSS Mem Size** | 300 MB
+| **Disk** | 300 MB
+| **RSS Mem Size** | 800 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.


### PR DESCRIPTION
Updates the recommended minimums for Elastic Agent as shown (version 8.2):

![Screenshot 2023-07-26 at 11 20 48 AM](https://github.com/elastic/ingest-docs/assets/41695641/e8e110f4-9842-4633-a004-f68e8d493706)

Rel: https://github.com/elastic/ingest-docs/issues/347