### PR TITLE
Update cluster migration docs with reset policy step

### DIFF
--- a/docs/en/ingest-management/fleet/migrate-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/migrate-elastic-agent.asciidoc
@@ -116,6 +116,38 @@ Using that value for `deployment-id`, the new {fleet-server} host URL is:
 image::images/migrate-agent-fleet-server-host.png[Fleet server hosts showing the new host URL]
 
 [discrete]
+[[migrate-elastic-agent-reset-policy]]
+=== Reset the {ecloud} policy
+
+On your target cluster, certain settings from the original {agent} policies may still be retained, and need to be updated to reference the new cluster.
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console.
+** If you're using {kib} version 8.11 or higher, run:
++
+[source,shell]
+----
+curl --request POST
+--url https://{KIBANA_HOST:PORT}/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud
+-u username:password
+--header 'Content-Type: application/json'
+--header 'kbn-xsrf: as'
+--header 'elastic-api-version: 1'
+----
+** If you're using a {kib} version below 8.11, run:
++
+[source,shell]
+----
+curl --request POST
+--url https://{KIBANA_HOST:PORT}/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud
+-u username:password
+--header 'Content-Type: application/json'
+--header 'kbn-xsrf: as'
+----
++
+After running the command, your {agent} policy settings should all be updated appropriately.
+
+[discrete]
 [[migrate-elastic-agent-confirm-policy]]
 === Confirm your policy settings
 


### PR DESCRIPTION
This updates the [Migrate Fleet-managed agents](https://www.elastic.co/guide/en/fleet/current/migrate-elastic-agent.html) page to include a step to reset the agent policies via a Kibana API command.

Closes: #726 

---

![Screenshot 2023-11-30 at 11 02 44 AM](https://github.com/elastic/ingest-docs/assets/41695641/3203409f-655b-49a2-83f6-35ed3884e89d)
