### PR TITLE
Add Fleet & Agent 8.9.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -31,24 +31,21 @@ Also see:
 Review important information about the {fleet} and {agent} 8.9.2 release.
 
 [discrete]
-[[security-updates-8.9.2]]
-=== Security updates
+[[enhancements-8.9.2]]
+=== Enhancements
+
+{fleet}::
+* Adds the configuration setting `xpack.fleet.packageVerification.gpgKeyPath` as an environment variable in the {kib} container. {kibana-pull}163783[#163783].
 
 {agent}::
-//* Example. {agent-pull}....[#....] 
+* Adds logging to the restart step of the {agemt} upgrade rollback process. {agent-pull}3245[#3245]
 
 [discrete]
 [[bug-fixes-8.9.2]]
 === Bug fixes
 
-{fleet}::
-//* Example ({kibana-pull}......[#......])
-
-{fleet-server}::
-//* Example {fleet-server-pull}2677[#2677]
-
 {agent}::
-//* Example {agent-pull}....[#....]
+* Correctly identify retryable errors when attempting to uninstall on Windows. {agent-pull}3317[#3317]
 
 // end 8.9.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -38,7 +38,7 @@ Review important information about the {fleet} and {agent} 8.9.2 release.
 * Adds the configuration setting `xpack.fleet.packageVerification.gpgKeyPath` as an environment variable in the {kib} container. {kibana-pull}163783[#163783].
 
 {agent}::
-* Adds logging to the restart step of the {agemt} upgrade rollback process. {agent-pull}3245[#3245]
+* Adds logging to the restart step of the {agent} upgrade rollback process. {agent-pull}3245[#3245]
 
 [discrete]
 [[bug-fixes-8.9.2]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.9.2>>
 * <<release-notes-8.9.1>>
 * <<release-notes-8.9.0>>
 
@@ -21,6 +22,35 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.9.2 relnotes
+
+[[release-notes-8.9.2]]
+== {fleet} and {agent} 8.9.2
+
+Review important information about the {fleet} and {agent} 8.9.2 release.
+
+[discrete]
+[[security-updates-8.9.2]]
+=== Security updates
+
+{agent}::
+//* Example. {agent-pull}....[#....] 
+
+[discrete]
+[[bug-fixes-8.9.2]]
+=== Bug fixes
+
+{fleet}::
+//* Example ({kibana-pull}......[#......])
+
+{fleet-server}::
+//* Example {fleet-server-pull}2677[#2677]
+
+{agent}::
+//* Example {agent-pull}....[#....]
+
+// end 8.9.2 relnotes
 
 // begin 8.9.1 relnotes
 


### PR DESCRIPTION
This adds the 8.9.2 Fleet & Agent Release Notes:
 - Fleet contents are from the [Kibana RN PR](https://github.com/elastic/kibana/pull/165370)
 - Fleet Server - No 8.9.2 fragments.
 - Elastic Agent contents are from the [8.9.2 BC1 fragments](https://github.com/elastic/elastic-agent/tree/162ea92bd5d85f543a0746546b8cb5ec4cd8e2f8/changelog/fragments)

[Docs preview](https://ingest-docs_439.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.9.2.html)

Closes: #436