### PR TITLE
Add 'fleet-server-port' parameter to agent install examples

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -349,7 +349,8 @@ elastic-agent enroll \
   --certificate-authorities=/path/to/ca.crt \
   --fleet-server-es-ca=/path/to/elasticsearch-ca.crt \
   --fleet-server-cert=/path/to/fleet-server.crt \
-  --fleet-server-cert-key=/path/to/fleet-server.key
+  --fleet-server-cert-key=/path/to/fleet-server.key \
+  --fleet-server-port=8220
 ----
 
 Then enroll another {agent} into the {fleet-server} started in the previous
@@ -586,7 +587,8 @@ elastic-agent install \
   --certificate-authorities=/path/to/ca.crt \
   --fleet-server-es-ca=/path/to/elasticsearch-ca.crt \
   --fleet-server-cert=/path/to/fleet-server.crt \
-  --fleet-server-cert-key=/path/to/fleet-server.key
+  --fleet-server-cert-key=/path/to/fleet-server.key \
+  --fleet-server-port=8220
 ----
 
 Then install another {agent} and enroll it into the {fleet-server} started in

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -219,7 +219,8 @@ sudo ./elastic-agent install \
    --fleet-server-es-ca=/path/to/elasticsearch-ca.crt \
    --certificate-authorities=/path/to/ca.crt \
    --fleet-server-cert=/path/to/fleet-server.crt \
-   --fleet-server-cert-key=/path/to/fleet-server.key
+   --fleet-server-cert-key=/path/to/fleet-server.key \
+   --fleet-server-port=8220
 ----
 
 Where:


### PR DESCRIPTION
This updates the two examples on the Elastic Agent [commands](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-install-command) page and a similar example on the [configure SSL/TLS](https://www.elastic.co/guide/en/fleet/current/secure-connections.html#_encrypt_traffic_between_elastic_agents_fleet_server_and_elasticsearch) page to include the parameter to specify the Fleet Server port.

![Screenshot 2023-10-04 at 12 36 42 PM](https://github.com/elastic/ingest-docs/assets/41695641/660790ed-fedc-4a15-8e99-4adeae505613)

Closes: https://github.com/elastic/ingest-docs/issues/233
