### PR TITLE
Add notes about asset installation on multiple spaces

### DIFF
--- a/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
@@ -22,6 +22,11 @@ and select an integration.
 
 . Click **Install <integration> assets** to set up the {kib} and {es} assets.
 
+There are a couple of things to note about installing integration assets:
+
+* {agent} integration assets can be installed only on a single {kib} {kibana-ref}/xpack-spaces.html[space]. If you want to access assets in a different space, you can {kibana-ref}/managing-saved-objects.html#managing-saved-objects-copy-to-space[copy them].
+* It's currently not possible to have multiple versions of the same integration running. When you upgrade an integration, the previous version assets are removed and replaced by the current version.
+
 [discrete]
 [[uninstall-integration-assets]]
 == Uninstall integration assets

--- a/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
@@ -25,7 +25,7 @@ and select an integration.
 There are a couple of things to note about installing integration assets:
 
 * {agent} integration assets can be installed only on a single {kib} {kibana-ref}/xpack-spaces.html[space]. If you want to access assets in a different space, you can {kibana-ref}/managing-saved-objects.html#managing-saved-objects-copy-to-space[copy them].
-* It's currently not possible to have multiple versions of the same integration running. When you upgrade an integration, the previous version assets are removed and replaced by the current version.
+* It's currently not possible to have multiple versions of the same integration installed. When you upgrade an integration, the previous version assets are removed and replaced by the current version.
 
 [discrete]
 [[uninstall-integration-assets]]


### PR DESCRIPTION
This adds the restrictions explained in https://github.com/elastic/ingest-docs/issues/324 to the [Install integration assets](https://www.elastic.co/guide/en/fleet/8.8/install-uninstall-integration-assets.html#install-integration-assets) instructions.

![Screenshot 2023-09-20 at 11 29 53 AM](https://github.com/elastic/ingest-docs/assets/41695641/5e6cd63b-a5b6-47d4-94b4-e9d300292bf3)

@lucabelluccini @yomduf  Please let me know if anything needs fixing.