### PR TITLE
Update Elastic Agent install docs to mention ARM binaries

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -92,7 +92,8 @@ Read more in {fleet-guide}/agent-policy.html#add-fleet-server-to-policy[Add a {f
 
 . Download, install, and enroll the {agent} on your host by selecting
 your host operating system and following the **Install {agent} on your host**
-step.
+step. Note that the commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the {agent} https://www.elastic.co/downloads/elastic-agent[downloads page] for the full list of available packages.
 .. If you are enrolling the agent in a {fleet-server} that uses your
 organization's certificate you _must_ add the `--certificate-authorities`
 option to the command provided in the in-product instructions.

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -21,7 +21,7 @@ data from remote services and hardware where direct deployment is not possible.
 
 To install and run {agent} standalone:
 
-. On your host, download and extract the installation package.
+. On your host, download and extract the installation package. 
 +
 --
 // tag::install-elastic-agent[]
@@ -31,8 +31,9 @@ include::{tab-widgets}/download-widget.asciidoc[]
 // end::install-elastic-agent[]
 --
 +
-Refer to the https://www.elastic.co/downloads/elastic-agent[download page] for other
-installation options.
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the {agent} https://www.elastic.co/downloads/elastic-agent[downloads page]
+for the full list of available packages.
 
 . Modify settings in the `elastic-agent.yml` as required.
 +


### PR DESCRIPTION
This adds a note to the Elastic Agent install instructions to note that ARM packages are available in addition to what's shown on the UI.
  
---

**Fleet managed agent instructions**
![Screenshot 2023-09-21 at 9 41 32 AM](https://github.com/elastic/ingest-docs/assets/41695641/23a02137-9811-4131-9670-014de72234ca)

**Standalone agent instructions**
![screenshot](https://github.com/elastic/ingest-docs/assets/41695641/9934a82a-5760-4a07-8e30-c4a54f71b0b0)

