### PR TITLE
Add Serverless restrictions to Fleet & Agent docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -49,6 +49,15 @@ Refer to:
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 --
 
+[IMPORTANT] 
+.Restrictions in {serverless-short}
+==== 
+If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
+
+* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
+* The minimum supported version of {agent} supported for use with {serverless-full} is version **VERSION TBD**.
+====
+
 [discrete]
 == Minimum Requirements
 

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -55,7 +55,7 @@ Refer to:
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
 
 * The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
-* The minimum supported version of {agent} supported for use with {serverless-full} is version **VERSION TBD**.
+* The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 ====
 
 [discrete]

--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -10,7 +10,7 @@ when deploying {fleet-server}:
 * <<fleet-server-on-prem-es-cloud>>. You manage {fleet-server} and Elastic manages {es}.
 
 ifeval::["{serverless-feature-flag}"=="yes"]
-IMPORTANT: On-premises {fleet-server} is not currently available for use in a {serverless-short} environment.
+IMPORTANT: On-premises {fleet-server} is not currently available for use in an link:{serverless-docs}[{serverless-full}] environment.
 We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.
 endif::[]
 

--- a/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server.asciidoc
@@ -9,6 +9,11 @@ when deploying {fleet-server}:
 * <<deployed-on-prem>> to work with {es} running on-premises. You self-manage both {fleet-server} and {es}.
 * <<fleet-server-on-prem-es-cloud>>. You manage {fleet-server} and Elastic manages {es}.
 
+ifeval::["{serverless-feature-flag}"=="yes"]
+IMPORTANT: On-premises {fleet-server} is not currently available for use in a {serverless-short} environment.
+We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.
+endif::[]
+
 Read more about each to choose the best approach for your situation.
 
 [discrete]

--- a/docs/en/ingest-management/fleet/fleet-server.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server.asciidoc
@@ -10,6 +10,11 @@ yourself.
 deployment.** {ecloud} runs a hosted version of {integrations-server} that
 includes {fleet-server}.
 
+ifeval::["{serverless-feature-flag}"=="yes"]
+* On-premises {fleet-server} is not currently available for use in an link:{serverless-docs}[{serverless-full}] environment.
+We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.
+endif::[]
+
 [discrete]
 == What is {fleet-server}?
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -29,6 +29,10 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[leveloffset=+1]
 
+ifeval::["{serverless-feature-flag}"=="yes"]
+include::serverless-restrictions.asciidoc[leveloffset=+2]
+endif::[]
+
 include::beats-agent-comparison.asciidoc[leveloffset=+1]
 
 include::quick-starts.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -21,13 +21,7 @@ image::images/agent-architecture.png[Image showing {agent} collecting data from 
 To learn about installation options, refer to <<elastic-agent-installation>>.
 
 ifeval::["{serverless-feature-flag}"=="yes"]
-.{agent} with {serverless-full}
-****
-If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
-
-* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
-* The minimum supported version of {agent} supported for use with {serverless-full} is **VERSION TBD**.
-****
+IMPORTANT: Using {fleet} and {agent} with link:{serverless-docs}[{serverless-full}]? Please note these <<fleet-agent-serverless-restrictions,restrictions>>.
 endif::[]
 
 [discrete]

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -20,6 +20,16 @@ image::images/agent-architecture.png[Image showing {agent} collecting data from 
 
 To learn about installation options, refer to <<elastic-agent-installation>>.
 
+ifeval::["{serverless-feature-flag}"=="yes"]
+.{agent} with {serverless-full}
+****
+If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
+
+* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
+* The minimum supported version of {agent} supported for use with {serverless-full} is **VERSION TBD**.
+****
+endif::[]
+
 [discrete]
 [[unified-integrations]]
 == {integrations}
@@ -138,6 +148,15 @@ a scalable infrastructure and is supported in {ecloud} and self-managed clusters
 It can be started from any available x64 architecture {agent} artifact.
 
 For more information, refer to <<fleet-server>>.
+
+ifeval::["{serverless-feature-flag}"=="yes"]
+.{fleet-server} with {serverless-full}
+****
+On-premises {fleet-server} is not currently available for use with
+link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
+environment we recommend using {fleet-server} on {ecloud}.
+****
+endif::[]
 
 [discrete]
 [[fleet-communication-layer]]

--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -1,0 +1,22 @@
+[[fleet-agent-serverless-restrictions]]
+= {fleet} and {agent} restrictions for {serverless-full}
+
+++++
+<titleabbrev>Restrictions for {serverless-full}</titleabbrev>
+++++
+
+[discrete]
+[[elastic-agent-serverless-restrictions]]
+== {agent}
+
+If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
+
+* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
+* The minimum supported version of {agent} supported for use with {serverless-full} is version **VERSION TBD**.
+
+[discrete]
+[[fleet-server-serverless-restrictions]]
+== {fleet-server}
+
+On-premises {fleet-server} is not currently available for use in a {serverless-short} environment.
+We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.

--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -12,7 +12,7 @@
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
 
 * The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
-* The minimum supported version of {agent} supported for use with {serverless-full} is version **VERSION TBD**.
+* The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 
 [discrete]
 [[fleet-server-serverless-restrictions]]


### PR DESCRIPTION
This updates the Fleet and Elastic Agent docs with restrictions for Serverless:
 - Fleet restrictions added to [Add a Fleet Server](https://ingest-docs_516.docs-preview.app.elstc.co/guide/en/fleet/master/add-a-fleet-server.html) and [Set up Fleet Server](https://ingest-docs_516.docs-preview.app.elstc.co/guide/en/fleet/master/fleet-server.html)
  ![screenshot](https://github.com/elastic/ingest-docs/assets/41695641/af402952-0f6b-4d64-a0ff-b741661457a8)
 - Agent restrictions added to [Install Elastic Agents](https://ingest-docs_516.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-installation.html)
  ![Screenshot 2023-10-11 at 10 51 27 AM](https://github.com/elastic/ingest-docs/assets/41695641/730f8f0a-0d12-4c2d-9f7a-546f432b512b)
 - Both of the above included on a new "Restrictions for Elastic Serverless" page
  ![Screenshot 2023-10-11 at 11 13 10 AM](https://github.com/elastic/ingest-docs/assets/41695641/fde42267-8ff1-4165-b578-08ff527f32b6)

Notes:
 - These changes are behind a feature flag.
 - Separately and later, we'll rework the Fleet Server pages to be less prominent: [issue](https://github.com/elastic/ingest-docs/issues/585).

Closes: #582 
