### PR TITLE
Update mergify.yml for 8.10

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,20 @@ pull_request_rules:
           git merge <remote-repo>/{{base}}
           git push <remote-repo> {{head}}
           ```
+  - name: backport patches to 8.10 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.10
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.10"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
   - name: backport patches to 8.9 branch
     conditions:
       - merged


### PR DESCRIPTION
This enables the auto-backport tool to merge from `main` into `8.10`. 

For future reference, I should have updated both [.mergify.yml](https://github.com/elastic/ingest-docs/blob/main/.mergify.yml) and [.backportrc.json](https://github.com/elastic/ingest-docs/blob/main/.backportrc.json) in the same PR. Now I know for next time.