### PR TITLE
Remove tested version number from agent minimum install reqs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -55,7 +55,7 @@ Refer to:
 == Minimum Requirements
 
 // lint ignore 2vcpu 1gb
-Minimum requirements have been determined by running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
+Minimum requirements have been determined by running the {agent} on a GCP `e2-micro` instance (2vCPU/1GB).
 The {agent} used the default policy, running the system integration and self-monitoring.
 
 // lint ignore mem


### PR DESCRIPTION
The Elastic Agent install [minimum requirements](https://www.elastic.co/guide/en/fleet/8.8/elastic-agent-installation.html#_minimum_requirements) mentions the agent version on which the requirements were tested. This isn't really necessary since the product requirements match the docs version, and it's one more thing that we have to maintain with each release (and in the event that we neglect to maintain it, the docs appear inconsistent).