### PR TITLE
Add Fleet & Agent 8.11.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -56,7 +56,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 * Fix inability to upgrade agents from version 8.10.4 to version 8.11. {kibana-pull}170974[#170974]
 
 {agent}::
-* Fix logging calls that incorrectly use non-f variants and have missing arguments. {agent-pull}3679[#3679]
+* Fix logging calls that have missing arguments. {agent-pull}3679[#3679]
 * Fix {fleet}-managed {agent} ignoring the `agent.download.proxy_url` setting after a policy is updated. {agent-pull}3803[#3803] {agent-issue}3560[#3560]
 * Create a custom `MarshalYAML()` method to properly handle error fields in agent diagnostics. {agent-pull}3835[#3835] {agent-issue}2940[#2940]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -58,7 +58,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 {agent}::
 * Fix logging calls that have missing arguments. {agent-pull}3679[#3679]
 * Fix {fleet}-managed {agent} ignoring the `agent.download.proxy_url` setting after a policy is updated. {agent-pull}3803[#3803] {agent-issue}3560[#3560]
-* Create a custom `MarshalYAML()` method to properly handle error fields in agent diagnostics. {agent-pull}3835[#3835] {agent-issue}2940[#2940]
+* Properly convert component error fields to YAML in agent diagnostics. {agent-pull}3835[#3835] {agent-issue}2940[#2940]
 
 // end 8.11.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
 * <<release-notes-8.11.0>>
 
@@ -21,6 +22,34 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+
+// begin 8.11.2 relnotes
+
+[[release-notes-8.11.2]]
+== {fleet} and {agent} 8.11.2
+
+Review important information about {fleet-server} and {agent} for the 8.11.1 release.
+
+IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2. If you're on an earlier version, avoid upgrading to 8.11.0 or 8.11.1 and update directly to version 8.11.2.
+
+[discrete]
+[[new-features-8.11.2]]
+=== New features
+
+The 8.11.2 release Added the following new and notable features.
+
+{agent}::
+//example * Add the dimensions `component.id` and `component.binary` to {agent} and {beats} monitoring output, to support unique entries for the Time Series Database (TSDB) feature. {agent-pull}3626[#3626] https://github.com/elastic/integrations/issues//7977[#7977]
+
+[discrete]
+[[bug-fixes-8.11.2]]
+=== Bug fixes
+
+{fleet}::
+//example * Append space ID to security solution tag. ({kibana-pull}170789[#170789]).
+
+// end 8.11.2 relnotes
 
 // begin 8.11.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -31,23 +31,34 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.11.1 release.
 
-IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2. If you're on an earlier version, avoid upgrading to 8.11.0 or 8.11.1 and update directly to version 8.11.2.
+IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2.
 
 [discrete]
-[[new-features-8.11.2]]
-=== New features
+[[enhancements-8.11.2]]
+=== Enhancements
 
-The 8.11.2 release Added the following new and notable features.
+{fleet}::
+* Improve UX for policy secrets. {kibana-pull}171405[#171405]
 
 {agent}::
-//example * Add the dimensions `component.id` and `component.binary` to {agent} and {beats} monitoring output, to support unique entries for the Time Series Database (TSDB) feature. {agent-pull}3626[#3626] https://github.com/elastic/integrations/issues//7977[#7977]
+* Add configuration parameters for the Kubernetes `leader_election` provider. {agent-pull}3625[#3625]
+* Update NodeJS version bundled with Heartbeat to v18.18.2. {agent-pull}3655[#3655]
+* Update Go version to 1.20.11. {agent-pull}3748[#3748]
 
 [discrete]
 [[bug-fixes-8.11.2]]
 === Bug fixes
 
 {fleet}::
-//example * Append space ID to security solution tag. ({kibana-pull}170789[#170789]).
+* Support integration secrets in a local package registry with variables `secret: true` and `required: false`. {kibana-pull}172078[#172078]
+* Fix agent metrics retrieval on the agent list page, previously displaying N/A for metrics for users with more than 10 agents. {kibana-pull}172016[#172016]
+* Only add `time_series_metric` if TSDB is enabled. {kibana-pull}171712[#171712]
+* Fix inability to upgrade agents from version 8.10.4 to version 8.11. {kibana-pull}170974[#170974]
+
+{agent}::
+* Fix logging calls that incorrectly use non-f variants and have missing arguments. {agent-pull}3679[#3679]
+* Fix {fleet}-managed {agent} ignoring the `agent.download.proxy_url` setting after a policy is updated. {agent-pull}3803[#3803] {agent-issue}3560[#3560]
+* Create a custom `MarshalYAML()` method to properly handle error fields in agent diagnostics. {agent-pull}3835[#3835] {agent-issue}2940[#2940]
 
 // end 8.11.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -29,7 +29,7 @@ Also see:
 [[release-notes-8.11.2]]
 == {fleet} and {agent} 8.11.2
 
-Review important information about {fleet-server} and {agent} for the 8.11.1 release.
+Review important information about {fleet-server} and {agent} for the 8.11.2 release.
 
 IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2.
 


### PR DESCRIPTION
This adds the 8.11.2 Fleet & Elastic Agent Release Notes:

 - Fleet contents are copied from the [Kibana 8.11.1 Release Notes PR](https://github.com/elastic/kibana/pull/172583).
 - Fleet Server: Nothing added since there are [no Fleet Server fragments in BC1](https://github.com/elastic/fleet-server/tree/6df48cbca66df891d7464b33e0d07808742b3439/changelog/fragment)
 - Elastic Agent contents are from [Elastic Agent BC1 fragments](https://github.com/elastic/elastic-agent/tree/1c21b00aae80a638a00ae5f549fcbcca32890660/changelog/fragments)

See [DOCS PREVIEW](https://ingest-docs_731.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.11.2.html)
Closes: #733 