### PR TITLE
Move 8.9.0 RN host.name change to breaking changes section

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -126,6 +126,19 @@ unchanged. On expected failure paths (for example, Agent Inactive, Missing Agent
 ====
 
 [discrete]
+[[breaking-ecs-hostname]]
+.`host.name` field changed to ECS lowercase format.
+[%collapsible]
+====
+*Details* +
+In {agent} output the `host.name` field has been changed to lowercase to match Elastic Common Schema (ECS) guidelines. The agent name is also reported in lowercase (`AGENT-name` becomes `agent-name`).
+
+*Impact* +
+After upgrading {agent} to version 8.9.0 or higher, any case-sensitive searches may result in false-positive alerts. For example, a case-sensitive search based on the upper-case `AGENT-name` could result in an alert such as `system.load.1 reported no data in the last 5m for AGENT-name`. After upgrading, you may need to manually clear alerts and adjust some searches to match the new `host.name` format.
+
+====
+
+[discrete]
 [[new-features-8.9.0]]
 === New features
 
@@ -158,7 +171,6 @@ The 8.9.0 release Added the following new and notable features.
 
 {agent}::
 * Add additional elements to support the Universal Profiling integration. {agent-pull}2881[#2881]
-* Lowercase reported hostnames per Elastic Common Schema (Ecs) Guidelines for the `host.name` field.
 
 [discrete]
 [[bug-fixes-8.9.0]]


### PR DESCRIPTION
This updates the [8.9.0 Release Notes](https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html). The change of the agent output `host.name` field to lowercase made in 8.9.0 should be marked as a breaking change.

Rel: https://github.com/elastic/kibana/issues/165642

![Screenshot 2023-09-06 at 9 40 52 AM](https://github.com/elastic/ingest-docs/assets/41695641/8b770e07-23fc-4d15-9f97-6b0db605b3eb)

