### PR TITLE
[8.10] Small fix to Fleet's Logstash output type (#422)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -5,6 +5,8 @@ Specify these settings to send data over a secure connection to {ls}. You must
 also configure a {ls} pipeline that reads encrypted data from {agent}s and sends
 the data to {es}. Follow the in-product steps to configure the {ls} pipeline.
 
+In the {fleet} <<output-settings,Output settings>>, make sure that the {ls} output type is selected.
+
 To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 
 [cols="2*<a"]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Small fix to Fleet's Logstash output type (#422)](https://github.com/elastic/ingest-docs/pull/422)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)