### PR TITLE
Add account and permissions requirements for Elastic Agent

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
@@ -1,0 +1,60 @@
+[[install-agent-account-requirements]]
+= {agent} account and permissions requirements
+
+There are a number of account and permissions requirements that should be met before running {agent} on your system.
+
+* <<elastic-agent-account-requirements-linux>>
+* <<elastic-agent-account-requirements-windows>>
+
+[discrete]
+[[elastic-agent-account-requirements-linux]]
+== Linux and Unix requirements
+
+Currently, on Linux and Unix systems {agent} needs to run as a super user with `root` privileges. 
+
+As well, {agent} components (Beats) each use a unique account with specific controlled `root` privileges, as shown in the following table.
+
+.Linux and Unix requirements for agent components
+|===
+|Component |Function |Requirements
+
+|{auditbeat}
+|Monitors the activities of users and processes on your systems.
+a|* SUDO privilege to run the `auditd` command.
+* Permissions to read and audit directories, such as `/user/bin`, `user/sbin`, `/bin`, `/etc`.
+* Permissions to read logs in `/var/log`.
+* Permissions to read and write logs cached in `/var/log/Elastic/.
+
+|{heartbeat}
+|Monitors the status of your services.
+a|* SUDO privilege to run the `auditd` command.
+* SUDO privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
+* Permissions to read and audit directories, such as `/user/bin`, `user/sbin`, `/bin`, `/etc`.
+* Permissions to read logs in `/var/log`.
+* Permissions to read and write logs in cache to `/var/log/Elastic/.
+
+|{filebeat}
+|Forwards and centralizes your log data.
+a|* Permissions to read logs in `/var/log`.
+* Permissions to read and write logs in cache to `/var/log/Elastic/.
+
+|{metricbeat}
+|Collect metrics from operating systems and services running on your servers.
+a|* SUDO privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
+* Permissions to read logs in `/var/log`.
+* Permissions to read and write logs in cache to `/var/log/Elastic/.
+
+|{packetbeat}
+|Monitors network traffic on your servers.
+a|* SUDO privilege to run commands to capture network statistics.
+* Permissions to read logs in `/var/log`.
+* Permissions to read and write logs in cache to `/var/log/Elastic/.
+
+|===
+
+[discrete]
+[[elastic-agent-account-requirements-windows]]
+== Windows requirements
+
+Currently, on Windows systems {agent} needs to run as the `SYSTEM` user.
+

--- a/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
@@ -10,9 +10,25 @@ There are a number of account and permissions requirements that should be met be
 [[elastic-agent-account-requirements-linux]]
 == Linux and Unix requirements
 
-Currently, on Linux and Unix systems {agent} needs to run as a super user with `root` privileges. 
+Currently, on Linux and Unix systems {agent} needs to run as a super user with `sudo` privileges. To create a new user with `sudo` privileges:
 
-As well, {agent} components (Beats) each use a unique account with specific controlled `root` privileges, as shown in the following table.
+. Create a user for your {agent}.
++
+[source,sh]
+----
+useradd elastic
+----
+
+. Add the new user to `sudo` group.
++
+[source,sh]
+----
+usermod -aG sudo elastic
+----
+
+. Proceed with the instructions to <<install-fleet-managed-elastic-agent>> or <<install-standalone-elastic-agent>>.
+
+As well, {agent} components (Beats) each use a unique account with specific controlled `sudo` privileges, as shown in the following table.
 
 .Linux and Unix requirements for agent components
 |===
@@ -20,15 +36,15 @@ As well, {agent} components (Beats) each use a unique account with specific cont
 
 |{auditbeat}
 |Monitors the activities of users and processes on your systems.
-a|* SUDO privilege to run the `auditd` command.
+a|* `sudo`` privilege to run the `auditd` command.
 * Permissions to read and audit directories, such as `/user/bin`, `user/sbin`, `/bin`, `/etc`.
 * Permissions to read logs in `/var/log`.
 * Permissions to read and write logs cached in `/var/log/Elastic/.
 
 |{heartbeat}
 |Monitors the status of your services.
-a|* SUDO privilege to run the `auditd` command.
-* SUDO privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
+a|* `sudo` privilege to run the `auditd` command.
+* `sudo` privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
 * Permissions to read and audit directories, such as `/user/bin`, `user/sbin`, `/bin`, `/etc`.
 * Permissions to read logs in `/var/log`.
 * Permissions to read and write logs in cache to `/var/log/Elastic/.
@@ -40,13 +56,13 @@ a|* Permissions to read logs in `/var/log`.
 
 |{metricbeat}
 |Collect metrics from operating systems and services running on your servers.
-a|* SUDO privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
+a|* `sudo` privilege to run commands to check disk IO, network IO, memory, process, and CPU level statistics.
 * Permissions to read logs in `/var/log`.
 * Permissions to read and write logs in cache to `/var/log/Elastic/.
 
 |{packetbeat}
 |Monitors network traffic on your servers.
-a|* SUDO privilege to run commands to capture network statistics.
+a|* `sudo` privilege to run commands to capture network statistics.
 * Permissions to read logs in `/var/log`.
 * Permissions to read and write logs in cache to `/var/log/Elastic/.
 

--- a/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
@@ -19,7 +19,7 @@ Currently, on Linux and Unix systems {agent} needs to run as a super user with `
 useradd elastic
 ----
 
-. Add the new user to `sudo` group.
+. Add the new user to the `sudo` group.
 +
 [source,sh]
 ----

--- a/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-account-requirements.asciidoc
@@ -36,7 +36,7 @@ As well, {agent} components (Beats) each use a unique account with specific cont
 
 |{auditbeat}
 |Monitors the activities of users and processes on your systems.
-a|* `sudo`` privilege to run the `auditd` command.
+a|* `sudo` privilege to run the `auditd` command.
 * Permissions to read and audit directories, such as `/user/bin`, `user/sbin`, `/bin`, `/etc`.
 * Permissions to read logs in `/var/log`.
 * Permissions to read and write logs cached in `/var/log/Elastic/.

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -32,6 +32,9 @@ Just want to learn how to install {agent}? Continue reading this page.
 
 You will always need:
 
+* *Account permissions requirements.* * Check the <<install-agent-account-requirements,requirements>>
+to ensure that all {agent} components can run on your system.
+
 * *A {kib} user with `All` privileges on {fleet} and {integrations}.* Since many
 Integrations assets are shared across spaces, users need the {kib} privileges in
 all spaces.

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -2,7 +2,7 @@
 = Install standalone {agent}s (advanced users)
 
 To run an {agent} in standalone mode, install the agent and manually configure
-the agent locally on the system where it’s installed. You are responsible for
+the agent locally on the system where it's installed. You are responsible for
 managing and upgrading the agents. This approach is recommended for advanced
 users only.
 
@@ -18,6 +18,17 @@ NOTE: You can install only a single {agent} per host.
 
 {agent} can monitor the host where it's deployed, and it can collect and forward
 data from remote services and hardware where direct deployment is not possible.
+
+[discrete]
+[[elastic-agent-standalone-prereqs]]
+== Prerequisites
+
+* Check the <<install-agent-account-requirements,account and permissions requirements>>
+to ensure that all {agent} components can run on your system.
+
+[discrete]
+[[elastic-agent-standalone-installation-steps]]
+== Installation steps
 
 To install and run {agent} standalone:
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -79,6 +79,8 @@ include::elastic-agent/scaling-on-kubernetes.asciidoc[leveloffset=+3]
 
 include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]
 
+include::elastic-agent/install-agent-account-requirements.asciidoc[leveloffset=+2]
+
 include::elastic-agent/installation-layout.asciidoc[leveloffset=+2]
 
 include::fleet/air-gapped.asciidoc[leveloffset=+2]


### PR DESCRIPTION
This adds details about the account and permissions requirements to install and run Elastic Agent.

This draft is based entirely off of an email thread with the SAs so it definitely needs technical input. Any suggestions for additions and changes are very welcome!

[PREVIEW PAGE](https://ingest-docs_522.docs-preview.app.elstc.co/guide/en/fleet/master/install-agent-account-requirements.html)

Closes: #521 
