### PR TITLE
Add known issue for PssFreeSnapshot memory leak

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -47,13 +47,15 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 
 *Details*
 
-A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} system integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
+A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} System integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
 
 *Impact* +
 
 This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your integrations.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disablling these datasets will prevent the collection of process-related metrics.
+
+Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
 
 ====
 
@@ -223,7 +225,9 @@ A memory leak has been identified in {metricbeat} on Windows. The leak also affe
 
 This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your integrations.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disablling these datasets will prevent the collection of process-related metrics.
+
+Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -41,7 +41,7 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 === Known issues
 
 [[known-issue-115-8.11.1]]
-.Potential memory leak running {agent} in Windows environments
+.Memory leak running {agent} in Windows environments with the System Integration
 [%collapsible]
 ====
 
@@ -213,7 +213,7 @@ For more information, refer to {agent-pull}3593[#3593].
 === Known issues
 
 [[known-issue-115-8.11.0]]
-.Potential memory leak running {agent} in Windows environments
+.Memory leak running {agent} in Windows environments with the System Integration
 [%collapsible]
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -47,11 +47,13 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 
 *Details*
 
-A potential memory leak has been identified in the {filebeat} and {metricbeat} components of {agent} when running on a Windows system. The leak can cause the component to halt or crash, in a worst case scenario potentially leading to system down time.
+A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} system integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
 
 *Impact* +
 
 This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your integrations.
 
 ====
 
@@ -215,11 +217,13 @@ For more information, refer to {agent-pull}3593[#3593].
 
 *Details*
 
-A potential memory leak has been identified in the {filebeat} and {metricbeat} components of {agent} when running on a Windows system. The leak can cause the component to halt or crash, in a worst case scenario potentially leading to system down time.
+A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} system integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
 
 *Impact* +
 
 This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your integrations.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -40,6 +40,21 @@ Review important information about {fleet-server} and {agent} for the 8.11.1 rel
 [[known-issues-8.11.1]]
 === Known issues
 
+[[known-issue-115-8.11.1]]
+.Potential memory leak running {agent} in Windows environments
+[%collapsible]
+====
+
+*Details*
+
+A potential memory leak has been identified in the {filebeat} and {metricbeat} components of {agent} when running on a Windows system. The leak can cause the component to halt or crash, in a worst case scenario potentially leading to system down time.
+
+*Impact* +
+
+This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+
+====
+
 [[known-issue-169825-8.11.1]]
 .Version 8.11.0 is not in the list of {agent} versions in {kib} {fleet} UI
 [%collapsible]
@@ -152,9 +167,6 @@ Breaking changes can prevent your application from optimal operation and
 performance. Before you upgrade, review the breaking changes, then mitigate the
 impact to your application.
 
-
-
-
 [discrete]
 [[breaking-3712]]
 .Integrations Server / APM unable to boot in specific ECE environments
@@ -195,6 +207,21 @@ For more information, refer to {agent-pull}3593[#3593].
 [discrete]
 [[known-issues-8.11.0]]
 === Known issues
+
+[[known-issue-115-8.11.0]]
+.Potential memory leak running {agent} in Windows environments
+[%collapsible]
+====
+
+*Details*
+
+A potential memory leak has been identified in the {filebeat} and {metricbeat} components of {agent} when running on a Windows system. The leak can cause the component to halt or crash, in a worst case scenario potentially leading to system down time.
+
+*Impact* +
+
+This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+
+====
 
 [[known-issue-169825-8.11.0]]
 .Version 8.11.0 is not in the list of {agent} versions in {kib} {fleet} UI


### PR DESCRIPTION
Adds the known issue (fixed by https://github.com/elastic/elastic-agent-system-metrics/pull/115) to the 8.11.0 and 8.11.1 Release Notes.

@cmacknz @pierrehilbert Do you think there's any workaround guidance that we should add, other than just waiting for 8.11.2?

---

<img width="662" alt="Screenshot 2023-11-23 at 10 35 05 AM" src="https://github.com/elastic/ingest-docs/assets/41695641/0a64516f-2f38-48a0-9f7a-7b68158e1ca2">


