### PR TITLE
Add restriction for on-prem Fleet Server on Serverless

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -12,7 +12,7 @@ when deploying {fleet-server}:
 ifeval::["{serverless-feature-flag}"=="yes"]
 IMPORTANT: On-premises {fleet-server} is not currently available for use with
 link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
-environment we you must use {fleet-server} on {ecloud}.
+environment you must use {fleet-server} on {ecloud}.
 endif::[]
 
 Read more about each to choose the best approach for your situation.

--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -12,7 +12,7 @@ when deploying {fleet-server}:
 ifeval::["{serverless-feature-flag}"=="yes"]
 IMPORTANT: On-premises {fleet-server} is not currently available for use with
 link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
-environment we recommend using {fleet-server} on {ecloud}.
+environment we you must use {fleet-server} on {ecloud}.
 endif::[]
 
 Read more about each to choose the best approach for your situation.

--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -9,6 +9,12 @@ when deploying {fleet-server}:
 * <<deployed-on-prem>> to work with {es} running on-premises. You self-manage both {fleet-server} and {es}.
 * <<fleet-server-on-prem-es-cloud>>. You manage {fleet-server} and Elastic manages {es}.
 
+ifeval::["{serverless-feature-flag}"=="yes"]
+IMPORTANT: On-premises {fleet-server} is not currently available for use with
+link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
+environment we recommend using {fleet-server} hosted on {ess}.
+endif::[]
+
 Read more about each to choose the best approach for your situation.
 
 [discrete]

--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -12,7 +12,7 @@ when deploying {fleet-server}:
 ifeval::["{serverless-feature-flag}"=="yes"]
 IMPORTANT: On-premises {fleet-server} is not currently available for use with
 link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
-environment we recommend using {fleet-server} hosted on {ess}.
+environment we recommend using {fleet-server} on {ecloud}.
 endif::[]
 
 Read more about each to choose the best approach for your situation.


### PR DESCRIPTION
This adds a note to [Add a Fleet Server](https://www.elastic.co/guide/en/fleet/current/add-a-fleet-server.html) that on-prem Fleet Server is not supported with Serverless projects. The note is hidden behind a feature flag so it will be hidden until Serverless goes live.

Rel: https://github.com/elastic/ingest-docs/pull/516

---

![Screenshot 2023-10-04 at 4 29 58 PM](https://github.com/elastic/ingest-docs/assets/41695641/018fa528-7e13-421b-99b1-6cb986a81815)




