### PR TITLE
Add Fleet & Agent 8.9.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -34,24 +34,19 @@ Review important information about the {fleet} and {agent} 8.9.1 release.
 === Security updates
 
 {agent}::
-//* TBD {agent-pull}xxxx[#xxxx] 
-
-[discrete]
-[[enhancements-8.9.1]]
-=== Enhancements
-//* TBD {agent-pull}xxxx[#xxxx] {agent-issue}xxxx[#xxxx]
+* Updated Go version to 1.19.12. {agent-pull}3186[#3186] 
 
 [discrete]
 [[bug-fixes-8.9.1]]
 === Bug fixes
 
 {fleet}::
-//* TBD {kibana-pull}xxxxxx[#xxxxxx]
-//* TBD {kibana-pull}xxxxxx[#xxxxxx]
+* Fixes for query error on Agents list in the UI. ({kibana-pull}162816[#162816])
+* Remove duplicate path being pushed to package archive. ({kibana-pull}162724[#162724])
 
 {agent}::
-//* TBD {agent-pull}xxxx[#xxxx]  {agent-issue}xxxx[#xxxx]
-//* TBD {agent-pull}xxxx[#xxxx]  {agent-issue}2899[#xxxx]
+* Improve two unclear error messages in the Upgrade Watcher {agent-pull}3093[#3093]
+* Add default UTC timezone to synthetics agent Docker images to prevent navigation errors {agent-pull}3160[#3160] {beats-issue}36117[#36117]
 
 // end 8.9.1 relnotes
 


### PR DESCRIPTION
This adds the 8.9.1 Fleet & Agent Release Notes:
 - Fleet contents are from the [Kibana RN PR](https://github.com/elastic/kibana/pull/163578)
 - Fleet Server - nothing to add as there are [no 8.9.1 fragments](https://github.com/elastic/fleet-server/tree/883cb46647979e234f70c88fd4aca1dc9f65800b/changelog/fragments). 
 - Elastic Agent contents are from the 8.9.1 fragments and verified by the [changelog PR](https://github.com/elastic/elastic-agent/pull/3248)

[Preview](https://ingest-docs_403.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.9.1.html)

Closes: https://github.com/elastic/ingest-docs/issues/404