### PR TITLE
Update air-gapped.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -8,6 +8,11 @@ steps to make sure:
 content.
 * {agent}s are able to download binaries during upgrades.
 
+[TIP]
+====
+See the Elastic Security for air-gapped https://www.elastic.co/guide/en/security/current/offline-endpoint.html[offline endpoints].
+====
+
 When upgrading all the components in an air-gapped environment, it is recommended that you upgrade in the following order:
 
 . Upgrade the {package-registry}.


### PR DESCRIPTION
This needs to cross reference the air-gapped setup for security endpoints.

This is commonly missed with elastic-agents using Elastic Defend integtrations