### PR TITLE
Add pre and post 8.11 versions of reset cloud policy command

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -32,6 +32,18 @@ may experience issues updating. To resolve this problem:
 
 . In a terminal window, run the following `cURL` request, providing your {kib} superuser credentials to reset the {ecloud} agent policy.
 
+** On {kib} versions 8.11 and higher, run:
++
+[source,shell]
+----
+curl -u <username>:<password> --request POST \
+  --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \
+  --header 'content-type: application/json' \
+  --header 'kbn-xsrf: xyz' \
+  --header 'elastic-api-version: 1'
+----
+
+** On {kib} versions below 8.11, run:
 +
 [source,shell]
 ----


### PR DESCRIPTION
This fixes a command on the [Troubleshooting](https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html#agents-in-cloud-stuck-at-updating) page. The command now has an additional header required for v8.11 and higher, so I've included the pre- and post-8.11 versions on the page.

Closes: #727

---

![360807](https://github.com/elastic/ingest-docs/assets/41695641/9a64970e-bfc1-41a9-b2e6-235a23fe5076)
