### PR TITLE
Add Fleet & Agent 8.10.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
 
@@ -21,6 +22,103 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.10.2 relnotes
+
+[[release-notes-8.10.2]]
+== {fleet} and {agent} 8.10.2
+
+Review important information about the {fleet} and {agent} 8.10.2 release.
+
+[discrete]
+[[known-issues-8.10.2]]
+=== Known issues
+
+[[known-issue-3375-v8102]]
+.PGP key download fails in an air-gapped environment
+[%collapsible]
+====
+
+*Details*
+
+IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+
+Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
+This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
+
+In an air-gapped environment, the agent won't be able to download the remote key and therefore cannot be upgraded. 
+
+*Impact* +
+
+For the upgrade to succeed, the agent needs to download the remote key from a server accessible from the air-gapped environment. Two workarounds are available.
+
+*Option 1*
+
+If an HTTP proxy is available to be used by the {agents} in your {fleet}, add the proxy settings using environment variables as explained in <<host-proxy-env-vars,Proxy Server connectivity using default host variables>>.
+Please note that you need to enable HTTP Proxy usage for `artifacts.elastic.co` to bypass this problem, so you can craft the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables to be used exclusively for it.
+
+*Option 2*
+
+As the upgrade URL is not customizable, we have to "trick" the system by pointing `https://artifacts.elastic.co/` to another host that will have the file.
+
+The following examples require a server in your air-gapped environment that will expose the key you will have downloaded from `https://artifacts.elastic.co/GPG-KEY-elastic-agent``.
+
+_Example 1: Manual_
+
+Edit the {agent} server hosts file to add the following content:
+
+[source,sh]
+----
+<YOUR_HOST_IP> artifacts.elastic.co
+----
+
+The Linux hosts file path is `/etc/hosts`.
+
+Windows hosts file path is `C:\Windows\System32\drivers\etc\hosts`.
+
+_Example 2: Puppet_
+
+[source,yaml]
+----
+host { 'elastic-artifacts':
+  ensure       => 'present'
+  comment      => 'Workaround for PGP check'
+  ip           => '<YOUR_HOST_IP>'
+}
+----
+
+_Example 3: Ansible_
+
+[source,yaml]
+----
+- name  : 'elastic-artifacts'
+  hosts : 'all'
+  become: 'yes'  
+
+  tasks:
+    - name: 'Add entry to /etc/hosts'
+      lineinfile:
+        path: '/etc/hosts'
+        line: '<YOUR_HOST_IP> artifacts.elastic.co'
+----
+
+====
+
+[discrete]
+[[enhancements-8.10.2]]
+=== Enhancements
+
+{agent}::
+* Updated Go version to 1.20.8. {agent-pull}3393[#3393]
+
+[discrete]
+[[bug-fixes-8.10.2]]
+=== Bug fixes
+
+{fleet}::
+* Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623]).
+
+// end 8.10.2 relnotes
 
 // begin 8.10.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -116,7 +116,7 @@ _Example 3: Ansible_
 === Bug fixes
 
 {fleet}::
-* Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623])
+* Fixed force delete package API, fixed validation check to reject request if package is used by agents. ({kibana-pull}166623[#166623])
 
 // end 8.10.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -116,7 +116,7 @@ _Example 3: Ansible_
 === Bug fixes
 
 {fleet}::
-* Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623]).
+* Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623])
 
 // end 8.10.2 relnotes
 


### PR DESCRIPTION
This adds the 8.10.2 Fleet & Agent Release Notes:

 - Fleet contents are copied from the [Kibana RN PR](https://github.com/elastic/kibana/pull/166895)
 - Fleet Server - no new fragments in [BC1 fragments](https://github.com/elastic/fleet-server/tree/7f1fd0d97ee51456d323328e982ac8b8fc7a7801/changelog/fragments )
 - Elastic Agent contents are from the [BC1 fragments](https://github.com/elastic/elastic-agent/tree/b0c688f63bc05c61d23b1c26983f2f5d02011ff1/changelog/fragments)

---

![Screenshot 2023-09-20 at 7 20 57 PM](https://github.com/elastic/ingest-docs/assets/41695641/1f041c62-db43-49f1-ade9-8616a8e0227a)

