### PR TITLE
Docs for secrets storage in agent outputs

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -282,7 +282,7 @@ will still forward data to the cluster.
 
 When you create an integration policy you often need to provide sensitive information such as an API key or a password. To help ensure that data can't be accessed inappropriately, any secret values used in an integration policy are stored separately from other policy details.
 
-When you add a secret value directly to the {kibana-ref}/fleet-settings-kb.html[`kibana.yml` configuration file], the value is replaced with a reference, with the original value stored outside of {fleet} and {kib} as a secure hash. Note that this type of secret storage requires all configured {fleet-server}s to be on version 8.12.0 or higher.
+As well, after you've saved a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`.
 
 When you save a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`. In order for sensitive values to be stored secretly in {fleet}, all configured {fleet-server}s must be on version 8.10.0 or higher.
 

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -284,7 +284,7 @@ When you create an integration policy you often need to provide sensitive inform
 
 As well, after you've saved a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`.
 
-When you save a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`. In order for sensitive values to be stored secretly in {fleet}, all configured {fleet-server}s must be on version 8.10.0 or higher.
+WARNING: In order for sensitive values to be stored secretly in {fleet}, all configured {fleet-server}s must be on version 8.10.0 or higher.
 
 Though secret values stored in {fleet} are hidden, they can be updated. To update a secret value in an integration policy:
 

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -282,9 +282,9 @@ will still forward data to the cluster.
 
 When you create an integration policy you often need to provide sensitive information such as an API key or a password. To help ensure that data can't be accessed inappropriately, any secret values used in an integration policy are stored separately from other policy details.
 
-As well, after you've saved a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`.
+When you add a secret value directly to the {kibana-ref}/fleet-settings-kb.html[`kibana.yml` configuration file], the value is replaced with a reference, with the original value stored outside of {fleet} and {kib} as a secure hash. Note that this type of secret storage requires all configured {fleet-server}s to be on version 8.12.0 or higher.
 
-WARNING: In order for sensitive values to be stored secretly in {fleet}, all configured {fleet-server}s must be on version 8.10.0 or higher.
+When you save a secret value in {fleet}, the value is hidden in both the {fleet} UI and in the agent policy definition. When you view the agent policy (**Actions -> View policy**), an environment variable is displayed in place of any secret values, for example `${SECRET_0}`. In order for sensitive values to be stored secretly in {fleet}, all configured {fleet-server}s must be on version 8.10.0 or higher.
 
 Though secret values stored in {fleet} are hidden, they can be updated. To update a secret value in an integration policy:
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -78,6 +78,8 @@ When SCRAM is enabled, {agent} uses the link:https://en.wikipedia.org/wiki/Salte
 * SCRAM-SHA-256 - uses the SHA-256 hashing function
 * SCRAM-SHA-512 - uses the SHA-512 hashing function
 
+To prevent unauthorized access your Kafka password is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition.
+
 // ============================================================================
 
 |
@@ -97,6 +99,8 @@ Client SSL certificate key::
 The private key generated for the client. This must be in PKCS 8 key. Copy and paste in the full contents of the certificate key. This is the certificate key that all the agents will use to connect to Kafka.
 +
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here. The agents will pick the certificate key in that location when establishing a connection to Kafka.
+
+To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition.
 
 // ============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -80,6 +80,8 @@ When SCRAM is enabled, {agent} uses the link:https://en.wikipedia.org/wiki/Salte
 
 To prevent unauthorized access your Kafka password is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
+Note that this setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
+
 // ============================================================================
 
 |

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -78,7 +78,7 @@ When SCRAM is enabled, {agent} uses the link:https://en.wikipedia.org/wiki/Salte
 * SCRAM-SHA-256 - uses the SHA-256 hashing function
 * SCRAM-SHA-512 - uses the SHA-512 hashing function
 
-To prevent unauthorized access your Kafka password is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
+To prevent unauthorized access your Kafka password is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // ============================================================================
 
@@ -100,7 +100,7 @@ The private key generated for the client. This must be in PKCS 8 key. Copy and p
 +
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here. The agents will pick the certificate key in that location when establishing a connection to Kafka.
 +
-To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
+To prevent unauthorized access the certificate key is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // ============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -78,7 +78,7 @@ When SCRAM is enabled, {agent} uses the link:https://en.wikipedia.org/wiki/Salte
 * SCRAM-SHA-256 - uses the SHA-256 hashing function
 * SCRAM-SHA-512 - uses the SHA-512 hashing function
 
-To prevent unauthorized access your Kafka password is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition.
+To prevent unauthorized access your Kafka password is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // ============================================================================
 
@@ -99,8 +99,8 @@ Client SSL certificate key::
 The private key generated for the client. This must be in PKCS 8 key. Copy and paste in the full contents of the certificate key. This is the certificate key that all the agents will use to connect to Kafka.
 +
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here. The agents will pick the certificate key in that location when establishing a connection to Kafka.
-
-To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition.
++
+To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // ============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -103,6 +103,8 @@ The private key generated for the client. This must be in PKCS 8 key. Copy and p
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here. The agents will pick the certificate key in that location when establishing a connection to Kafka.
 +
 To prevent unauthorized access the certificate key is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
++
+Note that this setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
 
 // ============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -64,6 +64,8 @@ Copy and paste in the full contents of the certificate key. This is the certific
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here.
 The agents will pick the certificate key in that location when establishing a connection to {ls}.
 
+To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition.
+
 // =============================================================================
 
 |

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -64,7 +64,7 @@ Copy and paste in the full contents of the certificate key. This is the certific
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here.
 The agents will pick the certificate key in that location when establishing a connection to {ls}.
 
-To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
+To prevent unauthorized access the certificate key is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // =============================================================================
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -66,6 +66,8 @@ The agents will pick the certificate key in that location when establishing a co
 
 To prevent unauthorized access the certificate key is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
+Note that this setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
+
 // =============================================================================
 
 |

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -64,7 +64,7 @@ Copy and paste in the full contents of the certificate key. This is the certific
 In cases where each client has a unique certificate key, the local path to that certificate key can be placed here.
 The agents will pick the certificate key in that location when establishing a connection to {ls}.
 
-To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition.
+To prevent unauthorized access the certificate key is stored as a <<agent-policy-secret-values,secret value>>, separate from other policy details. While secret storage is recommended, you can choose to override this setting and store the key as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher.
 
 // =============================================================================
 


### PR DESCRIPTION
This adds docs for agent output secrets. 

@jillguyonnet This is definitely a "first draft". I'm not sure that I've got the "Policy secret values" section (down at the bottom) quite right. Please let me know what you think.

Target: 8.12
Rel: #692

Docs preview links:
 - [Kafka authentication settings](https://ingest-docs_696.docs-preview.app.elstc.co/guide/en/fleet/master/kafka-output-settings.html#_authentication_settings)
 - [Logstash output settings](https://ingest-docs_696.docs-preview.app.elstc.co/guide/en/fleet/master/ls-output-settings.html#ls-output-settings)
---

Update to Logstash and Kafka outputs pages:
![Screenshot 2023-12-05 at 4 43 45 PM](https://github.com/elastic/ingest-docs/assets/41695641/9bc472fe-15be-4727-90f6-50e5329a2558)
