### PR TITLE
Change Serverless agent restriction to 10 thousand installs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -54,7 +54,7 @@ Refer to:
 ==== 
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
 
-* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
+* The number of {agents} that may be connected to an {serverless-full} project is limited to 10 thousand.
 * The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 ====
 

--- a/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
@@ -31,10 +31,8 @@ policies, collecting status information, and coordinating actions across
 deployment grows, you can deploy additional {fleet-server}s to manage the
 increased workload.
 
-ifeval::["{serverless-feature-flag}"=="yes"]
 * On-premises {fleet-server} is not currently available for use in an link:{serverless-docs}[{serverless-full}] environment.
 We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.
-endif::[]
 
 The following diagram shows how {agent}s communicate with {fleet-server} to
 retrieve agent policies:

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -29,9 +29,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[leveloffset=+1]
 
-ifeval::["{serverless-feature-flag}"=="yes"]
 include::serverless-restrictions.asciidoc[leveloffset=+2]
-endif::[]
 
 include::beats-agent-comparison.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -20,9 +20,7 @@ image::images/agent-architecture.png[Image showing {agent} collecting data from 
 
 To learn about installation options, refer to <<elastic-agent-installation>>.
 
-ifeval::["{serverless-feature-flag}"=="yes"]
 IMPORTANT: Using {fleet} and {agent} with link:{serverless-docs}[{serverless-full}]? Please note these <<fleet-agent-serverless-restrictions,restrictions>>.
-endif::[]
 
 [discrete]
 [[unified-integrations]]
@@ -143,14 +141,12 @@ It can be started from any available x64 architecture {agent} artifact.
 
 For more information, refer to <<fleet-server>>.
 
-ifeval::["{serverless-feature-flag}"=="yes"]
 .{fleet-server} with {serverless-full}
 ****
 On-premises {fleet-server} is not currently available for use with
 link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
 environment we recommend using {fleet-server} on {ecloud}.
 ****
-endif::[]
 
 [discrete]
 [[fleet-communication-layer]]

--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -11,7 +11,7 @@
 
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], note these differences from use with {ess} and self-managed {es}:
 
-* The number of {agents} that may be connected to an {serverless-full} project is limited to 25 thousand.
+* The number of {agents} that may be connected to an {serverless-full} project is limited to 10 thousand.
 * The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 
 [discrete]


### PR DESCRIPTION
This PR:
 - Enables the Serverless restrictions in the current (8.11) Fleet and Agent docs.
 - On request from Josh, changes the number of supported Elastic Agents from 25,000 to 10,000.

---

[Install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html) (already published)

---

![Screenshot 2023-11-08 at 10 58 06 AM](https://github.com/elastic/ingest-docs/assets/41695641/21ee214f-4f27-48a8-9db8-753ec4c7a391)

---

Fleet and Elastic Agent restrictions for Elastic Cloud serverless (will be published with this PR)

---

![Screenshot 2023-11-08 at 11 07 10 AM](https://github.com/elastic/ingest-docs/assets/41695641/69c7edfe-4b1e-47fb-902f-70a1053e04d9)

