### PR TITLE
Add Fleet & Agent 8.11.0 Release Notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -209,7 +209,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.10.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.11.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -21,16 +21,18 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
-// begin 8.10.0 relnotes
+// begin 8.11.0 relnotes
 
 [[release-notes-8.11.0]]
 == {fleet} and {agent} 8.11.0
 
-Review important information about the {fleet} and {agent} 8.11.0 release.
+Review important information about {fleet-server} and {agent} for the 8.11.0 release.
+
+For {fleet} updates, refer to the {kibana-ref}/release-notes.html[{kib} Release Notes].
 
 [discrete]
 [[breaking-changes-8.11.0]]
-=== Breaking changess
+=== Breaking changes
 
 Breaking changes can prevent your application from optimal operation and
 performance. Before you upgrade, review the breaking changes, then mitigate the
@@ -55,6 +57,7 @@ On typical workloads this is expected to decrease network data volume by 70-80%,
 ====
 *Details* +
 The `elastic-agent-autodiscover` Kubernetes library by default comes with `add_resource_metadata.deployment=false` and `add_resource_metadata.cronjob=false`.
+
 *Impact* +
 Pods that will be created from deployments or cronjobs will not have the extra metadata field for `kubernetes.deployment` or `kubernetes.cronjob`, respectively. This change was made to avoid the memory impact of keeping the feature enabled in big Kubernetes clusters.
 For more information, refer to {agent-pull}3593[#3593].
@@ -65,9 +68,6 @@ For more information, refer to {agent-pull}3593[#3593].
 === New features
 
 The 8.11.0 release Added the following new and notable features.
-
-{fleet}::
-//EXAMPLE * Enable agent policy secret storage when all fleet servers are above 8.11.0 {kibana-pull}163627[#163627].
 
 {fleet-server}::
 * Add new `upgrade_details` attribute to checkin requests and the agent index. {fleet-server-pull}2901[#2901]
@@ -82,14 +82,11 @@ The 8.11.0 release Added the following new and notable features.
 [[enhancements-8.11.0]]
 === Enhancements
 
-{fleet}::
-//EXAMPLE * Add support for runtime fields. {kibana-pull}161129[#161129].
-
 {fleet-server}::
 * Expand APM traces to track coordinator and monitor transactions. Add additonal spans across all API endpoints to better track what the server does. Add spans to bulker interactions that link with the queue flush transaction that the bulk action is executed through. {fleet-server-pull}2929[#2929]
 * Add endpoint to serve PGP keys that clients can use when validating upgrades in cases where the embedded PGP key in a client is compromised and the client can't reach the internet. {fleet-server-pull}2977[#2977] {fleet-server-issue}2887[#2887]
 * Add ActionLimit and a Gzip writer pool to handle checkin responses, to help prevent OOM errors when updates are issued to many clients. {fleet-server-pull}2929[#2994]
-* Fix errors produced by the {fleet-server} bulker to be ECS compliant. {fleet-server-pull}3034[#3034] {fleet-server-issue}3033[#3033]
+* Send errors in API calls and bulker flushes to APM. fleet-server-pull}3053[#3053]
 
 {agent}::
 * Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files. {agent-pull}3431[#3431] {agent-issue}3221[#3221]
@@ -105,14 +102,15 @@ The 8.11.0 release Added the following new and notable features.
 [[bug-fixes-8.11.0]]
 === Bug fixes
 
-{fleet}::
-
 {fleet-server}::
+* Fix errors produced by the {fleet-server} bulker to be ECS compliant. {fleet-server-pull}3034[#3034] {fleet-server-issue}3033[#3033]
 
 {agent}::
 * Enable resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available. {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 * Prevent a standalone {agent} from being upgraded if an upgrade is already in progress. {agent-pull}3473[#3473] {agent-issue}2706[#2706]
 * Fix a bug that affected reporting progress of the {agent} artifact download during an upgrade. {agent-pull}3548[#3548]
+* Upgrade `elastic-agent-libs` to v0.6.0 to improve restart, uninstall, and shutdown performance. {agent-pull}3632[#3632]
+* Increase wait period between service restarts on failure to 15s on Windows. {agent-pull}3657[#3657]
 
 // end 8.11.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -47,17 +47,14 @@ impact to your application.
 
 [discrete]
 [[breaking-3712]]
-.{agent} Docker container image can block ECE install
+.Integrations Server / APM unable to boot in specific ECE environments
 [%collapsible]
 ====
 *Details* +
-A permissions change in the {agent} Docker container can prevent {ece} deployments from booting up. The change affects ECE deployments that:
-
-* Are deployed with a non-default Linux user ID
-* Include the APM component (APM is included as part of Integrations Server)
+A permissions change in the {agent} Docker container can prevent the {agent} or Integrations Server component from booting up within an ECE deployment. The change affects ECE installations that are deployed with a Linux UID other than `1000`.
 
 *Impact* +
-ECE users with deployments that include APM are recommended to wait for the next patch release, which is planned to include a fix for this problem.
+ECE users with deployments that include APM or Integrations Server are recommended to wait for the next patch release, which is planned to include a fix for this problem.
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -128,6 +128,7 @@ The 8.11.0 release Added the following new and notable features.
 * Fix a bug that affected reporting progress of the {agent} artifact download during an upgrade. {agent-pull}3548[#3548]
 * Upgrade `elastic-agent-libs` to v0.6.0 to fix the {agent} Windows service becoming unresponsive. Fixes Windows service timeouts during WMI queries and during service shutdown. {agent-pull}3632[#3632] {agent-issue}3061[#3061]
 * Increase wait period between service restarts on failure to 15s on Windows. {agent-pull}3657[#3657]
+* Prevent multiple attempts by {agent} to stop an already stopped service. {agent-pull}3482[#3482]
 
 // end 8.11.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -46,6 +46,21 @@ performance. Before you upgrade, review the breaking changes, then mitigate the
 impact to your application.
 
 [discrete]
+[[breaking-3712]]
+.{agent} Docker container image can block ECE install
+[%collapsible]
+====
+*Details* +
+A permissions change in the {agent} Docker container can prevent {ece} deployments from booting up. The change affects ECE deployments that:
+
+* Are deployed with a non-default Linux user ID
+* Include the APM component (APM is included as part of Integrations Server)
+
+*Impact* +
+ECE users with deployments that include APM are recommended to wait for the next patch release, which is planned to include a fix for this problem.
+====
+
+[discrete]
 [[breaking-3505]]
 .Compression is enabled by default for {agent} {es} outputs
 [%collapsible]

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -31,6 +31,13 @@ Review important information about {fleet-server} and {agent} for the 8.11.0 rel
 For {fleet} updates, refer to the {kibana-ref}/release-notes.html[{kib} Release Notes].
 
 [discrete]
+[[security-updates-8.7.x]]
+=== Security updates
+
+{agent}::
+* Updated Go version to 1.20.10. {agent-pull}3[#3601]
+
+[discrete]
 [[breaking-changes-8.11.0]]
 === Breaking changes
 
@@ -69,14 +76,10 @@ For more information, refer to {agent-pull}3593[#3593].
 
 The 8.11.0 release Added the following new and notable features.
 
-{fleet-server}::
-* Add new `upgrade_details` attribute to checkin requests and the agent index. {fleet-server-pull}2901[#2901]
-
 {agent}::
 * Add support for processors in hints-based Kubernetes autodiscover. {agent-pull}3107[#3107] {agent-issue}2959[#2959]
 * Print out {agent} installation steps to show progress. {agent-pull}3338[#3338]
-* Add colors to {agent} log messages based on their level. {agent-pull}3345[#3345]
-* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files. {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+* Add colors to {agent} messages printed by the elastic-agent logs command based on their level. {agent-pull}3345[#3345]
 
 [discrete]
 [[enhancements-8.11.0]]
@@ -90,13 +93,12 @@ The 8.11.0 release Added the following new and notable features.
 
 {agent}::
 * Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files. {agent-pull}3431[#3431] {agent-issue}3221[#3221]
-* Updating Elastic manifests with NETINFO variable. Setting a new environmental variable `ELASTIC_NETINFO=false` globally disables the `netinfo.enabled` parameter of the `add_host_metadata` processor. This disables the indexing of `host.ip` and `host.mac` fields. {agent-pull}3354[#3354]
-* The {agent} uninstall process now finds and kills any running Watcher process. {agent-pull}3384[#3384] {agent-issue}3371[#3371]
+* Support the NETINFO variable in Elastic Kubernetes manifests. Setting a new environmental variable `ELASTIC_NETINFO=false` globally disables the `netinfo.enabled` parameter of the `add_host_metadata` processor. This disables the indexing of `host.ip` and `host.mac` fields. {agent-pull}3354[#3354]
+* The {agent} uninstall process now finds and kills any running upgrade Watcher process. Uninstalls initiated within 10 minutes of a previous upgrade now work as expected. {agent-pull}3384[#3384] {agent-issue}3371[#3371]
 * Fix the Kubernetes `deploy/kubernetes/creator_k8.sh` script to correcly exclude configmaps. {agent-pull}3396[#3396]
-* Add a secondary fallback for package signature verification, to enable reliable upgrades in air gapped environments where {fleet-server} is the only reachable URI. {agent-pull}3543[#3543] {agent-issue}3264[#3264]
+* Allow fetching the GPG key used for upgrade package signature verification from {fleet-server}. This enables upgrades using rotated GPG keys in air gapped environments where {fleet-server} is the only reachable URI. {agent-pull}3543[#3543] {agent-issue}3264[#3264]
 * Enable tamper protection feature flag by default for {agent} version 8.11.0. {agent-pull}3478[#3478]
-* Increase {agent} monitoring metrics interval from 10s to 60s to reduce load. {agent-pull}3578[#3578]
-* Updated Go version to 1.20.10. {agent-pull}3[#3601]
+* Increase {agent} monitoring metrics interval from 10s to 60s to reduce the default ingestion load and long term storage requirements. {agent-pull}3578[#3578]
 
 [discrete]
 [[bug-fixes-8.11.0]]
@@ -109,7 +111,7 @@ The 8.11.0 release Added the following new and notable features.
 * Enable resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available. {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 * Prevent a standalone {agent} from being upgraded if an upgrade is already in progress. {agent-pull}3473[#3473] {agent-issue}2706[#2706]
 * Fix a bug that affected reporting progress of the {agent} artifact download during an upgrade. {agent-pull}3548[#3548]
-* Upgrade `elastic-agent-libs` to v0.6.0 to improve restart, uninstall, and shutdown performance. {agent-pull}3632[#3632]
+* Upgrade `elastic-agent-libs` to v0.6.0 to fix the {agent} Windows service becoming unresponsive. Fixes Windows service timeouts during WMI queries and during service shutdown. {agent-pull}3632[#3632] {agent-issue}3061[#3061]
 * Increase wait period between service restarts on failure to 15s on Windows. {agent-pull}3657[#3657]
 
 // end 8.11.0 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -49,6 +49,18 @@ On typical workloads this is expected to decrease network data volume by 70-80%,
 ====
 
 [discrete]
+[[breaking-3593]]
+.`elastic-agent-autodiscover` library has been updated to version 0.6.4, disabling metadata For `kubernetes.deployment` and `kubernetes.cronjob` fields.
+[%collapsible]
+====
+*Details* +
+The `elastic-agent-autodiscover` Kubernetes library by default comes with `add_resource_metadata.deployment=false` and `add_resource_metadata.cronjob=false`.
+*Impact* +
+Pods that will be created from deployments or cronjobs will not have the extra metadata field for `kubernetes.deployment` or `kubernetes.cronjob`, respectively. This change was made to avoid the memory impact of keeping the feature enabled in big Kubernetes clusters.
+For more information, refer to {agent-pull}3593[#3593].
+====
+
+[discrete]
 [[new-features-8.11.0]]
 === New features
 
@@ -58,15 +70,13 @@ The 8.11.0 release Added the following new and notable features.
 //EXAMPLE * Enable agent policy secret storage when all fleet servers are above 8.11.0 {kibana-pull}163627[#163627].
 
 {fleet-server}::
-//EXAMPLE * Fleet Server support to handle agent policy secrets. {fleet-server-pull}2863[#2863] {fleet-server-issue}2485[#2485]
-* Add new `upgrade_details`` attribute to checkin requests and the agent index. {fleet-server-pull}2901[#2901]
+* Add new `upgrade_details` attribute to checkin requests and the agent index. {fleet-server-pull}2901[#2901]
 
 {agent}::
-//EXAMPLE * Improve upgrade process to use upgraded version of Watcher to ensure a successful upgrade. {agent-pull}3140[#3140] {agent-issue}2873[#2873]
 * Add support for processors in hints-based Kubernetes autodiscover. {agent-pull}3107[#3107] {agent-issue}2959[#2959]
 * Print out {agent} installation steps to show progress. {agent-pull}3338[#3338]
 * Add colors to {agent} log messages based on their level. {agent-pull}3345[#3345]
-* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files. {agent-pull}3431[#3431] {agent-issue}3221[#3221]
 
 [discrete]
 [[enhancements-8.11.0]]
@@ -76,19 +86,20 @@ The 8.11.0 release Added the following new and notable features.
 //EXAMPLE * Add support for runtime fields. {kibana-pull}161129[#161129].
 
 {fleet-server}::
-//EXaMPLE * Use a unique ID for agent action results to ensure accurate counts on {fleet} UI. {fleet-server-pull}2782[#2782] {fleet-server-issue}2596[#2596]
 * Expand APM traces to track coordinator and monitor transactions. Add additonal spans across all API endpoints to better track what the server does. Add spans to bulker interactions that link with the queue flush transaction that the bulk action is executed through. {fleet-server-pull}2929[#2929]
 * Add endpoint to serve PGP keys that clients can use when validating upgrades in cases where the embedded PGP key in a client is compromised and the client can't reach the internet. {fleet-server-pull}2977[#2977] {fleet-server-issue}2887[#2887]
 * Add ActionLimit and a Gzip writer pool to handle checkin responses, to help prevent OOM errors when updates are issued to many clients. {fleet-server-pull}2929[#2994]
+* Fix errors produced by the {fleet-server} bulker to be ECS compliant. {fleet-server-pull}3034[#3034] {fleet-server-issue}3033[#3033]
 
 {agent}::
-//EXaMPLE * Redundant calls to `/api/fleet/setup` were removed in favor of {kib}-initiated calls. {agent-pull}2985[#2985] {agent-issue}2910[#2910]
-* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files. {agent-pull}3431[#3431] {agent-issue}3221[#3221]
 * Updating Elastic manifests with NETINFO variable. Setting a new environmental variable `ELASTIC_NETINFO=false` globally disables the `netinfo.enabled` parameter of the `add_host_metadata` processor. This disables the indexing of `host.ip` and `host.mac` fields. {agent-pull}3354[#3354]
 * The {agent} uninstall process now finds and kills any running Watcher process. {agent-pull}3384[#3384] {agent-issue}3371[#3371]
 * Fix the Kubernetes `deploy/kubernetes/creator_k8.sh` script to correcly exclude configmaps. {agent-pull}3396[#3396]
 * Add a secondary fallback for package signature verification, to enable reliable upgrades in air gapped environments where {fleet-server} is the only reachable URI. {agent-pull}3543[#3543] {agent-issue}3264[#3264]
 * Enable tamper protection feature flag by default for {agent} version 8.11.0. {agent-pull}3478[#3478]
+* Increase {agent} monitoring metrics interval from 10s to 60s to reduce load. {agent-pull}3578[#3578]
+* Updated Go version to 1.20.10. {agent-pull}3[#3601]
 
 [discrete]
 [[bug-fixes-8.11.0]]
@@ -101,6 +112,7 @@ The 8.11.0 release Added the following new and notable features.
 {agent}::
 * Enable resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available. {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
 * Prevent a standalone {agent} from being upgraded if an upgrade is already in progress. {agent-pull}3473[#3473] {agent-issue}2706[#2706]
+* Fix a bug that affected reporting progress of the {agent} artifact download during an upgrade. {agent-pull}3548[#3548]
 
 // end 8.11.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -1,0 +1,215 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.11.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.10.0 relnotes
+
+[[release-notes-8.11.0]]
+== {fleet} and {agent} 8.11.0
+
+Review important information about the {fleet} and {agent} 8.11.0 release.
+
+[discrete]
+[[breaking-changes-8.11.0]]
+=== Breaking changess
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-3505]]
+.Compression is enabled by default for {agent} {es} outputs
+[%collapsible]
+====
+*Details* +
+The default compression level for {es} outputs is changing from `0` to `1`. 
+
+*Impact* +
+On typical workloads this is expected to decrease network data volume by 70-80%, while increasing CPU use by 20-25% and ingestion time by 10%. The previous behavior can be restored by adding the setting `compression_level: 0` to the agent output configuration.
+====
+
+[discrete]
+[[new-features-8.11.0]]
+=== New features
+
+The 8.11.0 release Added the following new and notable features.
+
+{fleet}::
+//EXAMPLE * Enable agent policy secret storage when all fleet servers are above 8.11.0 {kibana-pull}163627[#163627].
+
+{fleet-server}::
+//EXAMPLE * Fleet Server support to handle agent policy secrets. {fleet-server-pull}2863[#2863] {fleet-server-issue}2485[#2485]
+* Add new `upgrade_details`` attribute to checkin requests and the agent index. {fleet-server-pull}2901[#2901]
+
+{agent}::
+//EXAMPLE * Improve upgrade process to use upgraded version of Watcher to ensure a successful upgrade. {agent-pull}3140[#3140] {agent-issue}2873[#2873]
+* Add support for processors in hints-based Kubernetes autodiscover. {agent-pull}3107[#3107] {agent-issue}2959[#2959]
+* Print out {agent} installation steps to show progress. {agent-pull}3338[#3338]
+* Add colors to {agent} log messages based on their level. {agent-pull}3345[#3345]
+* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+
+[discrete]
+[[enhancements-8.11.0]]
+=== Enhancements
+
+{fleet}::
+//EXAMPLE * Add support for runtime fields. {kibana-pull}161129[#161129].
+
+{fleet-server}::
+//EXaMPLE * Use a unique ID for agent action results to ensure accurate counts on {fleet} UI. {fleet-server-pull}2782[#2782] {fleet-server-issue}2596[#2596]
+* Expand APM traces to track coordinator and monitor transactions. Add additonal spans across all API endpoints to better track what the server does. Add spans to bulker interactions that link with the queue flush transaction that the bulk action is executed through. {fleet-server-pull}2929[#2929]
+* Add endpoint to serve PGP keys that clients can use when validating upgrades in cases where the embedded PGP key in a client is compromised and the client can't reach the internet. {fleet-server-pull}2977[#2977] {fleet-server-issue}2887[#2887]
+* Add ActionLimit and a Gzip writer pool to handle checkin responses, to help prevent OOM errors when updates are issued to many clients. {fleet-server-pull}2929[#2994]
+
+{agent}::
+//EXaMPLE * Redundant calls to `/api/fleet/setup` were removed in favor of {kib}-initiated calls. {agent-pull}2985[#2985] {agent-issue}2910[#2910]
+* Improve {agent} uninstall on Windows by adding delay between retries when file removal is blocked by busy files {agent-pull}3431[#3431] {agent-issue}3221[#3221]
+* Updating Elastic manifests with NETINFO variable. Setting a new environmental variable `ELASTIC_NETINFO=false` globally disables the `netinfo.enabled` parameter of the `add_host_metadata` processor. This disables the indexing of `host.ip` and `host.mac` fields. {agent-pull}3354[#3354]
+* The {agent} uninstall process now finds and kills any running Watcher process. {agent-pull}3384[#3384] {agent-issue}3371[#3371]
+* Fix the Kubernetes `deploy/kubernetes/creator_k8.sh` script to correcly exclude configmaps. {agent-pull}3396[#3396]
+* Add a secondary fallback for package signature verification, to enable reliable upgrades in air gapped environments where {fleet-server} is the only reachable URI. {agent-pull}3543[#3543] {agent-issue}3264[#3264]
+* Enable tamper protection feature flag by default for {agent} version 8.11.0. {agent-pull}3478[#3478]
+
+[discrete]
+[[bug-fixes-8.11.0]]
+=== Bug fixes
+
+{fleet}::
+
+{fleet-server}::
+
+{agent}::
+* Enable resilient handling of air gapped PGP checks. {agent} should not fail when remote PGP is specified (or official Elastic fallback PGP is used) and remote is not available. {agent-pull}3427[#3427] {agent-pull}3426[#3426] {agent-issue}3368[#3368]
+* Prevent a standalone {agent} from being upgraded if an upgrade is already in progress. {agent-pull}3473[#3473] {agent-issue}2706[#2706]
+
+// end 8.11.0 relnotes
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.7.x relnotes
+
+//[[release-notes-8.7.x]]
+//== {fleet} and {agent} 8.7.x
+
+//Review important information about the {fleet} and {agent} 8.7.x release.
+
+//[discrete]
+//[[security-updates-8.7.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.7.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[known-issues-8.7.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.7.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.7.x, and will be removed in
+//8.7.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.7.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.7.x]]
+//=== New features
+
+//The 8.7.x release Added the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.7.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.7.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.7.x relnotes


### PR DESCRIPTION
This adds the 8.11.0 Fleet & Elastic Agent Release Notes:

 - Fleet Server contents are from [BC9 fragments](https://github.com/elastic/fleet-server/tree/de43d84e257cd4d0ed1243e99d23dafefa46b176/changelog/fragments)
 - Elastic Agent contents are from the [BC9 fragments](https://github.com/elastic/elastic-agent/tree/3c8be7201bbf4e3f91d7b56de9ff285c386a7804/changelog/fragments)


**NOTE:** For Fleet I've added a link to the [Kibana Release Notes](https://www.elastic.co/guide/en/kibana/master/release-notes.html). I think this makes more sense than duplicating the entries in the Kibana Guide and Fleet & Agent Guide, especially if edits to the entries in this PR aren't synced back with the Kibana release notes. Lately the entries have some differences between the two books and I think that could cause some confusion.

[DOCS PREVIEW](https://ingest-docs_580.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.11.0.html)

Closes: #578