### PR TITLE
[8.1] Remove tested version number from agent minimum install reqs (#360)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -56,7 +56,8 @@ Refer to:
 [discrete]
 == Minimum Requirements
 
-Minimum requirements have been determined by running the {agent} (`v8.0.0`) on a GCP `e2-micro` instance (2vCPU/1GB).
+// lint ignore 2vcpu 1gb
+Minimum requirements have been determined by running the {agent} on a GCP `e2-micro` instance (2vCPU/1GB).
 The {agent} used the default policy, running the system integration and self-monitoring.
 
 |===


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Remove tested version number from agent minimum install reqs (#360)](https://github.com/elastic/ingest-docs/pull/360)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)