### PR TITLE
Update 8.11.1 Release Notes for upgrade issue

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -41,16 +41,16 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 === Known issues
 
 [[known-issue-169825-8.11.1]]
-.Versions 8.11.0 and 8.11.1 are not in the list of {agent} versions in {kib} {fleet} UI
+.Current stack version is not in the list of {agent} versions in {kib} {fleet} UI
 [%collapsible]
 ====
 
 *Details*
 
-On the {fleet} UI in {kib} version 8.11.0 and 8.11.1:
+On the {fleet} UI in {kib}:
 
-* When adding a new {agent}, the user interface shows version 8.10.4 instead of 8.11.0 or 8.11.1.
-* When attempting to upgrade, the modal window to pick the version shows 8.10.4 as the latest version.
+* When adding a new {agent}, the user interface shows a previous version instead of the current version.
+* When attempting to upgrade, the modal window to pick the version shows an earlier version as the latest version.
 
 *Impact* +
 
@@ -197,16 +197,16 @@ For more information, refer to {agent-pull}3593[#3593].
 === Known issues
 
 [[known-issue-169825-8.11.0]]
-.Version 8.11.0 is not in the list of {agent} versions in {kib} {fleet} UI
+.Current stack version is not in the list of {agent} versions in {kib} {fleet} UI
 [%collapsible]
 ====
 
 *Details*
 
-On the {fleet} UI in {kib} version 8.11.0:
+On the {fleet} UI in {kib}:
 
-* When adding a new {agent}, the user interface shows version 8.10.4 instead of 8.11.0.
-* When attempting to upgrade, the modal window to pick the version shows 8.10.4 as latest version.
+* When adding a new {agent}, the user interface shows a previous version instead of the current version.
+* When attempting to upgrade, the modal window to pick the version shows an earlier version as the latest version.
 
 *Impact* +
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -41,16 +41,16 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 === Known issues
 
 [[known-issue-169825-8.11.1]]
-.Version 8.11.0 is not in the list of {agent} versions in {kib} {fleet} UI
+.Versions 8.11.0 and 8.11.1 are not in the list of {agent} versions in {kib} {fleet} UI
 [%collapsible]
 ====
 
 *Details*
 
-On the {fleet} UI in {kib} version 8.11.0:
+On the {fleet} UI in {kib} version 8.11.0 and 8.11.1:
 
-* When adding a new {agent}, the user interface shows version 8.10.4 instead of 8.11.0.
-* When attempting to upgrade, the modal window to pick the version shows 8.10.4 as latest version.
+* When adding a new {agent}, the user interface shows version 8.10.4 instead of 8.11.0 or 8.11.1.
+* When attempting to upgrade, the modal window to pick the version shows 8.10.4 as the latest version.
 
 *Impact* +
 


### PR DESCRIPTION
This updates the [8.11.1 release notes](https://www.elastic.co/guide/en/fleet/current/release-notes-8.11.1.html) to correct the known upgrade issue (the issue affects both version 8.11.0 and 8.11.1).

![Screenshot 2023-11-22 at 10 25 01 AM](https://github.com/elastic/ingest-docs/assets/41695641/08d8a32e-40fc-41e3-91e9-c0f5d2fbb747)
