### PR TITLE
Add compression_level setting to Fleet ES output page

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -102,6 +102,10 @@ include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[ta
 
 // =============================================================================
 
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=compression_level-setting]
+
+// =============================================================================
+
 include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=max_retries-setting]
 
 // =============================================================================


### PR DESCRIPTION
This updates the [Advanced YAML Configuration](https://www.elastic.co/guide/en/fleet/8.11/es-output-settings.html#es-output-settings-yaml-config) section of the Elasticsearch output settings page to include the `compression_level` setting (shown below), which previously was documented only in the section for standalone agent outputs.


![Screenshot 2023-11-15 at 10 36 21 AM](https://github.com/elastic/ingest-docs/assets/41695641/2555bef2-e81a-4e21-aff8-fae5c20ae528)

Closes: https://github.com/elastic/platform-docs-team/issues/276