### PR TITLE
Add restriction that PowerShell ISE is not supported

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -11,10 +11,17 @@
 doing common tasks. The commands listed here apply to both <<manage-agents-in-fleet,{fleet}-managed>>
 and <<elastic-agent-configuration,standalone>> {agent}.
 
-NOTE: You might need to log in as a root user (or Administrator on Windows) to
-run these commands. After the {agent} service is installed and running, make
-sure you run these commands without prepending them with `./` to avoid
+[IMPORTANT] 
+.Restrictions
+====
+Note the following restrictions for running {agent} commands:
+
+* You might need to log in as a root user (or Administrator on Windows) to
+run the commands described here. After the {agent} service is installed and running,
+make sure you run these commands without prepending them with `./` to avoid
 invoking the wrong binary.
+* Running {agent} commands using the Windows PowerShell ISE is not supported.
+====
 
 * <<elastic-agent-diagnostics-command,diagnostics>>
 * <<elastic-agent-enroll-command,enroll>>

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -1,6 +1,20 @@
 [[elastic-agent-installation]]
 = Install {agent}s
 
+[IMPORTANT] 
+.Restrictions
+====
+Note the following restrictions when installing {agent} on your system:
+
+* You can install only a single {agent} per host. Due to the fact that the {agent} may read data sources that are only accessible by a superuser, {agent} will therefore also need to be executed with superuser permissions.
+* You might need to log in as a root user (or Administrator on Windows) to
+run the commands described here. After the {agent} service is installed and running,
+make sure you run these commands without prepending them with `./` to avoid
+invoking the wrong binary.
+* Running {agent} commands using the Windows PowerShell ISE is not supported.
+====
+
+
 NOTE: You can install only a single {agent} per host. Due to the fact that the {agent} may read data sources that 
 are only accessible by a superuser, {agent} will therefore also need to be executed with superuser permissions.
 


### PR DESCRIPTION
This updates the Fleet & Agent Install landing page and Command reference page to note that Windows Powershell ISE is not supported. It also reformats the restrictions on both pages into one large note, rather than separate notes.

Closes #267

---

![screen1](https://github.com/elastic/ingest-docs/assets/41695641/bf09ef93-d0af-4adb-bf83-36f3546b9a3d)

---

![screen2](https://github.com/elastic/ingest-docs/assets/41695641/18d5fbe5-53e3-4441-95ef-d6d55295781f)
