### PR TITLE
Document that Logstash output is not available with Fleet Server and APM

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -94,6 +94,8 @@ See <<ls-output-settings-yaml-config>> for descriptions of the available setting
 | When this setting is on, {agent}s use this output to send data if no other
 output is set in the <<agent-policy,agent policy>>.
 
+Output to {ls} is not supported for agent integrations in a policy used by {fleet-server} or APM.
+
 // =============================================================================
 
 |
@@ -101,6 +103,8 @@ output is set in the <<agent-policy,agent policy>>.
 **Make this output the default for agent monitoring**
 
 | When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
+
+Output to {ls} is not supported for agent monitoring in a policy used by {fleet-server} or APM.
 
 |===
 


### PR DESCRIPTION
According to https://github.com/elastic/kibana/pull/153226 outputting agent data to Logstash is not supported for Fleet Server nor for APM. This adds that to the docs, as reported by the QA issue https://github.com/elastic/ingest-docs/issues/231

@criamico Can you please check that the text I've added here is accurate? 

![Screenshot 2023-10-04 at 2 07 27 PM](https://github.com/elastic/ingest-docs/assets/41695641/4f8ff12f-78c6-40ab-9c27-ac862fe5d70e)

Closes: https://github.com/elastic/ingest-docs/issues/231