### PR TITLE
Add Fleet & Agent 7.17.13 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.13>>
+
 * <<release-notes-7.17.12>>
 
 * <<release-notes-7.17.11>>
@@ -44,6 +46,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.13 relnotes
+
+[[release-notes-7.17.13]]
+== {fleet} and {agent} 7.17.13
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.13 relnotes
 
 // begin 7.17.12 relnotes
 


### PR DESCRIPTION
This adds the 7.17.13 Fleet & Agent Release Notes:

 - Fleet: no RN entries in [Kibana PR](https://github.com/elastic/kibana/pull/165342)
 - Fleet Server: [no fragments in bc1](https://github.com/elastic/fleet-server/tree/305aee56a8b631bf76d23ff7993f451608d12822/changelog/fragments)
 - Elastic Agent: [no changelog file for bc1](https://staging.elastic.co/7.17.13-d6f555d2/summary-7.17.13.html)


**PREVIEW**
![Screenshot 2023-08-31 at 7 48 57 PM](https://github.com/elastic/ingest-docs/assets/41695641/7c9dbec5-144b-4c58-ab9b-2017c834a27a)
