### PR TITLE
Add install '--base-path' parameter to agent command reference

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -483,6 +483,7 @@ To install the {agent} as a service, enroll it in {fleet}, and start the
 ----
 elastic-agent install --url <string>
                       --enrollment-token <string>
+                      [--base-path <string>]
                       [--ca-sha256 <string>]
                       [--certificate-authorities <string>]
                       [--delay-enroll]
@@ -503,6 +504,7 @@ a `fleet-server` process alongside the `elastic-agent` service:
 elastic-agent install --fleet-server-es <string>
                       --fleet-server-service-token <string>
                       [--fleet-server-service-token-path <string>]
+                      [--base-path <string>]
                       [--ca-sha256 <string>]
                       [--certificate-authorities <string>]
                       [--delay-enroll]
@@ -536,6 +538,10 @@ For more information about custom certificates, refer to <<secure-connections>>.
 
 [discrete]
 === Options
+
+`--base-path <string>`::
+Install {agent} in a location other than the <<installation-layout,default>>.
+Specify the custom base path for the install.
 
 `--ca-sha256 <string>`::
 Comma-separated list of certificate authority hash pins used for certificate


### PR DESCRIPTION
Updates the [install command](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-install-command) docs page to include the new install `--base-path <string>` parameter.

Closes: https://github.com/elastic/ingest-docs/issues/600

---

![Screenshot 2023-10-17 at 11 29 24 AM](https://github.com/elastic/ingest-docs/assets/41695641/86cd674f-afad-4bd4-a0d3-f87c024b41aa)
![Screenshot 2023-10-17 at 11 29 39 AM](https://github.com/elastic/ingest-docs/assets/41695641/1faeb9ae-e2f1-4bbe-aa73-f41acdadec78)
