### PR TITLE
Update .backportrc.json to add 8.10 backport label

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "elastic",
   "repoName": "ingest-docs",
-  "targetBranchChoices": ["main", "8.9", "8.8", "8.7", "8.6", "7.17"],
+  "targetBranchChoices": ["main", "8.10", "8.9", "8.8", "8.7", "8.6", "7.17"],
   "autoMerge": true,
   "autoMergeMethod": "squash",
   "branchLabelMapping": {


### PR DESCRIPTION
We'll need the `backport-8.10` tag now that `main` = v8.11.0.