### PR TITLE
Fix breaking link in 8.10 troubleshooting docs to known issue 3375

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -653,5 +653,5 @@ curl -u elastic:<password> --request POST \
 [[php-key-download-fail]]
 == Air-gapped {agent} upgrade can fail due to an inaccessible PGP key
 
-In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the link:https://www.elastic.co/guide/en/fleet/current/release-notes-8.9.0.html#known-issue-3375[PGP key download fails in an air-gapped environment] known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
+In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issue-3375[PGP key download fails in an air-gapped environment] known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -653,5 +653,5 @@ curl -u elastic:<password> --request POST \
 [[php-key-download-fail]]
 == Air-gapped {agent} upgrade can fail due to an inaccessible PGP key
 
-In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the <<known-issue-3375,PGP key download fails in an air-gapped environment>> known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
+In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the link:https://www.elastic.co/guide/en/fleet/current/release-notes-8.9.0.html#known-issue-3375[PGP key download fails in an air-gapped environment] known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
 


### PR DESCRIPTION
Fixes a bad link that's breaking the [8.10 Fleet & Agent Release Notes PR](https://github.com/elastic/ingest-docs/pull/469).