### PR TITLE
[DOCS] Removes // from fleet agent proxy support link

### DIFF
--- a/docs/en/ingest-arch/15-proxy.asciidoc
+++ b/docs/en/ingest-arch/15-proxy.asciidoc
@@ -33,7 +33,7 @@ Info on {agent} and agent integrations:
 
 Info on using a proxy server:
 
-* {fleet-guide}//fleet-agent-proxy-support.html[Using a proxy server with {agent} and {fleet}]
+* {fleet-guide}/fleet-agent-proxy-support.html[Using a proxy server with {agent} and {fleet}]
 
 Info on {es}:
 


### PR DESCRIPTION
Changes `{fleet-guide}//fleet-agent-proxy-support.html` to `{fleet-guide}/fleet-agent-proxy-support.html`