### PR TITLE
Update standalone input settings docs to match elastic-agent.yml

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -58,7 +58,7 @@ To enable {agent} to collect log files, you can use a configuration like the fol
   id: your-input-id <2>
   streams:
     - id: your-filestream-stream-id <3>
-      data_stream:
+      data_stream: <4>
         dataset: generic
       paths:
         - /var/log/*.log
@@ -67,6 +67,7 @@ To enable {agent} to collect log files, you can use a configuration like the fol
 <1> A generic type describing the data.
 <2> A unique ID for the input.
 <3> A unique ID for the data stream to track the state of the ingested files.
+<4> The streams block is required only if multiple streams are used on the same input. 
 
 The input in this example harvests all files in the path `/var/log/*.log`, which
 means that {beatname_uc} will harvest all files in the directory `/var/log/`

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -22,14 +22,10 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
   id: unique-system-metrics-id <2>
   data_stream.namespace: default <3>
   use_output: default <4>
-  meta:
-    package: <5>
-      name: system
-      version: 0.10.9
   streams:
-    - metricsets: <6>
+    - metricsets: <5>
       - cpu
-      data_stream.dataset: system.cpu <7>
+      data_stream.dataset: system.cpu <6>
     - metricsets:
       - memory
       data_stream.dataset: system.memory
@@ -45,11 +41,10 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
 <2> A unique ID for the input.
 <3> A user-defined namespace.
 <4> The name of the `output` to use. If not specified, `default` will be used.
-<5> Package specification.
-<6> Enabled module metricsets.
+<5> The set of enabled module metricsets.
 +
 Refer to the {metricbeat} {metricbeat-ref}/metricbeat-module-system.html[System module] for a list of available options. The metricset fields can be configured.
-<7> A user-defined dataset. It can contain anything that makes sense to signify the source of the data.
+<6> A user-defined dataset. It can contain anything that makes sense to signify the source of the data.
 
 [discrete]
 [[elastic-agent-input-configuration-sample-logs]]

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -7,7 +7,14 @@
 
 The `inputs` section of the `elastic-agent.yml` file specifies how {agent} locates and processes input data.
 
-By default {agent} collects system metrics, such as CPU, memory, network, and file system metrics, and sends them to the default output. For example, to define the datastream for `cpu` metrics, this is the configuration:
+* <<elastic-agent-input-configuration-sample-metrics>>
+* <<elastic-agent-input-configuration-sample-logs>>
+
+[discrete]
+[[elastic-agent-input-configuration-sample-metrics]]
+== Sample metrics input configuration
+
+By default {agent} collects system metrics, such as CPU, memory, network, and file system metrics, and sends them to the default output. For example, to define datastream for `cpu`, `memory`, `network` and `filesystem` metrics, this is the configuration:
 
 ["source","yaml"]
 -----------------------------------------------------------------------
@@ -43,3 +50,36 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
 +
 Refer to the {metricbeat} {metricbeat-ref}/metricbeat-module-system.html[System module] for a list of available options. The metricset fields can be configured.
 <7> A user-defined dataset. It can contain anything that makes sense to signify the source of the data.
+
+[discrete]
+[[elastic-agent-input-configuration-sample-logs]]
+== Sample log files input configuration
+
+To enable {agent} to collect log files, you can use a configuration like the following.
+
+["source","yaml"]
+-----------------------------------------------------------------------
+- type: filestream <1>
+  id: your-input-id <2>
+  streams:
+    - id: your-filestream-stream-id <3>
+#     data_stream:
+#       dataset: generic
+#     paths:
+#       - /var/log/*.log
+-----------------------------------------------------------------------
+
+<1> A generic type describing the data.
+<2> A unique ID for the input.
+<3> A unique ID for the data stream to track the state of the ingested files.
+
+The input in this example harvests all files in the path `/var/log/*.log`, which
+means that {beatname_uc} will harvest all files in the directory `/var/log/`
+that end with `.log`. All patterns supported by
+https://golang.org/pkg/path/filepath/#Glob[Go Glob] are also supported here.
+
+To fetch all files from a predefined level of subdirectories, use this pattern:
+`/var/log/*/*.log`. This fetches all `.log` files from the subfolders of
+`/var/log`. It does not fetch log files from the `/var/log` folder itself.
+Currently it is not possible to recursively fetch all files in all
+subdirectories of a directory.

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -14,7 +14,7 @@ The `inputs` section of the `elastic-agent.yml` file specifies how {agent} locat
 [[elastic-agent-input-configuration-sample-metrics]]
 == Sample metrics input configuration
 
-By default {agent} collects system metrics, such as CPU, memory, network, and file system metrics, and sends them to the default output. For example, to define datastream for `cpu`, `memory`, `network` and `filesystem` metrics, this is the configuration:
+By default {agent} collects system metrics, such as CPU, memory, network, and file system metrics, and sends them to the default output. For example, to define datastreams for `cpu`, `memory`, `network` and `filesystem` metrics, this is the configuration:
 
 ["source","yaml"]
 -----------------------------------------------------------------------

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -58,10 +58,10 @@ To enable {agent} to collect log files, you can use a configuration like the fol
   id: your-input-id <2>
   streams:
     - id: your-filestream-stream-id <3>
-#     data_stream:
-#       dataset: generic
-#     paths:
-#       - /var/log/*.log
+      data_stream:
+        dataset: generic
+      paths:
+        - /var/log/*.log
 -----------------------------------------------------------------------
 
 <1> A generic type describing the data.

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/input-configuration.asciidoc
@@ -11,34 +11,35 @@ By default {agent} collects system metrics, such as CPU, memory, network, and fi
 
 ["source","yaml"]
 -----------------------------------------------------------------------
-- id: unique-system-metrics-id <1>
-  type: system/metrics <2>
-  use_output: default <3>
+- type: system/metrics <1>
+  id: unique-system-metrics-id <2>
+  data_stream.namespace: default <3>
+  use_output: default <4>
   meta:
-    package: <4>
+    package: <5>
       name: system
       version: 0.10.9
-  data_stream:
-    namespace: default <5>
   streams:
-    - data_stream:
-        dataset: system.cpu <6>
-        type: metrics <7>
-      metricsets: <8>
-        - cpu
-      period: 10s
-      cpu.metrics:
-        - percentages
-        - normalized_percentages
+    - metricsets: <6>
+      - cpu
+      data_stream.dataset: system.cpu <7>
+    - metricsets:
+      - memory
+      data_stream.dataset: system.memory
+    - metricsets:
+      - network
+      data_stream.dataset: system.network
+    - metricsets:
+      - filesystem
+      data_stream.dataset: system.filesystem
 -----------------------------------------------------------------------
 
-<1> A unique ID for the input.
-<2> A generic type describing the data.
-<3> The name of the `output` to use. If not specified, `default` will be used.
-<4> Package specification.
-<5> A user-defined namespace.
-<6> A user-defined dataset. It can contain anything that makes sense to signify the source of the data.
-<7> The type of the data stream.
-<8> Enabled module metricsets.
+<1> A generic type describing the data.
+<2> A unique ID for the input.
+<3> A user-defined namespace.
+<4> The name of the `output` to use. If not specified, `default` will be used.
+<5> Package specification.
+<6> Enabled module metricsets.
 +
-In the {metricbeat-ref}/metricbeat-module-system.html[System module] there are several options. The `cpu` is just one of them. Its fields can be configured.
+Refer to the {metricbeat} {metricbeat-ref}/metricbeat-module-system.html[System module] for a list of available options. The metricset fields can be configured.
+<7> A user-defined dataset. It can contain anything that makes sense to signify the source of the data.


### PR DESCRIPTION
This updates the standalone [inputs config docs page](https://www.elastic.co/guide/en/fleet/current/elastic-agent-input-configuration.html) to better match [elastic-agent.yml](https://github.com/elastic/elastic-agent/blob/main/elastic-agent.yml). The examples use the newly supported flattened `data_stream`field format. This also adds a sample input configuration for logs collection.

Please see the [Preview page](https://ingest-docs_483.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-input-configuration.html).

Rel: #374