### PR TITLE
Expand guidance for integrations and Kibana spaces

### DIFF
--- a/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
@@ -24,7 +24,7 @@ and select an integration. You can select a category to narrow your search.
 
 There are a couple of things to note about installing integration assets:
 
-* {agent} integration assets can be installed only on a single {kib} {kibana-ref}/xpack-spaces.html[space]. If you want to access assets in a different space, you can {kibana-ref}/managing-saved-objects.html#managing-saved-objects-copy-to-space[copy them].
+* {agent} integration assets can be installed only on a single {kib} {kibana-ref}/xpack-spaces.html[space]. If you want to access assets in a different space, you can {kibana-ref}/managing-saved-objects.html#managing-saved-objects-copy-to-space[copy them]. We recommend reviewing the specific integration documentation for any space-related considerations.
 * It's currently not possible to have multiple versions of the same integration installed. When you upgrade an integration, the previous version assets are removed and replaced by the current version.
 
 [discrete]


### PR DESCRIPTION
This just expands the warning about Spaces on the [Install and uninstall Elastic Agent integration assets](https://www.elastic.co/guide/en/fleet/master/install-uninstall-integration-assets.html) page.

![Screenshot 2023-11-22 at 12 40 43 PM](https://github.com/elastic/ingest-docs/assets/41695641/57cb478a-f5a6-42a3-b886-2e3d235aabde)

Rel: #708 