### PR TITLE
Add warning about quotation marks to Kafka output docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -203,6 +203,13 @@ Processors are applied in the order that they appear, from top to bottom.
 
 The value field must be specified in a `[key]: value` format with both the key and value being strings. For example, `host.port: 2000` or `message: Test`.
 
+[NOTE]
+====
+Quotation marks cannot be used in the value of a key:value pair. This includes both single (') and double (") quotes.
+
+Also, spaces are removed from both the key and the value so as to preserve the YAML syntax in the {agent} configuration file.
+====
+
 As an example for setting up your processors, you might want to route log events based on severity. To do so, you can specify a default topic for all events not matched by other processors:
 
 * `%{[fields.log_topic]}`.
@@ -227,13 +234,6 @@ All non-critical and non-error events will then route to the default `%{[fields.
 == Header settings
 
 A header is a key-value pair, and multiple headers can be included with the same key. Only string values are supported. These headers will be included in each produced Kafka message.
-
-[IMPORTANT]
-====
-Quotation marks cannot be used in the value of a key:value pair. This includes both single (') and double (") quotes.
-
-Also, spaces are removed from both the key and the value so as to preserve the YAML syntax in the {agent} configuration file.
-====
 
 [cols="2*<a"]
 |===

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -203,7 +203,7 @@ Processors are applied in the order that they appear, from top to bottom.
 
 The value field must be specified in a `[key]: value` format with both the key and value being strings. For example, `host.port: 2000` or `message: Test`.
 
-NOTE: Quotation marks are included in the match string. That is, they should be specified in the key or value only if it's expected for them to be included in the events being matched against. So, `message: "error"` will match against the literal string `"error"`, including the quotations marks. This applies to both single (') and double (") quotation marks.
+NOTE: Quotation marks are included in the match string. That is, they should be specified in the key or value only if it's expected for them to be included in the events being matched against. So, `message: "error"` will match against the literal string `"error"`, including the quotations marks, and not against the unquoted `error`. This applies to both single (') and double (") quotation marks.
 
 As an example for setting up your processors, you might want to route log events based on severity. To do so, you can specify a default topic for all events not matched by other processors:
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -228,6 +228,13 @@ All non-critical and non-error events will then route to the default `%{[fields.
 
 A header is a key-value pair, and multiple headers can be included with the same key. Only string values are supported. These headers will be included in each produced Kafka message.
 
+[IMPORTANT]
+====
+Quotation marks cannot be used in the value of a key:value pair. This includes both single (') and double (") quotes.
+
+Also, spaces are removed from both the key and the value so as to preserve the YAML syntax in the {agent} configuration file.
+====
+
 [cols="2*<a"]
 |===
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -203,12 +203,7 @@ Processors are applied in the order that they appear, from top to bottom.
 
 The value field must be specified in a `[key]: value` format with both the key and value being strings. For example, `host.port: 2000` or `message: Test`.
 
-[NOTE]
-====
-Quotation marks cannot be used in the value of a key:value pair. This includes both single (') and double (") quotes.
-
-Also, spaces are removed from both the key and the value so as to preserve the YAML syntax in the {agent} configuration file.
-====
+NOTE: Quotation marks are included in the match string. That is, they should be specified in the key or value only if it's expected for them to be included in the events being matched against. So, `message: "error"` will match against the literal string `"error"`, including the quotations marks. This applies to both single (') and double (") quotation marks.
 
 As an example for setting up your processors, you might want to route log events based on severity. To do so, you can specify a default topic for all events not matched by other processors:
 


### PR DESCRIPTION
This adds the following highlighted note to the [Kafka output settings UI documentation](https://www.elastic.co/guide/en/fleet/8.10/kafka-output-settings.html#kafka-output-settings). 

![Screenshot 2023-09-25 at 11 29 30 AM](https://github.com/elastic/ingest-docs/assets/41695641/1d84e640-32cb-45ef-86f5-d03b04ef5415)

Rel: https://github.com/elastic/kibana/issues/166135
