### PR TITLE
Include profiling in air-gapped env

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -217,6 +217,12 @@ curl -O https://artifacts.elastic.co/downloads/fleet-server/fleet-server-{versio
 curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz
 curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz.sha512
 curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz.asc
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{version}-linux-x86_64.tar.gz
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{version}-linux-x86_64.tar.gz.sha512
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{version}-linux-x86_64.tar.gz.asc
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{version}-linux-x86_64.tar.gz
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{version}-linux-x86_64.tar.gz.sha512
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{version}-linux-x86_64.tar.gz.asc
 ----
 .. On your HTTP file server, group the artifacts into directories and
 sub-directories that follow the same convention used by the {artifact-registry}:

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -176,8 +176,8 @@ from it.
 .. Download the latest release artifacts from the public {artifact-registry} at
 `https://artifacts.elastic.co/downloads/`. For example, the
 following cURL commands download all the artifacts that may be needed to upgrade
-{agent}s running on Linux. The exact list depends on which integrations you're
-using.
+{agent}s running on Linux x86_64. You may replace `x86_64` with `arm64` for the ARM64 version.
+The exact list depends on which integrations you're using.
 +
 ["source","shell",subs="attributes"]
 ----
@@ -214,6 +214,9 @@ curl -O https://artifacts.elastic.co/downloads/endpoint-dev/endpoint-security-{v
 curl -O https://artifacts.elastic.co/downloads/fleet-server/fleet-server-{version}-linux-x86_64.tar.gz
 curl -O https://artifacts.elastic.co/downloads/fleet-server/fleet-server-{version}-linux-x86_64.tar.gz.sha512
 curl -O https://artifacts.elastic.co/downloads/fleet-server/fleet-server-{version}-linux-x86_64.tar.gz.asc
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz.sha512
+curl -O https://artifacts.elastic.co/downloads/prodfiler/pf-host-agent-{version}-linux-x86_64.tar.gz.asc
 ----
 .. On your HTTP file server, group the artifacts into directories and
 sub-directories that follow the same convention used by the {artifact-registry}:


### PR DESCRIPTION
We add the Universal Profiling agent download URL to the list of artifacts to download in air-gapped environments. We also amend the list with the ability to download ARM64 binaries.