### PR TITLE
Change standalone agent config examples to use API key

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -20,30 +20,29 @@ outputs: <1>
     type: elasticsearch <2>
     hosts:
       - '{elasticsearch-host-url}' <3>
-    username: '${ES_USERNAME}'
-    password: '${ES_PASSWORD}'
+    api_key: "my_api_key" <4>
 agent:
-  download: <4>
+  download: <5>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <5>
+  monitoring: <6>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <6>
-  - id: "insert a unique identifier here" <7>
+inputs: <7>
+  - id: "insert a unique identifier here" <8>
     name: apache-1
-    type: logfile <8>
+    type: logfile <9>
     use_output: default
-    data_stream: <9>
+    data_stream: <10>
       namespace: default
     streams:
-      - id: "insert a unique identifier here" <10>
+      - id: "insert a unique identifier here" <11>
         data_stream:
-          dataset: apache.access <11>
+          dataset: apache.access <12>
           type: logs
-        paths: <12>
+        paths: <13>
           - /var/log/apache2/access.log*
           - /var/log/apache2/other_vhosts_access.log*
           - /var/log/httpd/access_log*
@@ -51,11 +50,11 @@ inputs: <6>
           - apache-access
         exclude_files:
           - .gz$
-      - id: "insert a unique identifier here" <10>
+      - id: "insert a unique identifier here" <11>
         data_stream:
-          dataset: apache.error <11>
+          dataset: apache.error <12>
           type: logs
-        paths: <12>
+        paths: <13>
           - /var/log/apache2/error.log*
           - /var/log/httpd/error_log*
         exclude_files:
@@ -69,15 +68,16 @@ inputs: <6>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
-<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
-<6> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
-<7> Specify a unique ID for the input.
-<8> For available input types, refer to <<elastic-agent-inputs-list>>.
-<9> Learn about <<data-streams>> for time series data.
-<10> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
-<11> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
-<12> Path to the log files to be monitored.
+<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
+<6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
+<7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
+<8> Specify a unique ID for the input.
+<9> For available input types, refer to <<elastic-agent-inputs-list>>.
+<10> Learn about <<data-streams>> for time series data.
+<11> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.access` or `{user-defined-unique-id}-apache.error`) is a recommended practice, but any unique ID will work.
+<12> Refer to {integrations-docs}/apache#logs[Logs] in the Apache HTTP Server integration documentation for the logs available to ingest and exported fields.
+<13> Path to the log files to be monitored.
 
 [[config-file-example-apache-metrics]]
 == Apache HTTP Server metrics
@@ -89,28 +89,27 @@ outputs: <1>
     type: elasticsearch <2>
     hosts:
       - '{elasticsearch-host-url}' <3>
-    username: '${ES_USERNAME}'
-    password: '${ES_PASSWORD}'
+    api_key: "my_api_key" <4>
 agent:
-  download: <4>
+  download: <5>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <5>
+  monitoring: <6>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <6>
-    type: apache/metrics <7>
+inputs: <7>
+    type: apache/metrics <8>
     use_output: default
-    data_stream: <8>
+    data_stream: <9>
       namespace: default
     streams:
-      - id: "insert a unique identifier here" <9>
+      - id: "insert a unique identifier here" <10>
         data_stream: <8>
-          dataset: apache.status <10>
+          dataset: apache.status <11>
           type: metrics
-        metricsets: <11>
+        metricsets: <12>
           - status
         hosts:
           - 'http://127.0.0.1'
@@ -121,11 +120,12 @@ inputs: <6>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
-<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
-<6> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
-<7> For available input types, refer to <<elastic-agent-inputs-list>>.
-<8> Learn about <<data-streams>> for time series data.
-<9> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
-<10> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
-<11> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.
+<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
+<6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
+<7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
+<8> For available input types, refer to <<elastic-agent-inputs-list>>.
+<9> Learn about <<data-streams>> for time series data.
+<10> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-apache.status`) is a recommended practice, but any unique ID will work.
+<11> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
+<12> Refer to {integrations-docs}/apache#metrics[Metrics] in the Apache HTTP Server integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-nginx.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-nginx.asciidoc
@@ -20,31 +20,30 @@ outputs: <1>
     type: elasticsearch <2>
     hosts:
       - '{elasticsearch-host-url}' <3>
-    username: '${ES_USERNAME}'
-    password: '${ES_PASSWORD}'
+    api_key: "my_api_key" <4>
 agent:
-  download: <4>
+  download: <5>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <5>
+  monitoring: <6>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <6>
-  - id: "insert a unique identifier here" <7>
+inputs: <7>
+  - id: "insert a unique identifier here" <8>
     name: nginx-1
-    type: logfile <8>
+    type: logfile <9>
     use_output: default
-    data_stream: <9>
+    data_stream: <10>
       namespace: default
     streams:
-      - id: "insert a unique identifier here" <10>
+      - id: "insert a unique identifier here" <11>
         data_stream:
-          dataset: nginx.access <11>
+          dataset: nginx.access <12>
           type: logs
         ignore_older: 72h
-        paths: <12>
+        paths: <13>
           - /var/log/nginx/access.log*
         tags:
           - nginx-access
@@ -52,12 +51,12 @@ inputs: <6>
           - .gz$
         processors:
           - add_locale: null
-      - id: "insert a unique identifier here" <10>
+      - id: "insert a unique identifier here" <11>
         data_stream:
-          dataset: nginx.error <11>
+          dataset: nginx.error <12>
           type: logs
         ignore_older: 72h
-        paths: <12>
+        paths: <13>
           - /var/log/nginx/error.log*
         tags:
           - nginx-error
@@ -73,16 +72,17 @@ inputs: <6>
 
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
-<3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
-<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
-<6> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
-<7> A user-defined ID to uniquely identify the input stream.
-<8> For available input types, refer to <<elastic-agent-inputs-list>>.
-<9> Learn about <<data-streams>> for time series data.
-<10> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-nginx.access` or `{user-defined-unique-id}-nginx.error`) is a recommended practice, but any unique ID will work.
-<11> Refer to {integrations-docs}/nginx#logs-reference[Logs reference] in the Nginx HTTP integration documentation for the logs available to ingest and exported fields.
-<12> Path to the log files to be monitored.
+<3> The URL of the {es} cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
+<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
+<6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
+<7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
+<8> A user-defined ID to uniquely identify the input stream.
+<9> For available input types, refer to <<elastic-agent-inputs-list>>.
+<10> Learn about <<data-streams>> for time series data.
+<11> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-nginx.access` or `{user-defined-unique-id}-nginx.error`) is a recommended practice, but any unique ID will work.
+<12> Refer to {integrations-docs}/nginx#logs-reference[Logs reference] in the Nginx HTTP integration documentation for the logs available to ingest and exported fields.
+<13> Path to the log files to be monitored.
 
 [discrete]
 [[config-file-example-nginx-metrics]]
@@ -95,29 +95,28 @@ outputs: <1>
     type: elasticsearch <2>
     hosts:
       - '{elasticsearch-host-url}' <3>
-    username: '${ES_USERNAME}'
-    password: '${ES_PASSWORD}'
+    api_key: "my_api_key" <4>
 agent:
-  download: <4>
+  download: <5>
     sourceURI: 'https://artifacts.elastic.co/downloads/'
-  monitoring: <5>
+  monitoring: <6>
     enabled: true
     use_output: default
     namespace: default
     logs: true
     metrics: true
-inputs: <6>
-  - id: "insert a unique identifier here" <7>
-    type: nginx/metrics <8>
+inputs: <7>
+  - id: "insert a unique identifier here" <8>
+    type: nginx/metrics <9>
     use_output: default
-    data_stream: <9>
+    data_stream: <10>
       namespace: default
     streams:
-      - id: "insert a unique identifier here" <10>
-        data_stream: <9>
-          dataset: nginx.stubstatus <11>
+      - id: "insert a unique identifier here" <11>
+        data_stream: <10>
+          dataset: nginx.stubstatus <12>
           type: metrics
-        metricsets: <12>
+        metricsets: <13>
           - stubstatus
         hosts:
           - 'http://127.0.0.1:80'
@@ -128,12 +127,13 @@ inputs: <6>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
-<5> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
-<6> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
-<7> A user-defined ID to uniquely identify the input stream.
-<8> For available input types, refer to <<elastic-agent-inputs-list>>.
-<9> Learn about <<data-streams>> for time series data.
-<10> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-nginx.stubstatus`) is a recommended practice, but any unique ID will work.
-<11> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
-<12> Refer to {integrations-docs}/nginx#metrics-reference[Metrics reference] in the Nginx integration documentation for the type of metrics collected and exported fields.
+<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
+<6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
+<7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
+<8> A user-defined ID to uniquely identify the input stream.
+<9> For available input types, refer to <<elastic-agent-inputs-list>>.
+<10> Learn about <<data-streams>> for time series data.
+<11> Specify a unique ID for each individual input stream. Naming the ID by appending the associated `data_stream` dataset (for example `{user-defined-unique-id}-nginx.stubstatus`) is a recommended practice, but any unique ID will work.
+<12> A user-defined dataset. You can specify anything that makes sense to signify the source of the data.
+<13> Refer to {integrations-docs}/nginx#metrics-reference[Metrics reference] in the Nginx integration documentation for the type of metrics collected and exported fields.

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
@@ -17,8 +17,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    username: elastic
-    password: changeme
+    api_key: "my_api_key"
 
   monitoring:
     type: elasticsearch
@@ -26,10 +25,6 @@ outputs:
     hosts: ["localhost:9200"]
     ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
 -------------------------------------------------------------------------------------
-
-
-Notice that they use different authentication methods. The first one uses a
-username and password pair, and the second one contains an API key.
 
 [NOTE]
 ==============

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -26,6 +26,21 @@ outputs:
     password: changeme
 ----
 
+This example is similar to the previous one, except that it uses
+<<output-elasticsearch-apikey-authentication-settings,token-based (API key) authentication>>:
+
+[source,yaml]
+----
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    api_key: "my_api_key"
+----
+
+NOTE: Token-based authentication is required in a
+link:{serverless-docs}[{serverless-full}] environment.
+
 == {es} output configuration settings
 
 The `elasticsearch` output type supports the following settings, grouped by
@@ -215,7 +230,7 @@ outputs:
 [id="{type}-api_key-setting"]
 `api_key`
 
-| (string) Instead of using a username and password, you can use API keys to
+| (string) Instead of using a username and password, you can use {kibana-ref}/api-keys.html[API keys] to
 secure communication with {es}. The value must be the ID of the API key and the
 API key joined by a colon: `id:api_key`.
 // end::api_key-setting[]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -38,7 +38,7 @@ outputs:
     api_key: "my_api_key"
 ----
 
-NOTE: Token-based authentication is required in a
+NOTE: Token-based authentication is required in an
 link:{serverless-docs}[{serverless-full}] environment.
 
 == {es} output configuration settings


### PR DESCRIPTION
API key authentication is required for Serverless, so we should use it as the default in our configuration examples.

Closes: #653

---

![Screenshot 2023-11-06 at 6 37 03 PM](https://github.com/elastic/ingest-docs/assets/41695641/9b191d3a-6977-422b-8585-d1fcd7605b60)
 . . . 
![Screenshot 2023-11-06 at 6 08 33 PM](https://github.com/elastic/ingest-docs/assets/41695641/e24e21c6-3397-46fc-a006-87e41c55ba7e)

---

![Screenshot 2023-11-06 at 6 34 44 PM](https://github.com/elastic/ingest-docs/assets/41695641/491628b3-bee5-46d0-9b9e-439d4852048b)



