### PR TITLE
Fix images on Elastic Agent K8s Scaling page

### DIFF
--- a/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
@@ -47,7 +47,7 @@ Additionally, by default one agent is elected as **leader** (for more informatio
 
 --
 [role="screenshot"]
-image::../images/k8sscaling.png[{agent} as daemonset]
+image::images/k8sscaling.png[{agent} as daemonset]
 --
 
 The above schema explains how {agent} collects and sends metrics to {es}. Because of Leader Agent being responsible to also collecting cluster-lever metrics, this means that it requires additional resources.
@@ -171,7 +171,7 @@ If {agent} is configured as managed, in {kib} you can observe under **Fleet>Agen
 
 --
 [role="screenshot"]
-image::../images/agent-status.png[{agent} Status]
+image::images/agent-status.png[{agent} Status]
 --
 
 Additionally you can verify the process status with following commands:
@@ -248,13 +248,13 @@ elastic-agent-wvmpj                                              27m          35
 Filter for Pod dataset:
 --
 [role="screenshot"]
-image::../images/pod-latency.png[{k8s} Pod Metricset]
+image::images/pod-latency.png[{k8s} Pod Metricset]
 --
 
 Filter for State_Pod dataset
 --
 [role="screenshot"]
-image::../images/state-pod.png[{k8s} State Pod Metricset]
+image::images/state-pod.png[{k8s} State Pod Metricset]
 --
 
 Identify how many events have been sent to {es}:


### PR DESCRIPTION
Fixes broken image link in the v8.9 version of the [Scaling Elastic Agent on Kubernetes page](https://www.elastic.co/guide/en/fleet/master/scaling-on-kubernetes.html).

Closes: #395 