### PR TITLE
Document presets for performance tuning to ES output

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -81,6 +81,16 @@ output is set in the <<agent-policy,agent policy>>.
 | When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
 Sending monitoring data to a remote {es} cluster is currently not supported.
+
+// =============================================================================
+
+|
+[id="es-agent-performance-tuning"]
+**Performance tuning**
+
+| Choose one of the menu options to tune your {agent} performace when sending data to an {es} output. You can optimize for throughput, scale, latency, or select choose a balanced set of performance specifications. Refer to [Performance tuning settings] for details about the setting values and the potential impact on performance.
+
+You can also use the <<es-output-settings-yaml-config,Advanced YAML configuration>> field to set custom values. Note that if you adjust performance settings through the advanced YAML configuration, the **Performance tuning** option automatically changes to `Custom`.
 |===
 
 [[es-output-settings-yaml-config]]
@@ -116,6 +126,108 @@ include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[ta
 
 include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=worker-setting]
 
+|===
+
+
+[[es-output-settings-performance-tuning-settings]]
+== Performance tuning settings
+
+.Performance tuning preset values
+[cols="1,1,1,1,1"]
+|===
+|Configuration |Balanced|Optimized for Throughput |Optimized for Scale |Optimized for Latency
+
+|`bulk_max_size`
+|1600
+|1600
+|1600
+|50
+
+|`worker`
+|1
+|4
+|1
+|1
+
+|`queue.mem.events`
+|3200
+|12800
+|3200
+|4100
+
+|`flush.min_events`
+|1600
+|1600
+|1600
+|2050
+
+|`flush.timeout`
+|10
+|5
+|20
+|1
+
+|`compression`
+|1
+|1
+|1
+|1
+
+|`idle_timeout`
+|3
+|15
+|1
+|60
+|===
+
+For descriptions of each setting, refer to <<es-output-settings-yaml-config,Advanced YAML configuration>>. For the  `queue.mem.events`, `flush.min_events` and `flush.timeout` settings, refer to the {filebeat-ref}/configuring-internal-queue.html[internal queue configuration settings] in the {filebeat} documentation.
+
+.Potential performance effect
+[cols="1,1,1,1,1"]
+|===
+|Configuration |Balanced|Optimized for Throughput |Optimized for Scale |Optimized for Latency
+
+|Stateful throughput
+|3x
+|5x
+|3x
+|1x
+
+|Serverless throughput
+|5-10x
+|10-20x
+|5-10x
+|1x
+
+|Serverless throughput (relative to stateful)
+|0.2-0.3x
+|0.3-0.5x
+|0.2-0.3x
+|0.1x
+
+|Connections
+|0.3x
+|4x
+|0.04x
+|1x
+
+|Network traffic
+|0.1x
+|0.1x
+|0.05x
+|0.1x
+
+|High-throughput queue latency
+|1x
+|1x
+|1x
+|1x
+
+|Low-throughput queue latency
+|10x
+|5x
+|20x
+|1x
 |===
 
 :type!:

--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -88,7 +88,7 @@ Sending monitoring data to a remote {es} cluster is currently not supported.
 [id="es-agent-performance-tuning"]
 **Performance tuning**
 
-| Choose one of the menu options to tune your {agent} performace when sending data to an {es} output. You can optimize for throughput, scale, latency, or select choose a balanced set of performance specifications. Refer to [Performance tuning settings] for details about the setting values and the potential impact on performance.
+| Choose one of the menu options to tune your {agent} performace when sending data to an {es} output. You can optimize for throughput, scale, latency, or you can choose a balanced (the default) set of performance specifications. Refer to <<es-output-settings-performance-tuning-settings,Performance tuning settings>> for details about the setting values and their potential impact on performance.
 
 You can also use the <<es-output-settings-yaml-config,Advanced YAML configuration>> field to set custom values. Note that if you adjust performance settings through the advanced YAML configuration, the **Performance tuning** option automatically changes to `Custom`.
 |===

--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -88,9 +88,9 @@ Sending monitoring data to a remote {es} cluster is currently not supported.
 [id="es-agent-performance-tuning"]
 **Performance tuning**
 
-| Choose one of the menu options to tune your {agent} performace when sending data to an {es} output. You can optimize for throughput, scale, latency, or you can choose a balanced (the default) set of performance specifications. Refer to <<es-output-settings-performance-tuning-settings,Performance tuning settings>> for details about the setting values and their potential impact on performance.
+| Choose one of the menu options to tune your {agent} performance when sending data to an {es} output. You can optimize for throughput, scale, latency, or you can choose a balanced (the default) set of performance specifications. Refer to <<es-output-settings-performance-tuning-settings,Performance tuning settings>> for details about the setting values and their potential impact on performance.
 
-You can also use the <<es-output-settings-yaml-config,Advanced YAML configuration>> field to set custom values. Note that if you adjust performance settings through the advanced YAML configuration, the **Performance tuning** option automatically changes to `Custom`.
+You can also use the <<es-output-settings-yaml-config,Advanced YAML configuration>> field to set custom values. Note that if you adjust any of the performance settings described in the following **Advanced YAML configuration** section, the **Performance tuning** option automatically changes to `Custom` and cannot be changed.
 |===
 
 [[es-output-settings-yaml-config]]
@@ -198,12 +198,6 @@ For descriptions of each setting, refer to <<es-output-settings-yaml-config,Adva
 |10-20x
 |5-10x
 |1x
-
-|Serverless throughput (relative to stateful)
-|0.2-0.3x
-|0.3-0.5x
-|0.2-0.3x
-|0.1x
 
 |Connections
 |0.3x


### PR DESCRIPTION
This adds two new sections to the Fleet [Elasticsearch output settings](https://ingest-docs_749.docs-preview.app.elstc.co/guide/en/fleet/master/es-output-settings.html) docs page:

1. Description of the new "Performance tuning" option:

    ![screen](https://github.com/elastic/ingest-docs/assets/41695641/fbe7c07e-9b40-4e39-a36d-855ee72c11c1)

2. These two [Performance tuning settings](https://ingest-docs_749.docs-preview.app.elstc.co/guide/en/fleet/master/es-output-settings.html#es-output-settings-performance-tuning-settings) tables, one showing the settings and one showing the potential performance impact.

Closes: #720 