### PR TITLE
Add advanced YAML config for Fleet UI output settings docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
@@ -48,8 +48,8 @@ escaping.
 [id="{type}-worker-setting"]
 `worker`
 
-| (int) The number of workers per configured host publishing events to
-{output-type}. This is best used with load balancing mode enabled. Example: If
+| (int) The number of workers per configured host publishing events. 
+This is best used with load balancing mode enabled. Example: If
 you have two hosts and three workers, in total six workers are started (three
 for each host).
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -1,3 +1,4 @@
+:type: output-elasticsearch-fleet-settings
 
 [[es-output-settings]]
 = {es} output settings
@@ -60,6 +61,8 @@ To learn about proxy configuration, refer to <<fleet-agent-proxy-support>>.
 that uses this output. Make sure you specify valid YAML. The UI does not
 currently provide validation.
 
+See <<es-output-settings-yaml-config>> for descriptions of the available settings.
+
 // =============================================================================
 
 |
@@ -79,3 +82,36 @@ output is set in the <<agent-policy,agent policy>>.
 
 Sending monitoring data to a remote {es} cluster is currently not supported.
 |===
+
+[[es-output-settings-yaml-config]]
+== Advanced YAML configuration
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=backoff.init-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=backoff.max-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=bulk_max_size-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=max_retries-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=timeout-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=worker-setting]
+
+|===
+
+:type!:

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -391,7 +391,7 @@ output is set in the <<agent-policy,agent policy>>.
 [id="{type}-client_id-setting"]
 `client_id`
 
-| The configurable ClientID used for logging, debugging, and auditing purposes.
+| (string) The configurable ClientID used for logging, debugging, and auditing purposes.
 
 *Default:* `Elastic Agent`
 // end::client_id-setting[]
@@ -525,7 +525,7 @@ request.
 [id="{type}-keep_alive-setting"]
 `keep_alive`
 
-| The keep-alive period for an active network connection. If `0s`, keep-alives are disabled.
+| (string) The keep-alive period for an active network connection. If `0s`, keep-alives are disabled.
 
 *Default:* `0s`
 // end::keep_alive-setting[]
@@ -537,7 +537,7 @@ request.
 [id="{type}-max_message_bytes-setting"]
 `max_message_bytes`
 
-| The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. This value should be equal to or less than the broker's `message.max.bytes`.
+| (int) The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. This value should be equal to or less than the broker's `message.max.bytes`.
 
 *Default:* `1000000` (bytes)
 // end::max_message_bytes-setting[]

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -1,3 +1,5 @@
+:type: output-logstash-fleet-settings
+
 [[kafka-output-settings]]
 = Kafka output settings
 
@@ -356,6 +358,8 @@ To learn about proxy configuration, refer to <<fleet-agent-proxy-support>>.
 that uses this output. Make sure you specify valid YAML. The UI does not
 currently provide validation.
 
+See <<kafka-output-settings-yaml-config>> for descriptions of the available settings.
+
 // =============================================================================
 
 |
@@ -374,3 +378,172 @@ output is set in the <<agent-policy,agent policy>>.
 | When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 |===
+
+[[kafka-output-settings-yaml-config]]
+== Advanced YAML configuration
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+// tag::client_id-setting[]
+|
+[id="{type}-client_id-setting"]
+`client_id`
+
+| The configurable ClientID used for logging, debugging, and auditing purposes.
+
+*Default:* `Elastic Agent`
+// end::client_id-setting[]
+
+// =============================================================================
+
+// tag::codec-setting[]
+|
+[id="{type}-codec-setting"]
+`codec`
+
+| Output codec configuration. You can specify either the `json` or `format`
+codec. By default the `json` codec is used.
+
+*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
+
+*`json.escape_html`*: If `escape_html` is set to true, html symbols will be escaped in strings. The default is false.
+
+Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.json:
+    pretty: true
+    escape_html: false
+------------------------------------------------------------------------------
+
+*`format.string`*: Configurable format string used to create a custom formatted message.
+
+Example configurable that uses the `format` codec to print the events timestamp and message field to console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.format:
+    string: '%{[@timestamp]} %{[message]}'
+------------------------------------------------------------------------------
+
+*Default:* `json`
+// end::codec-setting[]
+
+// =============================================================================
+
+// tag::metadata-setting[]
+|
+[id="{type}-metadata-setting"]
+`metadata`
+
+| Kafka metadata update settings. The metadata do contain information about
+brokers, topics, partition, and active leaders to use for publishing.
+
+*`refresh_frequency`*:: Metadata refresh interval. Defaults to 10 minutes.
+
+*`full`*:: Strategy to use when fetching metadata, when this option is `true`, the client will maintain
+a full set of metadata for all the available topics, if the this option is set to `false` it will only refresh the
+metadata for the configured topics. The default is false.
+
+*`retry.max`*:: Total number of metadata update retries when cluster is in middle of leader election. The default is 3.
+
+*`retry.backoff`*:: Waiting time between retries during leader elections. Default is 250ms.
+// end::metadata-setting[]
+
+// =============================================================================
+
+// tag::backoff.init-setting[]
+|
+[id="{type}-backoff.init-setting"]
+`backoff.init`
+
+| (string) The number of seconds to wait before trying to reconnect to Kafka
+after a network error. After waiting `backoff.init` seconds, {agent} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset.
+
+*Default:* `1s`
+// end::backoff.init-setting[]
+
+// tag::backoff.max-setting[]
+|
+[id="{type}-backoff.max-setting"]
+`backoff.max`
+
+| (string) The maximum number of seconds to wait before attempting to connect to
+Kafka after a network error.
+
+*Default:* `60s`
+// end::backoff.max-setting[]
+
+// =============================================================================
+
+// tag::bulk_max_size-setting[]
+|
+[id="{type}-bulk_max_size-setting"]
+`bulk_max_size`
+
+| (int) The maximum number of events to bulk in a single Kafka
+request. 
+
+*Default:* `2048`
+// end::bulk_max_size-setting[]
+
+// =============================================================================
+
+// tag::bulk_flush_frequency-setting[]
+|
+[id="{type}-flush_frequency-setting"]
+`bulk_flush_frequency`
+
+| (int) Duration to wait before sending bulk Kafka request. `0`` is no delay. 
+
+*Default:* `0`
+// end::bulk_flush_frequency-setting[]
+
+// =============================================================================
+
+// tag::channel_buffer_size-setting[]
+|
+[id="{type}-channel_buffer_size-setting"]
+`channel_buffer_size`
+
+| (int) Per Kafka broker number of messages buffered in output pipeline.
+
+*Default:* `256`
+// end::channel_buffer_size-setting[]
+
+// =============================================================================
+
+// tag::keep_alive-setting[]
+|
+[id="{type}-keep_alive-setting"]
+`keep_alive`
+
+| The keep-alive period for an active network connection. If `0s`, keep-alives are disabled.
+
+*Default:* `0s`
+// end::keep_alive-setting[]
+
+// =============================================================================
+
+// tag::max_message_bytes-setting[]
+|
+[id="{type}-max_message_bytes-setting"]
+`max_message_bytes`
+
+| The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. This value should be equal to or less than the broker's `message.max.bytes`.
+
+*Default:* `1000000` (bytes)
+// end::max_message_bytes-setting[]
+
+// =============================================================================
+
+|===
+
+:type!:

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -1,4 +1,4 @@
-:type: output-logstash-fleet-settings
+:type: output-kafka-fleet-settings
 
 [[kafka-output-settings]]
 = Kafka output settings
@@ -386,77 +386,6 @@ output is set in the <<agent-policy,agent policy>>.
 |===
 | Setting | Description
 
-// tag::client_id-setting[]
-|
-[id="{type}-client_id-setting"]
-`client_id`
-
-| (string) The configurable ClientID used for logging, debugging, and auditing purposes.
-
-*Default:* `Elastic Agent`
-// end::client_id-setting[]
-
-// =============================================================================
-
-// tag::codec-setting[]
-|
-[id="{type}-codec-setting"]
-`codec`
-
-| Output codec configuration. You can specify either the `json` or `format`
-codec. By default the `json` codec is used.
-
-*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
-
-*`json.escape_html`*: If `escape_html` is set to true, html symbols will be escaped in strings. The default is false.
-
-Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
-
-[source,yaml]
-------------------------------------------------------------------------------
-output.console:
-  codec.json:
-    pretty: true
-    escape_html: false
-------------------------------------------------------------------------------
-
-*`format.string`*: Configurable format string used to create a custom formatted message.
-
-Example configurable that uses the `format` codec to print the events timestamp and message field to console:
-
-[source,yaml]
-------------------------------------------------------------------------------
-output.console:
-  codec.format:
-    string: '%{[@timestamp]} %{[message]}'
-------------------------------------------------------------------------------
-
-*Default:* `json`
-// end::codec-setting[]
-
-// =============================================================================
-
-// tag::metadata-setting[]
-|
-[id="{type}-metadata-setting"]
-`metadata`
-
-| Kafka metadata update settings. The metadata do contain information about
-brokers, topics, partition, and active leaders to use for publishing.
-
-*`refresh_frequency`*:: Metadata refresh interval. Defaults to 10 minutes.
-
-*`full`*:: Strategy to use when fetching metadata, when this option is `true`, the client will maintain
-a full set of metadata for all the available topics, if the this option is set to `false` it will only refresh the
-metadata for the configured topics. The default is false.
-
-*`retry.max`*:: Total number of metadata update retries when cluster is in middle of leader election. The default is 3.
-
-*`retry.backoff`*:: Waiting time between retries during leader elections. Default is 250ms.
-// end::metadata-setting[]
-
-// =============================================================================
-
 // tag::backoff.init-setting[]
 |
 [id="{type}-backoff.init-setting"]
@@ -469,6 +398,8 @@ to `backoff.max`. After a successful connection, the backoff timer is reset.
 
 *Default:* `1s`
 // end::backoff.init-setting[]
+
+// =============================================================================
 
 // tag::backoff.max-setting[]
 |
@@ -520,6 +451,56 @@ request.
 
 // =============================================================================
 
+// tag::client_id-setting[]
+|
+[id="{type}-client_id-setting"]
+`client_id`
+
+| (string) The configurable ClientID used for logging, debugging, and auditing purposes.
+
+*Default:* `Elastic Agent`
+// end::client_id-setting[]
+
+// =============================================================================
+
+// tag::codec-setting[]
+|
+[id="{type}-codec-setting"]
+`codec`
+
+| Output codec configuration. You can specify either the `json` or `format`
+codec. By default the `json` codec is used.
+
+*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
+
+*`json.escape_html`*: If `escape_html` is set to true, html symbols will be escaped in strings. The default is false.
+
+Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.json:
+    pretty: true
+    escape_html: false
+------------------------------------------------------------------------------
+
+*`format.string`*: Configurable format string used to create a custom formatted message.
+
+Example configurable that uses the `format` codec to print the events timestamp and message field to console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.format:
+    string: '%{[@timestamp]} %{[message]}'
+------------------------------------------------------------------------------
+
+*Default:* `json`
+// end::codec-setting[]
+
+// =============================================================================
+
 // tag::keep_alive-setting[]
 |
 [id="{type}-keep_alive-setting"]
@@ -543,6 +524,26 @@ request.
 // end::max_message_bytes-setting[]
 
 // =============================================================================
+
+// tag::metadata-setting[]
+|
+[id="{type}-metadata-setting"]
+`metadata`
+
+| Kafka metadata update settings. The metadata contains information about
+brokers, topics, partition, and active leaders to use for publishing.
+
+*`refresh_frequency`*:: Metadata refresh interval. Defaults to 10 minutes.
+
+*`full`*:: Strategy to use when fetching metadata. When this option is `true`, the 
+client will maintain a full set of metadata for all the available topics. When set
+to `false` it will only refresh the metadata for the configured topics. The default
+is false.
+
+*`retry.max`*:: Total number of metadata update retries. The default is 3.
+
+*`retry.backoff`*:: Waiting time between retries. The default is 250ms.
+// end::metadata-setting[]
 
 |===
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -112,15 +112,33 @@ output is set in the <<agent-policy,agent policy>>.
 |===
 | Setting | Description
 
-include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=escape_html-setting]
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=backoff.init-setting]
 
 // =============================================================================
 
-include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=proxy_use_local_resolver-setting]
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=backoff.max-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=bulk_max_size-setting]
 
 // =============================================================================
 
 include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=compression_level-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=escape_html-setting]
+
+// =============================================================================
+
+// tag::index-setting[]
+|
+[id="{type}-index-setting"]
+`index`
+
+| (string) The index root name to write events to.
+// end::index-setting[]
 
 // =============================================================================
 
@@ -133,6 +151,10 @@ include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=max
 // =============================================================================
 
 include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=pipelining-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=proxy_use_local_resolver-setting]
 
 // =============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -1,3 +1,5 @@
+:type: output-logstash-fleet-settings
+
 [[ls-output-settings]]
 = {ls} output settings
 
@@ -81,6 +83,8 @@ To learn about proxy configuration, refer to <<fleet-agent-proxy-support>>.
 that uses this output. Make sure you specify valid YAML. The UI does not
 currently provide validation.
 
+See <<ls-output-settings-yaml-config>> for descriptions of the available settings.
+
 // =============================================================================
 
 |
@@ -99,3 +103,53 @@ output is set in the <<agent-policy,agent policy>>.
 | When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 |===
+
+
+[[ls-output-settings-yaml-config]]
+== Advanced YAML configuration
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=escape_html-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=proxy_use_local_resolver-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=compression_level-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=loadbalance-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=max_retries-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=pipelining-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=slow_start-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=timeout-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-logstash.asciidoc[tag=ttl-setting]
+
+// =============================================================================
+
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=worker-setting]
+
+|===
+
+:type!:


### PR DESCRIPTION
This adds output settings that can be applied in the `Advanced YAML configuration` field in Fleet's Elasticsearch, Logstash, and Kafka output settings UIs. Settings are based off of the respective [Filebeat output settings](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-output.html) pages.

Preview pages:
 - [Elasticsearch advanced YAML](https://ingest-docs_465.docs-preview.app.elstc.co/guide/en/fleet/master/es-output-settings.html#es-output-settings-yaml-config)
 - [Logstash advanced YAML](https://ingest-docs_465.docs-preview.app.elstc.co/guide/en/fleet/master/ls-output-settings.html#ls-output-settings-yaml-config)
 - [Kafka advanced YAML](https://ingest-docs_465.docs-preview.app.elstc.co/guide/en/fleet/master/kafka-output-settings.html#kafka-output-settings-yaml-config)

Closes: #458 
Rel: https://github.com/elastic/ingest-docs/pull/453