### PR TITLE
Change CODEOWNERS to platform-docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/ingest-docs
+* @elastic/platform-docs


### PR DESCRIPTION
Updates CODEOWNERS to the larger @elastic/platform-docs team. This ensures there are reviewers around when folks are absent, etc.