### PR TITLE
Remove external ES monitoring restriction

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -80,8 +80,6 @@ output is set in the <<agent-policy,agent policy>>.
 
 | When this setting is on, {agent}s use this output to send <<monitor-elastic-agent,agent monitoring data>> if no other output is set in the <<agent-policy,agent policy>>.
 
-Sending monitoring data to a remote {es} cluster is currently not supported.
-
 // =============================================================================
 
 |


### PR DESCRIPTION
Removes "Sending monitoring data to a remote Elasticsearch cluster is currently not supported." The feature is supported as of 8.12.0.

Rel: #530
