### PR TITLE
[8.10] Adds tip about creating Elastic Defend policy using Fleet API (#417)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -100,8 +100,10 @@ policies.
 [[create-integration-policy-api]]
 == Create integration policy
 
-To create a integration policy (also known as an package policy) and add it to an 
+To create an integration policy (also known as a package policy) and add it to an 
 existing agent policy, call `POST /api/fleet/package_policies`.
+
+TIP: You can use the {fleet} API to {security-guide}/create-defend-policy-api.html[Create and customize an {elastic-defend} policy].
 
 This cURL example creates an integration policy for Nginx and adds it to the
 agent policy created in the previous example:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Adds tip about creating Elastic Defend policy using Fleet API (#417)](https://github.com/elastic/ingest-docs/pull/417)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)