### PR TITLE
Document that remote ES service token can be stored as a secret

### DIFF
--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -264,6 +264,8 @@ To configure a remote {es} cluster for your {agent} monitoring data:
 .. Copy the value for the generated token.
 
 .. Back in your main cluster, paste the value you copied into the output **Service Token** field.
++
+NOTE: To prevent unauthorized access the Service Token password is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher. This setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
 
 . Choose whether or not the remote output should be the default for agent monitoring. When set, {agent}s use this output to send data if no other output is set in the <<agent-policy,agent policy>>.
 

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -265,7 +265,7 @@ To configure a remote {es} cluster for your {agent} monitoring data:
 
 .. Back in your main cluster, paste the value you copied into the output **Service Token** field.
 +
-NOTE: To prevent unauthorized access the Service Token password is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher. This setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
+NOTE: To prevent unauthorized access the {es} Service Token is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher. This setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
 
 . Choose whether or not the remote output should be the default for agent monitoring. When set, {agent}s use this output to send data if no other output is set in the <<agent-policy,agent policy>>.
 


### PR DESCRIPTION
This follows https://github.com/elastic/ingest-docs/pull/696 to add a setting that I missed in the first PR.

That first PR added notes that the following output settings can be stored as secrets:
 - Kafka output password
 - Kafka output SSL key
 - Logstash output SSL key

This PR adds a similar note for the Remote Elasticsearch service token:

Rel: https://github.com/elastic/ingest-docs/issues/692

See [Preview page](https://ingest-docs_762.docs-preview.app.elstc.co/guide/en/fleet/master/monitor-elastic-agent.html#external-elasticsearch-monitoring)

--- 

![screen](https://github.com/elastic/ingest-docs/assets/41695641/05565fd2-a4f9-4318-a08d-3b7b94df53db)



