### PR TITLE
Fix code typo on Kubernetes autodiscover page

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-conditions-autodiscover.asciidoc
@@ -41,7 +41,7 @@ Some examples of conditions usage are:
 
 1. For a pod with label `app.kubernetes.io/name=ingress-nginx` the condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`.
 2. For a pod with annotation `prometheus.io/scrape: "true"` the condition should be `${kubernetes.annotations.prometheus.io/scrape} == "true"`.
-3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name == "kube-scheduler-kind-control-plane"`.
+3. For a pod with name `kube-scheduler-kind-control-plane` the condition should be `${kubernetes.pod.name} == "kube-scheduler-kind-control-plane"`.
 
 
 The `redis` input defined in the {agent} manifest only specifies the`info` metricset. To learn about other available metricsets and their configuration settings, refer to the {metricbeat-ref}/metricbeat-module-redis.html[Redis module page].


### PR DESCRIPTION
Redo of https://github.com/elastic/ingest-docs/pull/620 targetting `main`.