### PR TITLE
Fix agent install path for macOS

### DIFF
--- a/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install-layout.asciidoc
@@ -11,7 +11,7 @@ Main {agent} {fleet} encrypted configuration
 Log files for {agent}footnote:lognumbering[Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.]
 `/Library/Elastic/Agent/data/elastic-agent-*/logs/default/*-json.log`::
 Log files for {beats} shippersfootnote:lognumbering[]
-`/usr/bin/elastic-agent`::
+`/usr/local/bin/elastic-agent`::
 Shell wrapper installed into PATH
 
 You can install {agent} in a custom base path other than `/Library`.  When installing {agent} with the `./elastic-agent install`


### PR DESCRIPTION
Updates the macOS install path as shown:

![Screenshot 2023-11-07 at 11 54 46 AM](https://github.com/elastic/ingest-docs/assets/41695641/ceee5ea5-358e-4fae-9630-5e46e0721f7d)
