### PR TITLE
Can someone explain why Fleet & Agent needs to talk to 5601?

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -79,8 +79,6 @@ You may need to allow access to these ports. Refer to the following table for de
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 9200
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 5601
-| {fleet-server} → {fleet} | 5601
 | {fleet-server} → {es} | 9200
 |===
 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -80,6 +80,7 @@ You may need to allow access to these ports. Refer to the following table for de
 | Elastic Agent → {es} | 9200
 | Elastic Agent → Logstash | 5044
 | {fleet-server} → {es} | 9200
+| {fleet-server} → {kib} | 5601
 |===
 
 //[discrete]


### PR DESCRIPTION
5601 is usually reserved for Kibana. I don't understand why those two ports are listed there as communication parts. Seems werid.

Fleet => Kibana using 5601 makes sense as there is a fleet kibana url in the fleet settings:
https://www.elastic.co/guide/en/fleet/current/agent-environment-variables.html#env-enroll-agent
