### PR TITLE
Update 8.11.0 and 8.11.1 Release Notes with upgrade issue workaround

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -54,7 +54,60 @@ On the {fleet} UI in {kib} version 8.11.0:
 
 *Impact* +
 
-For a workaround, refer to the steps in this knowledge article: link:https://support.elastic.dev/knowledge/view/86bef2c1[Cannot upgrade Fleet Managed Elastic Agents to 8.11.0 via Fleet UI in 8.11.0].
+You can use the following steps as a workaround:
+
+*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+
+. Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
+. Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.
+
+*When upgrading {agent} currently on any version (more complex, requires API)*
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console. Each of the requests uses version `8.11.0` as an example, but this can be changed to any available version.
++
+* To upgrade a single {agent} to any version, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/<Elastic Agent ID>/upgrade
+{"version":"8.11.0"}
+----
++
+* To upgrade a set of {agents} based on a known set of agent IDs, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "version":"8.11.0",
+  "agents":["<Elastic Agent ID>","<Another Elastic Agent ID>"],
+  "start_time":"2023-11-10T09:41:39.850Z"
+}
+----
+* To upgrade a set of {agents} running a specific policy, and below a specific version (for example, `8.11.0`), run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:<Elastic Fleet Policy ID> and fleet-agents.agent.version<<VERSION>",
+  "version": "8.11.0"
+}
+----
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:uuid1-uuid2-uuid3-uuid4 and fleet-agents.agent.version<8.11.0",
+  "version": "8.11.0"
+}
+----
+
+TIP: To get the {agent} IDs you see in the {fleet} UI you can inspect the Network tab of the Developer Tools of the browser and look for the request `/api/fleet/agents?kuery=...`. The kuery parameter is the KQL query passed from the UI. If you search or select a subset of {agents} using filters in the UI or KQL, you can get the list of agent IDs from such a request.
+
+To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
 
 ====
 
@@ -157,7 +210,60 @@ On the {fleet} UI in {kib} version 8.11.0:
 
 *Impact* +
 
-For a workaround, refer to the steps in this knowledge article: link:https://support.elastic.dev/knowledge/view/86bef2c1[Cannot upgrade Fleet Managed Elastic Agents to 8.11.0 via Fleet UI in 8.11.0].
+You can use the following steps as a workaround:
+
+*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+
+. Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
+. Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.
+
+*When upgrading {agent} currently on any version (more complex, requires API)*
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console. Each of the requests uses version `8.11.0` as an example, but this can be changed to any available version.
++
+* To upgrade a single {agent} to any version, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/<Elastic Agent ID>/upgrade
+{"version":"8.11.0"}
+----
++
+* To upgrade a set of {agents} based on a known set of agent IDs, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "version":"8.11.0",
+  "agents":["<Elastic Agent ID>","<Another Elastic Agent ID>"],
+  "start_time":"2023-11-10T09:41:39.850Z"
+}
+----
+* To upgrade a set of {agents} running a specific policy, and below a specific version (for example, `8.11.0`), run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:<Elastic Fleet Policy ID> and fleet-agents.agent.version<<VERSION>",
+  "version": "8.11.0"
+}
+----
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:uuid1-uuid2-uuid3-uuid4 and fleet-agents.agent.version<8.11.0",
+  "version": "8.11.0"
+}
+----
+
+TIP: To get the {agent} IDs you see in the {fleet} UI you can inspect the Network tab of the Developer Tools of the browser and look for the request `/api/fleet/agents?kuery=...`. The kuery parameter is the KQL query passed from the UI. If you search or select a subset of {agents} using filters in the UI or KQL, you can get the list of agent IDs from such a request.
+
+To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
 
 ====
 


### PR DESCRIPTION
Adds workaround steps to address the known issue affecting Elastic Agent upgrades in 8.11.0 and 8.11.1.

Please see the [documentation preview](https://ingest-docs_687.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.11.0.html#known-issues-8.11.0).

Closes: #686 