### PR TITLE
Update Agent ID tip in 8.11 upgrade known issue

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -105,7 +105,7 @@ POST kbn:/api/fleet/agents/bulk_upgrade
 }
 ----
 
-TIP: To get the {agent} IDs you see in the {fleet} UI you can inspect the Network tab of the Developer Tools of the browser and look for the request `/api/fleet/agents?kuery=...`. The kuery parameter is the KQL query passed from the UI. If you search or select a subset of {agents} using filters in the UI or KQL, you can get the list of agent IDs from such a request.
+TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and select **View agent** from the **Actions** menu. The agent ID and other details are shown.
 
 To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
 
@@ -261,7 +261,7 @@ POST kbn:/api/fleet/agents/bulk_upgrade
 }
 ----
 
-TIP: To get the {agent} IDs you see in the {fleet} UI you can inspect the Network tab of the Developer Tools of the browser and look for the request `/api/fleet/agents?kuery=...`. The kuery parameter is the KQL query passed from the UI. If you search or select a subset of {agents} using filters in the UI or KQL, you can get the list of agent IDs from such a request.
+TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and select **View agent** from the **Actions** menu. The agent ID and other details are shown.
 
 To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
 


### PR DESCRIPTION
This updates the tip shown near the bottom of the [known issue](https://www.elastic.co/guide/en/fleet/current/release-notes-8.11.0.html#known-issues-8.11.0) affecting agent upgrades, included in the 8.11.0 and 8.11.1 Release Notes.

**original:**
![Screenshot 2023-11-20 at 5 23 30 PM](https://github.com/elastic/ingest-docs/assets/41695641/ec22495b-092f-475d-a401-adc0fd5363c5)

**updated:**
![Screenshot 2023-11-20 at 5 23 57 PM](https://github.com/elastic/ingest-docs/assets/41695641/178c598f-d6fd-4a05-8caa-18db08d1bf50)
