### PR TITLE
Small fix to Fleet's Logstash output type

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -5,7 +5,7 @@ Specify these settings to send data over a secure connection to {ls}. You must
 also configure a {ls} pipeline that reads encrypted data from {agent}s and sends
 the data to {es}. Follow the in-product steps to configure the {ls} pipeline.
 
-In the {fleet} <<output-settings,Output settings>>, make sure that {ls} is selected.
+In the {fleet} <<output-settings,Output settings>>, make sure that the {ls} output type is selected.
 
 To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 


### PR DESCRIPTION
Rel: #421 
This updates Fleet's Logstash output type page equivalent to the same for for Kafka and Elasticsearch (I forgot to click Save when making the updates in the original PR).