### PR TITLE
Add Fleet & Agent 7.17.15 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -49,6 +49,15 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 7.17.15 relnotes
+
+[[release-notes-7.17.15]]
+== {fleet} and {agent} 7.17.15
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.15 relnotes
+
 // begin 7.17.14 relnotes
 
 [[release-notes-7.17.14]]


### PR DESCRIPTION
This adds the 7.17.15 Fleet & Agent Release Notes:

 - Fleet: no RN entries in Kibana PR
 - Fleet Server: No fragments in bc1
 - Elastic Agent: No changelog file for bc1

---

![Screenshot 2023-11-14 at 10 29 25 AM](https://github.com/elastic/ingest-docs/assets/41695641/6e8172f6-11e3-4087-8ebf-d659eef72d6f)