### PR TITLE
Add title to Performance Tuning EPS table

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -185,6 +185,7 @@ For descriptions of each setting, refer to <<es-output-settings-yaml-config,Adva
 As mentioned, the `custom` preset allows you to input your own set of parameters for a finer tuning of performance. The following table
 is a summary of a few data points and how the resulting EPS compares to the `Balanced` setting mentioned above.
 
+.Performance tuning: EPS data
 [cols="1,1,1,1,1,1,1"]
 |===
 |worker |bulk_max_size |queue.mem_events |flush.min_events |flush.timeout |idle_timeout |Relative EPS


### PR DESCRIPTION
Adds a title to our second Performance Tuning table in the Elasticsearch output docs.