### PR TITLE
Add links to the newly added standalone tutorial

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-configuration.asciidoc
@@ -3,7 +3,8 @@
 
 TIP: To get started quickly, use {kib} to create and download a standalone
 policy file. You'll still need to deploy and manage the file, though. For more
-information, refer to <<create-standalone-agent-policy>>.
+information, refer to <<create-standalone-agent-policy>> or try out our example: 
+<<example-standalone-monitor-nginx,Use standalone {agent} to monitor nginx>>.
 
 Standalone {agent}s are manually configured and managed locally on the systems
 where they are installed. They are useful when you are not interested in

--- a/docs/en/ingest-management/elastic-agent/configuration/structure-config-file.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/structure-config-file.asciidoc
@@ -3,7 +3,7 @@
 
 The `elastic-agent.yml` policy file contains all of the settings that determine how {agent} runs. The most important and commonly used settings are described here, including input and output options, providers used for variables and conditional output, security settings, logging options, enabling of special features, and specifications for {agent} upgrades.
 
-An `elastic-agent.yml` file is modular: You can combine input, output, and all other settings to enable the {integrations-docs}[{integrations}] to use with {agent}. Refer to <<create-standalone-agent-policy,Create a standalone {agent} policy>> for the steps to download the settings to use as a starting point, and then refer to the following links for specifics on how to adjust the settings individually as needed.
+An `elastic-agent.yml` file is modular: You can combine input, output, and all other settings to enable the {integrations-docs}[{integrations}] to use with {agent}. Refer to <<create-standalone-agent-policy,Create a standalone {agent} policy>> for the steps to download the settings to use as a starting point, and then refer to the following links for specifics on how to adjust the settings individually as needed. You can also refer to our example: <<example-standalone-monitor-nginx,Use standalone {agent} to monitor nginx>>.
 
 // Coming soon: Add instructions for obtaining cut-and-paste settings from a new tab on each integration landing page.
 


### PR DESCRIPTION
Adds links to the tutorial about using standalone Elastic Agent to monitor nginx logs.