### PR TITLE
[Hints Support] Update documentation for hints/host

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -21,13 +21,15 @@ This is the full list of supported hints:
 
 The package to use for monitoring.
 
+[discrete]
+== Optional hints available:
+
 [float]
 === `co.elastic.hints/host`
 
-The host to use for metrics retrieval.
+The host to use for metrics retrieval. If not defined, the host will be set as the default one: `<pod-ip>:<container-port>`.
 
-[discrete]
-== Optional hints available:
+
 
 [float]
 === `co.elastic.hints/data_stream`


### PR DESCRIPTION
## What?

Update the documentation to set the host as an optional hint. This follows the work in https://github.com/elastic/elastic-agent/pull/3575.

## Issues

Relates to https://github.com/elastic/elastic-agent/pull/3575.