### PR TITLE
Update memory leak known issue to indicate all Beats are affected, updated workaround

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -31,7 +31,7 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.11.2 release.
 
-IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we recommend upgrading to 8.11.2 to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2.
+IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2.
 
 [discrete]
 [[enhancements-8.11.2]]
@@ -85,13 +85,13 @@ IMPORTANT: Due to a memory leak issue, Windows users running {agent} are recomme
 
 *Details*
 
-A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} System integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
+A memory leak has been identified in {beats} on Windows. All {beats} running Elastic Stack version 8.11.0 or 8.11.1 are affected. The leak also affects the {agent} System integration which is implemented with {beats}. The leak will eventually exhaust all memory on the host system, typically after several days.
 
 *Impact* +
 
-This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+This issue has been fixed in version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disablling these datasets will prevent the collection of process-related metrics.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disabling these datasets will prevent the collection of process-related metrics.
 
 Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
 
@@ -247,13 +247,13 @@ For more information, refer to {agent-pull}3593[#3593].
 
 *Details*
 
-A memory leak has been identified in {metricbeat} on Windows. The leak also affects the {agent} system integration which is implemented with {metricbeat}. The leak will eventually exhaust all memory on the host system, typically after several days.
+A memory leak has been identified in {beats} on Windows. All {beats} running Elastic Stack version 8.11.0 or 8.11.1 are affected. The leak also affects the {agent} System integration which is implemented with {beats}. The leak will eventually exhaust all memory on the host system, typically after several days.
 
 *Impact* +
 
 This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disablling these datasets will prevent the collection of process-related metrics.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disabling these datasets will prevent the collection of process-related metrics.
 
 Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -31,7 +31,7 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.11.2 release.
 
-IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2.
+IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 or a higher release to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2 or higher.
 
 [discrete]
 [[enhancements-8.11.2]]
@@ -89,11 +89,19 @@ A memory leak has been identified in {beats} on Windows. All {beats} running Ela
 
 *Impact* +
 
-This issue has been fixed in version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+This issue has been fixed in version 8.11.2. For a Windows environment, we strongly recommend upgrading directly to 8.11.2 or any later release.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disabling these datasets will prevent the collection of process-related metrics.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows and do not want to upgrade, we recommend that you:
+
+. Disable the `process` and `process_summary` metrics in your System integration.
+. Disable logs and metrics collection.
+. Restart {agent}.
+ 
+Note that disabling these datasets will prevent the collection of process-related metrics.
 
 Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
+
+For {beats} we currently do not have a workaround apart from upgrading to 8.12.2 or a later release.
 
 ====
 
@@ -251,11 +259,19 @@ A memory leak has been identified in {beats} on Windows. All {beats} running Ela
 
 *Impact* +
 
-This issue has been fixed in upcoming version 8.11.2. For a Windows environment, we recommend waiting for the official release of 8.11.2 before upgrading from 8.10.x or earlier.
+This issue has been fixed in version 8.11.2. For a Windows environment, we strongly recommend upgrading directly to 8.11.2 or any later release.
 
-If you're already running {agent} version 8.11.0 or 8.11.1 on Windows, we recommend disabling the `process` and `process_summary` metrics in your System integration and restarting {agent}. Note that disabling these datasets will prevent the collection of process-related metrics.
+If you're already running {agent} version 8.11.0 or 8.11.1 on Windows and do not want to upgrade, we recommend that you:
+
+. Disable the `process` and `process_summary` metrics in your System integration.
+. Disable logs and metrics collection.
+. Restart {agent}.
+ 
+Note that disabling these datasets will prevent the collection of process-related metrics.
 
 Another workaround is to downgrade {agent} to a version below 8.11.0. Note that this could result in missing or reindexed logs or metrics as the "state" will not be persisted after {agent} is uninstalled and reinstalled.
+
+For {beats} we currently do not have a workaround apart from upgrading to 8.12.2 or a later release.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -31,7 +31,7 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.11.2 release.
 
-IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 or a higher release to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2 or higher.
+IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 or a later release to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2 or later.
 
 [discrete]
 [[enhancements-8.11.2]]
@@ -259,7 +259,7 @@ A memory leak has been identified in {beats} on Windows. All {beats} running Ela
 
 *Impact* +
 
-This issue has been fixed in version 8.11.2. For a Windows environment, we strongly recommend upgrading directly to 8.11.2 or any later release.
+This issue has been fixed in version 8.11.2. For a Windows environment, we strongly recommend upgrading directly to 8.11.2 or any higher release.
 
 If you're already running {agent} version 8.11.0 or 8.11.1 on Windows and do not want to upgrade, we recommend that you:
 


### PR DESCRIPTION
This updates the 8.11.0 and 8.11.1 Release Notes to indicate that the memory leak issue impacts all Beats running on these versions, rather than just Metricbeat.

It also fixes a small typo and removes the "upcoming" reference to version 8.11.2, since that version is now available.

---

![Screenshot 2023-12-11 at 1 27 17 PM](https://github.com/elastic/ingest-docs/assets/41695641/65ce1c5d-b5ff-44ad-8b82-6d651cae1f9a)



