### PR TITLE
Add Fleet & Agent 8.10.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -44,7 +44,7 @@ Review important information about the {fleet} and {agent} 8.10.4 release.
 === Bug fixes
 
 {fleet}::
-//EXAMPLE * Fix incorrect index template used from the data stream name ({kibana-pull}166941[#166941])
+* Fix validation errors in KQL queries ({kibana-pull}168329[#168329])
 
 {fleet-server}::
 //EXAMPLE * Fleet Server support to handle agent policy secrets. {fleet-server-pull}2863[#2863] {fleet-server-issue}2485[#2485]

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -39,6 +39,13 @@ Review important information about the {fleet} and {agent} 8.10.4 release.
 {agent}::
 * Enable {agent} to upgrade securely in an air-gapped environment where {fleet-server} is the only reachable URI. {agent-pull}3453[#3453] {agent-issue}3264[#3264]
 
+[discrete]
+[[bug-fixes-8.10.4]]
+=== Bug fixes
+
+{fleet}::
+* Fix validation errors in KQL queries. ({kibana-pull}168329[#168329])
+
 // end 8.10.4 relnotes
 
 // begin 8.10.3 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.10.4>>
 * <<release-notes-8.10.3>>
 * <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
@@ -23,6 +24,35 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.10.4 relnotes
+
+[[release-notes-8.10.4]]
+== {fleet} and {agent} 8.10.4
+
+Review important information about the {fleet} and {agent} 8.10.4 release.
+
+[discrete]
+[[enhancements-8.10.4]]
+=== Enhancements
+
+{agent}::
+//EXAMPLE * Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+
+[discrete]
+[[bug-fixes-8.10.4]]
+=== Bug fixes
+
+{fleet}::
+//EXAMPLE * Fix incorrect index template used from the data stream name ({kibana-pull}166941[#166941])
+
+{fleet-server}::
+//EXAMPLE * Fleet Server support to handle agent policy secrets. {fleet-server-pull}2863[#2863] {fleet-server-issue}2485[#2485]
+
+{agent}::
+//EXAMPLE * Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+
+// end 8.10.4 relnotes
 
 // begin 8.10.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -37,20 +37,7 @@ Review important information about the {fleet} and {agent} 8.10.4 release.
 === Enhancements
 
 {agent}::
-//EXAMPLE * Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
-
-[discrete]
-[[bug-fixes-8.10.4]]
-=== Bug fixes
-
-{fleet}::
-* Fix validation errors in KQL queries ({kibana-pull}168329[#168329])
-
-{fleet-server}::
-//EXAMPLE * Fleet Server support to handle agent policy secrets. {fleet-server-pull}2863[#2863] {fleet-server-issue}2485[#2485]
-
-{agent}::
-//EXAMPLE * Resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+* Enable {agent} to upgrade securely in an air-gapped environment where {fleet-server} is the only reachable URI. {agent-pull}3453[#3453] {agent-issue}3264[#3264]
 
 // end 8.10.4 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.10.asciidoc
@@ -33,11 +33,35 @@ Also see:
 Review important information about the {fleet} and {agent} 8.10.4 release.
 
 [discrete]
+[[breaking-changes-8.10.4]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+elastic-agent::
+
+[discrete]
+[[breaking-3591]]
+.`elastic-agent-autodiscover` library has been updated to version 0.6.4, disabling metadata For `kubernetes.deployment` and `kubernetes.cronjob` fields.
+[%collapsible]
+====
+*Details* +
+The `elastic-agent-autodiscover` Kubernetes library by default comes with `add_resource_metadata.deployment=false` and `add_resource_metadata.cronjob=false`.
+
+*Impact* +
+Pods that will be created from deployments or cronjobs will not have the extra metadata field for `kubernetes.deployment` or `kubernetes.cronjob`, respectively. This change was made to avoid the memory impact of keeping the feature enabled in big Kubernetes clusters.
+
+For more information, refer to {agent-pull}3591[#3591].
+====
+
+[discrete]
 [[enhancements-8.10.4]]
 === Enhancements
 
 {agent}::
-* Enable {agent} to upgrade securely in an air-gapped environment where {fleet-server} is the only reachable URI. {agent-pull}3453[#3453] {agent-issue}3264[#3264]
+* Enable {agent} to upgrade securely in an air-gapped environment where {fleet-server} is the only reachable URI. {agent-pull}3591[#3591] {agent-issue}3863[#3863]
 
 [discrete]
 [[bug-fixes-8.10.4]]


### PR DESCRIPTION
This adds the 8.10.4 Fleet & Agent Release Notes:

 - Fleet contents are copied from the [Kibana RN PR](https://github.com/elastic/kibana/pull/168599)
 - No Fleet Server contents according to [BC1 fragments](https://github.com/elastic/fleet-server/tree/adc11090b3559e32302606d8b8cb23802d64f309/changelog/fragments)
 - Elastic Agent contents are from the [BC1 fragments](https://github.com/elastic/elastic-agent/tree/a92ca32b922dc62e45b532600a8562ee1c82205f/changelog/fragments) and [8.10.4 changelog PR](https://github.com/elastic/elastic-agent/pull/3606).

Closes: #595 

---

![Screenshot 2023-10-16 at 9 51 47 AM](https://github.com/elastic/ingest-docs/assets/41695641/fab79934-76ce-4335-b742-e8a7d3c73b6c)

