### PR TITLE
Update Fleet/Agent docs for Agent tamper protection (Elastic Defend)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -21,7 +21,7 @@ If you run into problems, refer to <<fleet-troubleshooting>>.
 If you are using DEB or RPM, you can use the package manager to remove the
 installed package.
 
-NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {security-guide}/agent-tamper-protection.html[{elastic-sec} documentation] for more information.
+NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {security-guide}/agent-tamper-protection.html[Agent tamper protection docs] for more information.
 
 [discrete]
 == Remove {agent} files manually

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -21,6 +21,8 @@ If you run into problems, refer to <<fleet-troubleshooting>>.
 If you are using DEB or RPM, you can use the package manager to remove the
 installed package.
 
+NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {elastic-sec} documentation for more information.
+
 [discrete]
 == Remove {agent} files manually
 

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -23,6 +23,9 @@ installed package.
 
 NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {elastic-sec} documentation for more information.
 
+// Include link once elastic/security-docs#4232 is published:
+// Refer to the {security-guide}/agent-tamper-protection.html[{elastic-sec} documentation] for more information.
+
 [discrete]
 == Remove {agent} files manually
 

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -21,10 +21,7 @@ If you run into problems, refer to <<fleet-troubleshooting>>.
 If you are using DEB or RPM, you can use the package manager to remove the
 installed package.
 
-NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {elastic-sec} documentation for more information.
-
-// Include link once elastic/security-docs#4232 is published:
-// Refer to the {security-guide}/agent-tamper-protection.html[{elastic-sec} documentation] for more information.
+NOTE: For hosts enrolled in the {elastic-defend} integration with Agent tamper protection enabled, you'll need to include the uninstall token in the command, using the `--uninstall-token` flag. Refer to the {security-guide}/agent-tamper-protection.html[{elastic-sec} documentation] for more information.
 
 [discrete]
 == Remove {agent} files manually

--- a/docs/en/ingest-management/fleet/fleet.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet.asciidoc
@@ -49,9 +49,7 @@ including {fleet-server} hosts and output settings.
 |<<fleet-enrollment-tokens>>
 |Create and revoke enrollment tokens.
 
-|Uninstall tokens
-// Include link once elastic/security-docs#4232 is published:
-// |{security-guide}/agent-tamper-protection.html[Uninstall tokens]
+|{security-guide}/agent-tamper-protection.html[Uninstall tokens]
 |({elastic-defend} integration only) Access tokens to allow uninstalling {agent} from endpoints with Agent tamper protection enabled.
 
 |<<data-streams>>

--- a/docs/en/ingest-management/fleet/fleet.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet.asciidoc
@@ -50,7 +50,9 @@ including {fleet-server} hosts and output settings.
 |Create and revoke enrollment tokens.
 
 |Uninstall tokens
-|*{elastic-defend} integration only*: Access tokens to allow uninstalling {agent} from endpoints with Agent tamper protection enabled.
+// Include link once elastic/security-docs#4232 is published:
+// |{security-guide}/agent-tamper-protection.html[Uninstall tokens]
+|({elastic-defend} integration only) Access tokens to allow uninstalling {agent} from endpoints with Agent tamper protection enabled.
 
 |<<data-streams>>
 |View data streams and navigate to dashboards to analyze your data.

--- a/docs/en/ingest-management/fleet/fleet.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet.asciidoc
@@ -49,6 +49,9 @@ including {fleet-server} hosts and output settings.
 |<<fleet-enrollment-tokens>>
 |Create and revoke enrollment tokens.
 
+|Uninstall tokens
+|*{elastic-defend} integration only*: Access tokens to allow uninstalling {agent} from endpoints with Agent tamper protection enabled.
+
 |<<data-streams>>
 |View data streams and navigate to dashboards to analyze your data.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/3183 by updating the Fleet & Elastic Agent guide with some notes and links regarding Elastic Defend's Agent tamper protection feature, which is configured and accessed via Agent policy and Fleet UI. Links to [Elastic Security docs](https://www.elastic.co/guide/en/security/master/agent-tamper-protection.html) created via https://github.com/elastic/security-docs/pull/4232.

Previews:
- [Uninstall Elastic Agents from edge hosts](https://ingest-docs_674.docs-preview.app.elstc.co/guide/en/fleet/master/uninstall-elastic-agent.html) — Added note below uninstall Agent commands.
- [Centrally manage Elastic Agents in Fleet](https://ingest-docs_674.docs-preview.app.elstc.co/guide/en/fleet/master/manage-agents-in-fleet.html) — Added "Uninstall tokens" to list of Fleet UI tabs.