### PR TITLE
Fix broken link to "Using a proxy server with Elastic Agent and Fleet"

### DIFF
--- a/docs/en/ingest-arch/15-proxy.asciidoc
+++ b/docs/en/ingest-arch/15-proxy.asciidoc
@@ -33,7 +33,7 @@ Info on {agent} and agent integrations:
 
 Info on using a proxy server:
 
-* {fleet-guide}//fleet-agent-proxy-support.html[Using a proxy server with {agent} and {fleet}]
+* {fleet-guide}/fleet-agent-proxy-support.html[Using a proxy server with {agent} and {fleet}]
 
 Info on {es}:
 


### PR DESCRIPTION
Rel: https://github.com/elastic/platform-docs-team/issues/195