### PR TITLE
Fix malformed link

### DIFF
--- a/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
@@ -147,14 +147,14 @@ Policy configuration of {k8s} package can heavily affect the amount of metrics c
 
 
 [discrete]
-=== Dashboards and Visualisations 
+=== Dashboards and Visualisations
 
 The https://github.com/elastic/integrations/blob/main/docs/dashboard_guidelines.md[Dashboard Guidelines] document provides guidance on how to implement your dashboards and is constantly updated to track the needs of Observability at scale.
 
 User experience regarding Dashboard responses, is also affected from the size of data being requested. As dashboards can contain multiple visualisations, the general consideration is to split visualisations and group them according to the frequency of access. The less number of visualisations tends to improve user experience.
 
 [discrete]
-=== Disabling indexing host.ip and host.mac fields 
+=== Disabling indexing host.ip and host.mac fields
 
 A new environemntal variable `ELASTIC_NETINFO: false` has been introduced to globally disable the indexing of `host.ip` and `host.mac` fields in your {k8s} integration. For more information see <<agent-environment-variables>>.
 
@@ -287,7 +287,7 @@ The number of events denotes the number of documents that should be depicted ins
 [discrete]
 === Define if {es} is the bottleneck of ingestion
 
-In some cases maybe the {es} can not cope with the rate of data that are trying to be ingested. In order to verify the resource utilisation, installation of [{stack}Monitoring Cluster](https://www.elastic.co/guide/en/elasticsearch/reference/current/monitoring-overview.html) is advised.
+In some cases maybe the {es} can not cope with the rate of data that are trying to be ingested. In order to verify the resource utilisation, installation of an {ref}/monitoring-overview.html[{stack} monitoring cluster] is advised.
 
 Additionally, in {ecloud} deployments you can navigate to *Manage Deployment > Deployments > Monitoring > Performance*.
 Corresponding dashboards for `CPU Usage`, `Index Response Times` and `Memory Pressure` can reveal possible problems and suggest vertical scaling of {stack} resources.


### PR DESCRIPTION
**Problem:** [Scaling Elastic Agent on Kubernetes](https://www.elastic.co/guide/en/fleet/current/scaling-on-kubernetes.html) contains a malformed link. Screenshot:

<img width="874" alt="Screenshot 2023-09-13 at 2 46 18 PM" src="https://github.com/elastic/ingest-docs/assets/40268737/45272103-aee8-4ec9-a7e5-f52b0b345e0a">

**Solution:** Fix the link syntax.