### PR TITLE
Add GH action for posting docs preview

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,20 @@
+---
+name: docs-preview
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  doc-preview-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/docs/.github/actions/docs-preview@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.event.repository.name }}
+          preview-path: 'guide/en/fleet/index.html'
+          pr: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -12,7 +12,7 @@ jobs:
   doc-preview-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/docs/.github/actions/docs-preview@main
+      - uses: elastic/docs/.github/actions/docs-preview@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
@nkammah Thanks for the explanation of how to add these previews!

I noticed that this line doesn't include any version branch (`current`, `main`, `8.11`), so I hope I've got things right: `preview-path: 'guide/en/fleet/index.html'`

Just for reference, this is a copy of https://github.com/elastic/elasticsearch-py/pull/2389 

