### PR TITLE
Remove experimental tag and improve documentation of syslog processor

### DIFF
--- a/docs/en/ingest-management/processors/processor-syslog.asciidoc
+++ b/docs/en/ingest-management/processors/processor-syslog.asciidoc
@@ -5,9 +5,12 @@
 <titleabbrev>syslog</titleabbrev>
 ++++
 
-experimental[]
-
-The `syslog` processor parses RFC 3146 and/or RFC 5424 formatted syslog messages.
+The syslog processor parses RFC 3146 and/or RFC 5424 formatted syslog messages
+that are stored in a field. The processor itself does not handle receiving syslog
+messages from external sources. This is done through an input, such as the TCP
+input. Certain integrations, when enabled through configuration, will embed the
+syslog processor to process syslog messages, such as Custom TCP Logs and
+Custom UDP Logs.
 
 [discrete]
 == Example


### PR DESCRIPTION
- Removed the experimental tag for the syslog processor
- Improve documentation of the syslog processor to note that it does not directly handle receiving external messages.
- See elastic/beats#36417