### PR TITLE
Move data streams into integrations section; reorder ToC

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -141,25 +141,7 @@ include::create-agent-policies-no-UI.asciidoc[leveloffset=+3]
 
 include::security/enrollment-tokens.asciidoc[leveloffset=+2]
 
-include::data-streams.asciidoc[leveloffset=+2]
-
 include::fleet/fleet-api-docs.asciidoc[leveloffset=+2]
-
-include::integrations/integrations.asciidoc[leveloffset=+1]
-
-include::integrations/package-signatures.asciidoc[leveloffset=+2]
-
-include::integrations/add-integration-to-policy.asciidoc[leveloffset=+2]
-
-include::integrations/view-integration-policies.asciidoc[leveloffset=+2]
-
-include::integrations/edit-or-delete-integration-policy.asciidoc[leveloffset=+2]
-
-include::integrations/install-integration-assets.asciidoc[leveloffset=+2]
-
-include::integrations/view-integration-assets.asciidoc[leveloffset=+2]
-
-include::integrations/upgrade-integration.asciidoc[leveloffset=+2]
 
 include::elastic-agent/configuration/elastic-agent-configuration.asciidoc[leveloffset=+1]
 
@@ -204,6 +186,24 @@ include::elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover
 include::elastic-agent/configuration/elastic-agent-monitoring.asciidoc[leveloffset=+2]
 
 include::elastic-agent/configuration/yaml/elastic-agent-reference-yaml.asciidoc[leveloffset=+2]
+
+include::integrations/integrations.asciidoc[leveloffset=+1]
+
+include::integrations/package-signatures.asciidoc[leveloffset=+2]
+
+include::integrations/add-integration-to-policy.asciidoc[leveloffset=+2]
+
+include::integrations/view-integration-policies.asciidoc[leveloffset=+2]
+
+include::integrations/edit-or-delete-integration-policy.asciidoc[leveloffset=+2]
+
+include::integrations/install-integration-assets.asciidoc[leveloffset=+2]
+
+include::integrations/view-integration-assets.asciidoc[leveloffset=+2]
+
+include::integrations/upgrade-integration.asciidoc[leveloffset=+2]
+
+include::data-streams.asciidoc[leveloffset=+2]
 
 include::processors/processors.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Based on [a couple of suggestions](https://github.com/elastic/ingest-docs/issues/638#issuecomment-1791978985), this:

 - Moves the "data streams" section to be part of "Manage integrations".
 - Moves the "Manage Elastic Agents in Fleet" and the "Configure standalone Elastic Agents" sections to be consecutive in the ToC.

The original structure, with data streams part of the "Manage Elastic Agents in Fleet" section, gives the impression that they're supported only with Fleet and not when standalone agents are used.

PREVIEW

---

![screenshot](https://github.com/elastic/ingest-docs/assets/41695641/c4d14fb2-e339-4a3b-805e-5b9aa3511726)

