### PR TITLE
Add notice for Windows memory leak issue in 8.11.0 and 8.11.1 RN

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -29,6 +29,8 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.11.1 release.
 
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available. See the <<known-issue-115-8.11.1,known issue>> for more detail.
+
 [discrete]
 [[breaking-changes-8.11.1]]
 === Breaking changes
@@ -155,6 +157,8 @@ The 8.11.1 release Added the following new and notable features.
 == {fleet} and {agent} 8.11.0
 
 Review important information about {fleet-server} and {agent} for the 8.11.0 release.
+
+IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recommended to avoid upgrading to this release and waiting for the upcoming 8.11.2 release in which the issue is resolved. If you've already upgraded to 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 as soon as it becomes available. See the <<known-issue-115-8.11.0,known issue>> for more detail.
 
 [discrete]
 [[security-updates-8.7.x]]


### PR DESCRIPTION
This, recommended by Nima, adds a banner to the 8.11.0 and 8.11.1 release notes to call attention to the known issue affecting Windows systems.

![Screenshot 2023-11-28 at 10 05 38 AM](https://github.com/elastic/ingest-docs/assets/41695641/32e7d810-15bb-4ebd-8034-135b7770086b)
