### PR TITLE
Add Fleet & Agent 8.10.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -41,11 +41,14 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 === Enhancements
 
 {agent}::
-* * Updated Go version to 1.20.8. {agent-pull}3393[#3393]
+* Updated Go version to 1.20.8. {agent-pull}3393[#3393]
 
 [discrete]
 [[bug-fixes-8.10.2]]
 === Bug fixes
+
+{fleet}::
+* Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623]).
 
 {agent}::
 * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -52,6 +52,7 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 
 {agent}::
 * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+* Resilient handling of air gapped PGP checks. {agent-pull}3427[#3427] {agent-issue}3368[#3368]
 
 // end 8.10.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
 
@@ -21,6 +22,35 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.10.2 relnotes
+
+[[release-notes-8.10.2]]
+== {fleet} and {agent} 8.10.2
+
+Review important information about the {fleet} and {agent} 8.10.2 release.
+
+[discrete]
+[[known-issues-8.10.2]]
+=== Known issues
+
+IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful upgrades in an air-gapped environment for {agent} versions 8.9.0 to 8.10.1 has been resolved in this release. If you're using an air-gapped environment, we recommend installing version 8.10.2 or higher to avoid not being unable to upgrade.
+
+[discrete]
+[[enhancements-8.10.2]]
+=== Enhancements
+
+{agent}::
+* * Updated Go version to 1.20.8. {agent-pull}3393[#3393]
+
+[discrete]
+[[bug-fixes-8.10.2]]
+=== Bug fixes
+
+{agent}::
+* Fix GPG verification; if one is successful upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+
+// end 8.10.2 relnotes
 
 // begin 8.10.1 relnotes
 
@@ -40,7 +70,7 @@ Review important information about the {fleet} and {agent} 8.10.1 release.
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommend installing version 8.10.2 or higher to avoid not being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
@@ -162,7 +192,7 @@ If you need to access a diagnostic bundle for an agent, ensure that {fleet-serve
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommend installing version 8.10.2 or higher to avoid not being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -48,7 +48,7 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 === Bug fixes
 
 {agent}::
-* Fix GPG verification; if one is successful upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+* Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 
 // end 8.10.2 relnotes
 


### PR DESCRIPTION
DRAFT ONLY. PLEASE DO NOT MERGE.

This adds the 8.10.2 Fleet & Agent Release Notes:

 - Fleet contents are from the [Kibana RN PR](https://github.com/elastic/kibana/pull/166549)
 - Fleet Server - no new fragments in [BC1 fragments](https://github.com/elastic/fleet-server/tree/7f1fd0d97ee51456d323328e982ac8b8fc7a7801/changelog/fragments )
 - Elastic Agent contents are from the [BC2 fragments - TBD]

---

![Screenshot 2023-09-20 at 7 14 58 PM](https://github.com/elastic/ingest-docs/assets/41695641/fe8383f8-ec9f-483c-b09e-be34b783727b)
