### PR TITLE
Re-add docs for install '--base-path' parameter

### DIFF
--- a/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
@@ -1,7 +1,6 @@
 [[installation-layout]]
 = Installation layout
 
-{agent} files are installed in the following locations. You cannot override
-these installation paths because they are required for upgrades.
+{agent} files are installed in the following locations.
 
 include::{tab-widgets}/install-layout-widget.asciidoc[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -14,6 +14,8 @@ Log files for {beats} shippersfootnote:lognumbering[]
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
+You can install {agent} in a custom base path other than `/Library`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::mac[]
 
 // tag::linux[]
@@ -31,6 +33,8 @@ Log files for {beats} shippers
 `/usr/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
+You can install {agent} in a custom base path other than `/opt`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::linux[]
 
 // tag::win[]
@@ -46,6 +50,8 @@ Log files for {agent}footnote:lognumbering[]
 `C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\default\*-json.log*`::
 Log files for {beats} shippers
 
+You can install {agent} in a custom base path other than `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
+command, use the `--base-path` CLI option to specify the custom base path.
 // end::win[]
 
 // tag::deb[]

--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -50,7 +50,7 @@ Log files for {agent}footnote:lognumbering[]
 `C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\default\*-json.log*`::
 Log files for {beats} shippers
 
-You can install {agent} in a custom base path other than `C:\Program Files`.  When installing {agent} with the `./elastic-agent install`
+You can install {agent} in a custom base path other than `C:\Program Files`.  When installing {agent} with the `.\elastic-agent.exe install`
 command, use the `--base-path` CLI option to specify the custom base path.
 // end::win[]
 


### PR DESCRIPTION
This is essentially a re-do of https://github.com/elastic/ingest-docs/pull/160 which was reverted.

In https://github.com/elastic/ingest-dev/issues/1609 the install command's `--base-path` option was temporarily hidden. It's re-enabled now and should also be re-added to the documentation. See [comment](https://github.com/elastic/ingest-dev/issues/1609#issuecomment-1533505729) and [comment](https://github.com/elastic/ingest-dev/issues/1609#issuecomment-1746078531).

@ycombinator I've tagged this to go into 8.10 and later docs. Do you know if it should go into 8.9 as well?

PREVIEWS

---

Linux

![linux](https://github.com/elastic/ingest-docs/assets/41695641/6a737e3d-1855-4a90-9c0e-80a6a3d30670)

Mac

![mac](https://github.com/elastic/ingest-docs/assets/41695641/aec89d04-4973-45ac-acea-c86a3f897189)

Windows

![windows](https://github.com/elastic/ingest-docs/assets/41695641/fcea0f13-665c-40a3-9ee1-560ffc30c164)



