### PR TITLE
Note that integrations list can be filtered by category

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -128,7 +128,7 @@ Click the name of the policy you want to add an integration to.
 
 . Click **Add integration**.
 
-. Search for and select an integration.
+. Search for and select an integration. You can select a category to narrow your search.
 
 . Click **Add <Integration>**.
 

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -18,7 +18,7 @@ integrations that work with {agent}.
 +
 [role="screenshot"]
 image::images/unified-view-selector.png[Screen capture showing options for filtering the view]
-. Search for and select an integration.
+. Search for and select an integration. You can select a category to narrow your search.
 . Click **Add <Integration>**.
 . Name the integration and add any required configuration variables.
 +

--- a/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
@@ -16,7 +16,7 @@ index templates.
 == Install integration assets
 
 . In {kib}, go to **Management > Integrations > Browse integrations**. Search for
-and select an integration.
+and select an integration. You can select a category to narrow your search.
 
 . Click the **Settings** tab.
 

--- a/docs/en/ingest-management/integrations/view-integration-policies.asciidoc
+++ b/docs/en/ingest-management/integrations/view-integration-policies.asciidoc
@@ -11,7 +11,7 @@ policy.
 To view details about all the integration policies for a specific integration:
 
 . In {kib}, go to *Management > Integrations > Installed*. Search for and select
-the integration you want to view.
+the integration you want to view. You can select a category to narrow your search.
 
 . Click the *Policies* tab to see the list of integration policies.
 


### PR DESCRIPTION
The Integrations UI now has category filters, implemented by https://github.com/elastic/kibana/issues/147125

This adds a note in a few spots in the Fleet & Agent docs to mention that the full list of integrations can be filtered.

Closes: https://github.com/elastic/ingest-docs/issues/238