### PR TITLE
Add Fleet & Agent 8.10.3 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -48,6 +48,11 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 [[bug-fixes-8.10.3]]
 === Bug fixes
 
+{fleet}::
+* Fixes incorrect index template used from the data stream name ({kibana-pull}166941[#166941]).
+* Increase package install max timeout limit and add concurrency control to rollovers ({kibana-pull}166775[#166775]).
+* Fixes bulk action dropdown ({kibana-pull}166475[#166475]).
+
 {agent}::
 * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 * Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-issue}3368[#3368]

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -54,8 +54,7 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 * Fix bulk action dropdown ({kibana-pull}166475[#166475])
 
 {agent}::
-* Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
-* Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-issue}3368[#3368]
+* Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 
 // end 8.10.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -49,9 +49,9 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 === Bug fixes
 
 {fleet}::
-* Fixes incorrect index template used from the data stream name ({kibana-pull}166941[#166941]).
-* Increase package install max timeout limit and add concurrency control to rollovers ({kibana-pull}166775[#166775]).
-* Fixes bulk action dropdown ({kibana-pull}166475[#166475]).
+* Fix incorrect index template used from the data stream name ({kibana-pull}166941[#166941])
+* Increase package install max timeout limit and add concurrency control to rollovers ({kibana-pull}166775[#166775])
+* Fix bulk action dropdown ({kibana-pull}166475[#166475])
 
 {agent}::
 * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -42,7 +42,7 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 === Enhancements
 
 {agent}::
-* Improve {agent} uninstall by adding some pause between retries when removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
 
 [discrete]
 [[bug-fixes-8.10.3]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -42,18 +42,15 @@ IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful u
 === Enhancements
 
 {agent}::
-//EXAMPLE * Updated Go version to 1.20.8. {agent-pull}3393[#3393]
+* Improve {agent} uninstall by adding some pause between retries when removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
 
 [discrete]
 [[bug-fixes-8.10.3]]
 === Bug fixes
 
-{fleet}::
-//EXAMPLE * Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623]).
-
 {agent}::
-//EXAMPLE * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
-//EXAMPLE * Resilient handling of air gapped PGP checks. {agent-pull}3427[#3427] {agent-issue}3368[#3368]
+* Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+* Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-issue}3368[#3368]
 
 // end 8.10.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.10.3>>
 * <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
@@ -22,6 +23,39 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.10.3 relnotes
+
+[[release-notes-8.10.3]]
+== {fleet} and {agent} 8.10.3
+
+Review important information about the {fleet} and {agent} 8.10.3 release.
+
+[discrete]
+[[known-issues-8.10.3]]
+=== Known issues
+
+IMPORTANT: The <<known-issue-3375-v8100,known issue>> that prevents successful upgrades in an air-gapped environment for {agent} versions 8.9.0 to 8.10.2 has been resolved in this release. If you're using an air-gapped environment, we recommend installing version 8.10.3 or any higher version to avoid not being unable to upgrade.
+
+[discrete]
+[[enhancements-8.10.3]]
+=== Enhancements
+
+{agent}::
+//EXAMPLE * Updated Go version to 1.20.8. {agent-pull}3393[#3393]
+
+[discrete]
+[[bug-fixes-8.10.3]]
+=== Bug fixes
+
+{fleet}::
+//EXAMPLE * Fix force delete package, updated used by agents check. ({kibana-pull}166623[#166623]).
+
+{agent}::
+//EXAMPLE * Fix GPG verification; if one GPG check is successful the upgrade should continue. {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+//EXAMPLE * Resilient handling of air gapped PGP checks. {agent-pull}3427[#3427] {agent-issue}3368[#3368]
+
+// end 8.10.3 relnotes
 
 // begin 8.10.2 relnotes
 
@@ -41,7 +75,7 @@ Review important information about the {fleet} and {agent} 8.10.2 release.
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommended installing version 8.10.3 or any higher version, to avoid being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
@@ -138,7 +172,7 @@ Review important information about the {fleet} and {agent} 8.10.1 release.
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommended installing version 8.10.3 or any higher version, to avoid being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
@@ -260,7 +294,7 @@ If you need to access a diagnostic bundle for an agent, ensure that {fleet-serve
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommended installing version 8.10.3 or any higher version, to avoid being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.

--- a/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.9.asciidoc
@@ -41,7 +41,7 @@ Review important information about the {fleet} and {agent} 8.9.2 release.
 
 *Details*
 
-IMPORTANT: If you're using an air-gapped environment, we recommended waiting for this issue to be resolved before installing 8.9.x or any higher version, to avoid being unable to upgrade.
+IMPORTANT: If you're using an air-gapped environment, we recommended installing version 8.10.3 or any higher version, to avoid being unable to upgrade.
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent.
 This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.


### PR DESCRIPTION
This adds the 8.10.3 Fleet & Agent Release Notes:

 - Fleet contents are copied from the [Kibana RN PR TBD](TBD)
 - Fleet Server - no new fragments in [BC1 fragments](https://github.com/elastic/fleet-server/tree/badea41a034a0080a24aaaa0c34a94c18ca6fcda/changelog/fragments)
 - Elastic Agent contents are from the [BC1 fragments](https://github.com/elastic/elastic-agent/tree/7ae7e8f672dfd45516cbd46f7b9c11848f622cb3/changelog/fragments)

Closes: #551

---

![Screenshot 2023-10-06 at 2 55 52 PM](https://github.com/elastic/ingest-docs/assets/41695641/8183a0d8-3abc-48d5-9e77-ceaf73172263)

