### PR TITLE
Add option enrich none to input

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -42,7 +42,9 @@ incoming {agent} connections and routes received events to {es}:
 input {
   elastic_agent {
     port => 5044
-    enrich => none
+    enrich => none # don't modify the events' schema at all
+    # or minimal change, add only ssl and source metadata
+    # enrich => [ssl_peer_metadata, source_metadata]
   }
 }
 

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -42,6 +42,7 @@ incoming {agent} connections and routes received events to {es}:
 input {
   elastic_agent {
     port => 5044
+    enrich => none
   }
 }
 


### PR DESCRIPTION
Add [enrich](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-elastic_agent.html#plugins-inputs-elastic_agent-ecs_metadata) option to none in the configuration example to prevent Logstash from adding the field like `event.original`, which can break integrations like apache.access (which expects the field event.original to not exist before the ingest pipeline). This should also slightly improve input performances, because it avoids Logstash to perform unuseful work.


An alternative configuration could be:
```
input {
  elastic_agent {
    port => 5044
    enrich => [ssl_peer_metadata, source_metadata]
  }
}
```

