### PR TITLE
Add doc links to Fleet UI output settings descriptions

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -65,7 +65,7 @@ currently provide validation.
 **Make this output the default for agent integrations**
 
 | When this setting is on, {agent}s use this output to send data if no other
-output is set in the agent policy.
+output is set in the <<agent-policy,agent policy>>.
 
 // =============================================================================
 
@@ -73,8 +73,7 @@ output is set in the agent policy.
 [id="es-agent-monitoring-output"]
 **Make this output the default for agent monitoring**
 
-| When this setting is on, {agent}s use this output to send agent monitoring
-data if no other output is set in the agent policy.
+| When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 Sending monitoring data to a remote {es} cluster is currently not supported.
 |===

--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -27,6 +27,8 @@ Default {es} port for {ecloud}
 * `https://1d7a52f5eb344de18ea04411fe09e564.fleet.eu-west-1.aws.qa.cld.elstc.co:443`
 * `https://[2001:db8::1]:9200`
 
+Refer to the <<add-a-fleet-server,{fleet-server}>> documentation for default ports and other configuration details.
+
 // =============================================================================
 
 |

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -35,6 +35,8 @@ Use the format `host:port` (without any protocol `http://`). Click **Add row** t
 * `localhost:9092`
 * `mykafkahost:9092`
 
+Refer to the <<add-a-fleet-server,{fleet-server}>> documentation for default ports and other configuration details.
+
 |===
 
 [discrete]

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -361,7 +361,7 @@ currently provide validation.
 **Make this output the default for agent integrations**
 
 | When this setting is on, {agent}s use this output to send data if no other
-output is set in the agent policy.
+output is set in the <<agent-policy,agent policy>>.
 
 // =============================================================================
 
@@ -369,7 +369,6 @@ output is set in the agent policy.
 [id="kafka-output-agent-monitoring"]
 **Make this output the default for agent monitoring**
 
-| When this setting is on, {agent}s use this output to send agent monitoring
-data if no other output is set in the agent policy.
+| When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 |===

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -86,7 +86,7 @@ currently provide validation.
 **Make this output the default for agent integrations**
 
 | When this setting is on, {agent}s use this output to send data if no other
-output is set in the agent policy.
+output is set in the <<agent-policy,agent policy>>.
 
 // =============================================================================
 
@@ -94,7 +94,6 @@ output is set in the agent policy.
 [id="ls-agent-monitoring-output"]
 **Make this output the default for agent monitoring**
 
-| When this setting is on, {agent}s use this output to send agent monitoring
-data if no other output is set in the agent policy.
+| When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 |===

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -23,6 +23,8 @@ To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 * `192.0.2.0:5044`
 * `mylogstashhost:5044`
 
+Refer to the <<add-a-fleet-server,{fleet-server}>> documentation for default ports and other configuration details.
+
 // =============================================================================
 
 |


### PR DESCRIPTION
This adds links to more detailed docs from the Fleet output settings descriptions. I'll update the Advanced YAML Configuration setting separately once we know which advanced settings to describe for each output type.

Elasticsearch Output settings, for example:


![Screenshot 2023-09-05 at 11 32 25 AM](https://github.com/elastic/ingest-docs/assets/41695641/401b0c19-f5af-42b6-ad7c-f5304b6c786e)
