### PR TITLE
Remove beta tags from Fleet API Preview request

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -111,7 +111,7 @@ image::images/create-agent-policy.png[{fleet} in {kib}]
 +
 . Create the agent policy:
 * To use the UI, click **Create agent policy**.
-* beta[] To use the {fleet} API, click **Preview API request** and run the
+* To use the {fleet} API, click **Preview API request** and run the
 request.
 
 Also see <<create-a-policy-no-ui>>.
@@ -141,7 +141,7 @@ policies.
 +
 --
 * To use the UI, click **Save and continue**.
-* beta[] To use the {fleet} API, click **Preview API request** and run the
+* To use the {fleet} API, click **Preview API request** and run the
 request.
 --
 

--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -76,7 +76,7 @@ curl --request POST \
 ----
 
 ****
-beta[] To save time, you can use {kib} to generate the API request, then run it
+To save time, you can use {kib} to generate the API request, then run it
 from the Dev Tools console. 
 
 . Go to **{fleet} -> Agent policies**.
@@ -162,7 +162,7 @@ curl --request POST \
 ----
 
 ****
-* beta[] To save time, you can use {kib} to generate the API call, then run it
+* To save time, you can use {kib} to generate the API call, then run it
 from the Dev Tools console. 
 +
 . Go to **Integrations**, select an {agent} integration, and click

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -32,7 +32,7 @@ existing agent policy or create a new one.
 +
 --
 * To use the UI, click **Save integration**.
-* beta[] To use the {fleet} API, click **Preview API request** and run the
+* To use the {fleet} API, click **Preview API request** and run the
 request.
 --
 


### PR DESCRIPTION
Removes outdated beta tags for the Preview API Request feature, for example from [here](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html), [here](https://www.elastic.co/guide/en/fleet/8.10/add-integration-to-policy.html), and [here](https://www.elastic.co/guide/en/fleet/current/fleet-api-docs.html#create-agent-policy-api).