### PR TITLE
Adding docs for leader election timings

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -55,7 +55,7 @@ The available key is:
 As described above, the LeaderElection configuration offers the following parameters: Lease duration (`leader_leaseduration`), Renew deadline (`leader_renewdeadline`), and  
 Retry period (`leader_retryperiod`). Based on the config provided, each agent will trigger {k8s} API requests and will try to check the status of the lease. 
 
-NOTE: The number of Leader API calls is proportional to the number of {agent}s installed. This means that Leader API requests will come from all {agent}s per `leader_retryperiod`. Setting `leader_retryperiod` to a greater value than the default (2sec), means that fewer API requests will be made towards the {k8s} Control API, but will also increase the period where collection of metrics from the leader {agent} might be lost.
+NOTE: The number of leader calls to the K8s Control API is proportional to the number of {agent}s installed. This means that requests will come from all {agent}s per `leader_retryperiod`. Setting `leader_retryperiod` to a greater value than the default (2sec), means that fewer requests will be made towards the {k8s} Control API, but will also increase the period where collection of metrics from the leader {agent} might be lost.
 
 The library applies https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/leaderelection.go#L76[specific checks] for the timing parameters and if those are not verified {agent} will exit with a `panic` error.
 


### PR DESCRIPTION
This PR add the relevant documentation for the enhancement request of kubernetes Leader Election provider described https://github.com/elastic/elastic-agent/pull/3625