### PR TITLE
Update command reference docs

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -8,7 +8,8 @@
 ++++
 
 {agent} provides commands for running {agent}, managing {fleet-server}, and
-doing common tasks.
+doing common tasks. The commands listed here apply to both <<manage-agents-in-fleet,{fleet}-managed>>
+and <<elastic-agent-configuration,standalone>> {agent}.
 
 NOTE: You might need to log in as a root user (or Administrator on Windows) to
 run these commands. After the {agent} service is installed and running, make
@@ -542,6 +543,8 @@ For more information about custom certificates, refer to <<secure-connections>>.
 `--base-path <string>`::
 Install {agent} in a location other than the <<installation-layout,default>>.
 Specify the custom base path for the install.
++
+The `--base-path` option is not currently supported with {security-guide}/install-endpoint.html[{elastic-defend}].
 
 `--ca-sha256 <string>`::
 Comma-separated list of certificate authority hash pins used for certificate


### PR DESCRIPTION
This updates the [Elastic Agent command reference](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html) page to note that:

 - The `--base-path` install option does not work with Elastic Defend. CC @joepeeples, we should both keep an eye on this restriction, so that we can update the docs if it eventually goes away.
 - All of the commands can be applied to both Fleet-managed and standalone Elastic Agent.

Closes: #688 

---

![Screenshot 2023-11-20 at 11 10 48 AM](https://github.com/elastic/ingest-docs/assets/41695641/a25049d3-6b80-4414-8b8c-14cbef2d895a)

---

![Screenshot 2023-11-20 at 11 17 07 AM](https://github.com/elastic/ingest-docs/assets/41695641/6c0cc804-f2c2-447b-8b93-5d106af7eacb)
