### PR TITLE
Add standalone agent config file example: Apache HTTP Server

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -126,6 +126,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
+<9> A user-defined ID to identify the individual input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
 <10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
 <11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -1,0 +1,120 @@
+[[config-file-example-apache]]
+= Config file example: Apache HTTP Server
+
+++++
+<titleabbrev>Apache HTTP Server</titleabbrev>
+++++
+
+Include these settings in your standalone {agent} `elastic-agent.yml` configuration file to ingest data from Apache HTTP server. 
+
+* <<config-file-example-apache-logs>>
+* <<config-file-example-apache-metrics>>
+
+[[config-file-example-apache-logs]]
+== Apache HTTP Server logs
+
+["source","yaml"]
+----
+outputs: <1>
+  default:
+    type: elasticsearch <2>
+    hosts:
+      - 'https://94d343762a2b465f976aa292df6a0fe1.us-central1.gcp.cloud.es.io:443'
+    username: '${ES_USERNAME}'
+    password: '${ES_PASSWORD}'
+agent:
+  download: <3>
+    sourceURI: 'https://artifacts.elastic.co/downloads/'
+  monitoring: <4>
+    enabled: true
+    use_output: default
+    namespace: default
+    logs: true
+    metrics: true
+inputs: <5>
+  - id: logfile-apache-fb9e632d-3708-4e76-bf4e-9758d379507e
+    name: apache-1
+    type: logfile <6>
+    use_output: default
+    data_stream:
+      namespace: default
+    streams:
+      - id: logfile-apache.access-fb9e632d-3708-4e76-bf4e-9758d379507e
+        data_stream:
+          dataset: apache.access
+          type: logs
+        paths:
+          - /var/log/apache2/access.log*
+          - /var/log/apache2/other_vhosts_access.log*
+          - /var/log/httpd/access_log*
+        tags:
+          - apache-access
+        exclude_files:
+          - .gz$
+      - id: logfile-apache.error-fb9e632d-3708-4e76-bf4e-9758d379507e
+        data_stream:
+          dataset: apache.error
+          type: logs
+        paths:
+          - /var/log/apache2/error.log*
+          - /var/log/httpd/error_log*
+        exclude_files:
+          - .gz$
+        tags:
+          - apache-error
+        processors:
+          - add_locale: null
+----
+
+<1> For available output settings, refer to <<elastic-agent-output-configuration>>.
+<2> For settings specific to the {es} output, refer to <<elasticsearch-output>>.
+<3> For available download settings, refer to <<elastic-agent-standalone-download>>.
+<4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
+<5> For available input settings, refer to <<elastic-agent-input-configuration>>.
+<6> For available input types, refer to <<elastic-agent-inputs-list>>.
+
+[[config-file-example-apache-metrics]]
+== Apache HTTP Server metrics
+
+["source","yaml"]
+----
+outputs: <1>
+  default:
+    type: elasticsearch <2>
+    hosts:
+      - 'https://94d343762a2b465f976aa292df6a0fe1.us-central1.gcp.cloud.es.io:443'
+    username: '${ES_USERNAME}'
+    password: '${ES_PASSWORD}'
+agent:
+  download: <3>
+    sourceURI: 'https://artifacts.elastic.co/downloads/'
+  monitoring: <4>
+    enabled: true
+    use_output: default
+    namespace: default
+    logs: true
+    metrics: true
+inputs: <5>
+    type: apache/metrics <6>
+    use_output: default
+    data_stream:
+      namespace: default
+    streams:
+      - id: apache/metrics-apache.status-6c23c542-9460-4ef5-b155-ab1bec34d489
+        data_stream:
+          dataset: apache.status
+          type: metrics
+        metricsets:
+          - status
+        hosts:
+          - 'http://127.0.0.1'
+        period: 30s
+        server_status_path: /server-status
+----
+
+<1> For available output settings, refer to <<elastic-agent-output-configuration>>.
+<2> For settings specific to the {es} output, refer to <<elasticsearch-output>>.
+<3> For available download settings, refer to <<elastic-agent-standalone-download>>.
+<4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
+<5> For available input settings, refer to <<elastic-agent-input-configuration>>.
+<6> For available input types, refer to <<elastic-agent-inputs-list>>.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -39,11 +39,11 @@ inputs: <6>
     data_stream: <9>
       namespace: default
     streams:
-      - id: {user-defined-unique-id}-apache.access <7>
+      - id: {user-defined-unique-id}-apache.access <10>
         data_stream:
-          dataset: apache.access <10>
+          dataset: apache.access <11>
           type: logs
-        paths: <11>
+        paths: <12>
           - /var/log/apache2/access.log*
           - /var/log/apache2/other_vhosts_access.log*
           - /var/log/httpd/access_log*
@@ -51,11 +51,11 @@ inputs: <6>
           - apache-access
         exclude_files:
           - .gz$
-      - id: {user-defined-unique-id}-apache.error <7>
+      - id: {user-defined-unique-id}-apache.error <10>
         data_stream:
-          dataset: apache.error <10>
+          dataset: apache.error <11>
           type: logs
-        paths: <11>
+        paths: <12>
           - /var/log/apache2/error.log*
           - /var/log/httpd/error_log*
         exclude_files:
@@ -72,11 +72,12 @@ inputs: <6>
 <4> For available download settings, refer to <<elastic-agent-standalone-download>>.
 <5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<7> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming each ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
+<7> A user-defined, unique ID to identify the input.
 <8> For available input types, refer to <<elastic-agent-inputs-list>>.
 <9> Learn about <<data-streams>> for time series data.
-<10> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
-<11> Path to the log files to be monitored.
+<10> A user-defined ID to identify the individual input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
+<11> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
+<12> Path to the log files to be monitored.
 
 [[config-file-example-apache-metrics]]
 == Apache HTTP Server metrics

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -39,7 +39,7 @@ inputs: <6>
     data_stream: <9>
       namespace: default
     streams:
-      - id: {user-defined-unique-id} <7>
+      - id: {user-defined-unique-id}-apache.access <7>
         data_stream:
           dataset: apache.access <10>
           type: logs
@@ -51,7 +51,7 @@ inputs: <6>
           - apache-access
         exclude_files:
           - .gz$
-      - id: {user-defined-unique-id} <7>
+      - id: {user-defined-unique-id}-apache.error <7>
         data_stream:
           dataset: apache.error <10>
           type: logs
@@ -72,7 +72,7 @@ inputs: <6>
 <4> For available download settings, refer to <<elastic-agent-standalone-download>>.
 <5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<7> A user-defined ID to uniquely identify the input stream.
+<7> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming each ID by appending the associated `data_stream` dataset (for example, `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
 <8> For available input types, refer to <<elastic-agent-inputs-list>>.
 <9> Learn about <<data-streams>> for time series data.
 <10> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
@@ -105,7 +105,7 @@ inputs: <6>
     data_stream: <8>
       namespace: default
     streams:
-      - id: {user-defined-unique-id} <9>
+      - id: {user-defined-unique-id}-apache.status <9>
         data_stream: <8>
           dataset: apache.status <10>
           type: metrics
@@ -125,6 +125,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined ID to uniquely identify the input stream.
+<9> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example, `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
 <10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
 <11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -72,7 +72,7 @@ inputs: <6>
 <4> For available download settings, refer to <<elastic-agent-standalone-download>>.
 <5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<7> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming each ID by appending the associated `data_stream` dataset (for example, `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
+<7> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming each ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
 <8> For available input types, refer to <<elastic-agent-inputs-list>>.
 <9> Learn about <<data-streams>> for time series data.
 <10> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
@@ -125,6 +125,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example, `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
+<9> A user-defined ID to identify the input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
 <10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
 <11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -19,31 +19,31 @@ outputs: <1>
   default:
     type: elasticsearch <2>
     hosts:
-      - 'https://94d343762a2b465f976aa292df6a0fe1.us-central1.gcp.cloud.es.io:443'
+      - '{elasticsearch-host-url}' <3>
     username: '${ES_USERNAME}'
     password: '${ES_PASSWORD}'
 agent:
-  download: <3>
+  download: <4>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <4>
+  monitoring: <5>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <5>
-  - id: logfile-apache-fb9e632d-3708-4e76-bf4e-9758d379507e
+inputs: <6>
+  - id: {user-defined-unique-id} <7>
     name: apache-1
-    type: logfile <6>
+    type: logfile <8>
     use_output: default
-    data_stream: <7>
+    data_stream: <9>
       namespace: default
     streams:
-      - id: logfile-apache.access-fb9e632d-3708-4e76-bf4e-9758d379507e
+      - id: {user-defined-unique-id} <7>
         data_stream:
-          dataset: apache.access <8>
+          dataset: apache.access <10>
           type: logs
-        paths: <9>
+        paths: <11>
           - /var/log/apache2/access.log*
           - /var/log/apache2/other_vhosts_access.log*
           - /var/log/httpd/access_log*
@@ -51,11 +51,11 @@ inputs: <5>
           - apache-access
         exclude_files:
           - .gz$
-      - id: logfile-apache.error-fb9e632d-3708-4e76-bf4e-9758d379507e
+      - id: {user-defined-unique-id} <7>
         data_stream:
-          dataset: apache.error <8>
+          dataset: apache.error <10>
           type: logs
-        paths: <9>
+        paths: <11>
           - /var/log/apache2/error.log*
           - /var/log/httpd/error_log*
         exclude_files:
@@ -68,13 +68,15 @@ inputs: <5>
 
 <1> For available output settings, refer to <<elastic-agent-output-configuration>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output>>.
-<3> For available download settings, refer to <<elastic-agent-standalone-download>>.
-<4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
-<5> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<6> For available input types, refer to <<elastic-agent-inputs-list>>.
-<7> Learn about <<data-streams>> for time series data.
-<8> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
-<9> Path to the log files to be monitored.
+<3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
+<4> For available download settings, refer to <<elastic-agent-standalone-download>>.
+<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
+<6> For available input settings, refer to <<elastic-agent-input-configuration>>.
+<7> A user-defined unique ID to identify the input stream.
+<8> For available input types, refer to <<elastic-agent-inputs-list>>.
+<9> Learn about <<data-streams>> for time series data.
+<10> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
+<11> Path to the log files to be monitored.
 
 [[config-file-example-apache-metrics]]
 == Apache HTTP Server metrics
@@ -85,29 +87,29 @@ outputs: <1>
   default:
     type: elasticsearch <2>
     hosts:
-      - 'https://94d343762a2b465f976aa292df6a0fe1.us-central1.gcp.cloud.es.io:443'
+      - '{elasticsearch-host-url}' <3>
     username: '${ES_USERNAME}'
     password: '${ES_PASSWORD}'
 agent:
-  download: <3>
+  download: <4>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <4>
+  monitoring: <5>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <5>
-    type: apache/metrics <6>
+inputs: <6>
+    type: apache/metrics <7>
     use_output: default
-    data_stream: <7>
+    data_stream: <8>
       namespace: default
     streams:
-      - id: apache/metrics-apache.status-6c23c542-9460-4ef5-b155-ab1bec34d489
-        data_stream: <7>
-          dataset: apache.status <8>
+      - id: {user-defined-unique-id}
+        data_stream: <8>
+          dataset: apache.status <9>
           type: metrics
-        metricsets: <9>
+        metricsets: <10>
           - status
         hosts:
           - 'http://127.0.0.1'
@@ -117,10 +119,11 @@ inputs: <5>
 
 <1> For available output settings, refer to <<elastic-agent-output-configuration>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output>>.
-<3> For available download settings, refer to <<elastic-agent-standalone-download>>.
-<4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
-<5> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<6> For available input types, refer to <<elastic-agent-inputs-list>>.
-<7> Learn about <<data-streams>> for time series data.
-<8> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
-<9> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.
+<3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
+<4> For available download settings, refer to <<elastic-agent-standalone-download>>.
+<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
+<6> For available input settings, refer to <<elastic-agent-input-configuration>>.
+<7> For available input types, refer to <<elastic-agent-inputs-list>>.
+<8> Learn about <<data-streams>> for time series data.
+<9> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
+<10> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -36,14 +36,14 @@ inputs: <5>
     name: apache-1
     type: logfile <6>
     use_output: default
-    data_stream:
+    data_stream: <7>
       namespace: default
     streams:
       - id: logfile-apache.access-fb9e632d-3708-4e76-bf4e-9758d379507e
         data_stream:
-          dataset: apache.access
+          dataset: apache.access <8>
           type: logs
-        paths:
+        paths: <9>
           - /var/log/apache2/access.log*
           - /var/log/apache2/other_vhosts_access.log*
           - /var/log/httpd/access_log*
@@ -53,9 +53,9 @@ inputs: <5>
           - .gz$
       - id: logfile-apache.error-fb9e632d-3708-4e76-bf4e-9758d379507e
         data_stream:
-          dataset: apache.error
+          dataset: apache.error <8>
           type: logs
-        paths:
+        paths: <9>
           - /var/log/apache2/error.log*
           - /var/log/httpd/error_log*
         exclude_files:
@@ -72,6 +72,9 @@ inputs: <5>
 <4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <5> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <6> For available input types, refer to <<elastic-agent-inputs-list>>.
+<7> Learn about <<data-streams>> for time series data.
+<8> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
+<9> Path to the log files to be monitored.
 
 [[config-file-example-apache-metrics]]
 == Apache HTTP Server metrics
@@ -97,14 +100,14 @@ agent:
 inputs: <5>
     type: apache/metrics <6>
     use_output: default
-    data_stream:
+    data_stream: <7>
       namespace: default
     streams:
       - id: apache/metrics-apache.status-6c23c542-9460-4ef5-b155-ab1bec34d489
-        data_stream:
-          dataset: apache.status
+        data_stream: <7>
+          dataset: apache.status <8>
           type: metrics
-        metricsets:
+        metricsets: <9>
           - status
         hosts:
           - 'http://127.0.0.1'
@@ -118,3 +121,6 @@ inputs: <5>
 <4> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <5> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <6> For available input types, refer to <<elastic-agent-inputs-list>>.
+<7> Learn about <<data-streams>> for time series data.
+<8> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
+<9> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -105,11 +105,11 @@ inputs: <6>
     data_stream: <8>
       namespace: default
     streams:
-      - id: {user-defined-unique-id}
+      - id: {user-defined-unique-id} <9>
         data_stream: <8>
-          dataset: apache.status <9>
+          dataset: apache.status <10>
           type: metrics
-        metricsets: <10>
+        metricsets: <11>
           - status
         hosts:
           - 'http://127.0.0.1'
@@ -125,5 +125,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
-<10> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.
+<9> A user-defined unique ID to identify the input stream.
+<10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
+<11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Apache HTTP Server</titleabbrev>
 ++++
 
-Include these settings in your standalone {agent} `elastic-agent.yml` configuration file to ingest data from Apache HTTP server. 
+Include these sample settings in your standalone {agent} `elastic-agent.yml` configuration file to ingest data from Apache HTTP server.
 
 * <<config-file-example-apache-logs>>
 * <<config-file-example-apache-metrics>>
@@ -72,7 +72,7 @@ inputs: <6>
 <4> For available download settings, refer to <<elastic-agent-standalone-download>>.
 <5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<7> A user-defined unique ID to identify the input stream.
+<7> A user-defined ID to uniquely identify the input stream.
 <8> For available input types, refer to <<elastic-agent-inputs-list>>.
 <9> Learn about <<data-streams>> for time series data.
 <10> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
@@ -125,6 +125,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined unique ID to identify the input stream.
+<9> A user-defined ID to uniquely identify the input stream.
 <10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
 <11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -32,14 +32,14 @@ agent:
     logs: true
     metrics: true
 inputs: <6>
-  - id: {user-defined-unique-id} <7>
+  - id: "insert a unique identifier here" <7>
     name: apache-1
     type: logfile <8>
     use_output: default
     data_stream: <9>
       namespace: default
     streams:
-      - id: {user-defined-unique-id}-apache.access <10>
+      - id: "insert a unique identifier here" <10>
         data_stream:
           dataset: apache.access <11>
           type: logs
@@ -51,7 +51,7 @@ inputs: <6>
           - apache-access
         exclude_files:
           - .gz$
-      - id: {user-defined-unique-id}-apache.error <10>
+      - id: "insert a unique identifier here" <10>
         data_stream:
           dataset: apache.error <11>
           type: logs
@@ -72,10 +72,10 @@ inputs: <6>
 <4> For available download settings, refer to <<elastic-agent-standalone-download>>.
 <5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration>>.
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
-<7> A user-defined, unique ID to identify the input.
+<7> Specify a unique ID for the input.
 <8> For available input types, refer to <<elastic-agent-inputs-list>>.
 <9> Learn about <<data-streams>> for time series data.
-<10> A user-defined ID to identify the individual input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
+<10> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
 <11> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
 <12> Path to the log files to be monitored.
 
@@ -106,7 +106,7 @@ inputs: <6>
     data_stream: <8>
       namespace: default
     streams:
-      - id: {user-defined-unique-id}-apache.status <9>
+      - id: "insert a unique identifier here" <9>
         data_stream: <8>
           dataset: apache.status <10>
           type: metrics
@@ -126,6 +126,6 @@ inputs: <6>
 <6> For available input settings, refer to <<elastic-agent-input-configuration>>.
 <7> For available input types, refer to <<elastic-agent-inputs-list>>.
 <8> Learn about <<data-streams>> for time series data.
-<9> A user-defined ID to identify the individual input stream. The ID for each input stream needs to be unique. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
+<9> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
 <10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
 <11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
@@ -1,0 +1,9 @@
+[[config-file-examples]]
+= Config file examples
+
+These examples show a basic configuration to include in a standalone {agent} `elastic-agent.yml` <<structure-config-file,configuration file>> to gather data from various types of source.
+
+* <<config-file-example-apache-logs>>
+* <<config-file-example-apache-metrics>>
+
+include::config-file-example-apache.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
@@ -1,7 +1,7 @@
 [[config-file-examples]]
 = Config file examples
 
-These examples show a basic configuration to include in a standalone {agent} `elastic-agent.yml` <<structure-config-file,configuration file>> to gather data from various types of source.
+These examples show a basic, sample configuration to include in a standalone {agent} `elastic-agent.yml` <<structure-config-file,configuration file>> to gather data from various source types.
 
 * <<config-file-example-apache,Apache HTTP Server>>
 

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-examples.asciidoc
@@ -3,7 +3,6 @@
 
 These examples show a basic configuration to include in a standalone {agent} `elastic-agent.yml` <<structure-config-file,configuration file>> to gather data from various types of source.
 
-* <<config-file-example-apache-logs>>
-* <<config-file-example-apache-metrics>>
+* <<config-file-example-apache,Apache HTTP Server>>
 
 include::config-file-example-apache.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/configuration/structure-config-file.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/structure-config-file.asciidoc
@@ -3,9 +3,10 @@
 
 The `elastic-agent.yml` policy file contains all of the settings that determine how {agent} runs. The most important and commonly used settings are described here, including input and output options, providers used for variables and conditional output, security settings, logging options, enabling of special features, and specifications for {agent} upgrades.
 
-An `elastic-agent.yml` file is modular: You can combine input, output, and all other settings to enable the {integrations-docs}[{integrations}] to use with {agent}. Refer to <<create-standalone-agent-policy,Create a standalone {agent} policy>> for the steps to download the settings to use as a starting point, and then refer to the following links for specifics on how to adjust the settings individually as needed. You can also refer to our example: <<example-standalone-monitor-nginx,Use standalone {agent} to monitor nginx>>.
+An `elastic-agent.yml` file is modular: You can combine input, output, and all other settings to enable the {integrations-docs}[{integrations}] to use with {agent}. Refer to <<create-standalone-agent-policy,Create a standalone {agent} policy>> for the steps to download the settings to use as a starting point, and then refer to the following examples to learn about the available settings:
 
-// Coming soon: Add instructions for obtaining cut-and-paste settings from a new tab on each integration landing page.
+* <<config-file-examples>>
+* <<example-standalone-monitor-nginx,Use standalone {agent} to monitor nginx>>.
 
 [discrete]
 [[structure-config-file-components]]

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -183,6 +183,8 @@ include::elastic-agent/configuration/elastic-agent-standalone-features.asciidoc[
 
 include::elastic-agent/configuration/elastic-agent-standalone-download.asciidoc[leveloffset=+2]
 
+include::elastic-agent/configuration/examples/config-file-examples.asciidoc[leveloffset=+2]
+
 include::elastic-agent/grant-access-to-elasticsearch.asciidoc[leveloffset=+2]
 
 include::elastic-agent/example-standalone-monitor-nginx.asciidoc[leveloffset=+2]


### PR DESCRIPTION
This adds configuration examples for Apache logs and metrics. The intent is to add similar examples for the Nginx and System Integrations, so let's make sure the format for this one looks good and then I'll proceed with the other two.

[DOCS PREVIEW](https://ingest-docs_583.docs-preview.app.elstc.co/guide/en/fleet/master/config-file-examples.html) (follow the "Apache HTTP Server" link)

Closes: #584
