### PR TITLE
Add Console details to Fleet API docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -22,6 +22,22 @@ https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/common/openapi/
 In this section, we provide examples of some commonly used {fleet} APIs.
 
 [discrete]
+[[using-the-console]]
+== Using the Console
+
+You can run {fleet} API requests through the {kib} Console.
+
+. Open the {kib} menu and go to **Management -> Dev Tools**.
+. In your request, prepend your {fleet} API endpoint with `kbn:`, for example:
++
+[source,sh]
+----
+GET kbn:/api/fleet/agent_policies
+----
+
+For more detail about using the {kib} Console refer to {kibana-ref}/console-kibana.html[Run API requests].
+
+[discrete]
 [[authentication]]
 == Authentication
 


### PR DESCRIPTION
The [Fleet API docs page](https://www.elastic.co/guide/en/fleet/current/fleet-api-docs.html) has no mention of how to run the APIs in the Kibana Console, i.e., by prepending the endpoint with `kbn:`. This adds a note about that as well as a link to [Run API requests](https://www.elastic.co/guide/en/kibana/master/console-kibana.html) page for more details.

Closes: https://github.com/elastic/ingest-docs/issues/432


![Screenshot 2023-09-01 at 12 30 09 PM](https://github.com/elastic/ingest-docs/assets/41695641/f126e02d-66af-4d8b-b9a6-e160eae6affd)
