### PR TITLE
Update release notes with upgrade issues

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -51,7 +51,7 @@ On the {fleet} UI in {kib}:
 
 You can use the following steps as a workaround:
 
-*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+*When upgrading {agent} currently on versions 8.10.3 or earlier (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
 . Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -143,7 +143,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 
 *Details*
 
-When attempting to upgrade an {agent}, {kib} is trying to access https://www.elastic.co/api/product_versions to check the latest version available.
+When attempting to upgrade an {agent}, {kib} tries to access (https://www.elastic.co/api/product_versions)[available versions]. 
 In an air-gapped environment, this call will be blocked and the upgrade flow will therefore be blocked too.
 
 An upgrade for {kib} to version 8.11.3 is necessary to solve the issue.

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -137,7 +137,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 === Known issues
 
 [[known-issue-169826-8.11.2]]
-.Triggering {agent} upgrades from {kib} {fleet} UI in an air-gapped environement will fail
+.Triggering {agent} upgrades from {kib} {fleet} UI in an air-gapped environment will fail
 [%collapsible]
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -146,7 +146,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 When attempting to upgrade an {agent}, {kib} tries to access (https://www.elastic.co/api/product_versions)[available versions]. 
 In an air-gapped environment, this call will be blocked and the upgrade flow will therefore be blocked too.
 
-An upgrade for {kib} to version 8.11.3 is necessary to solve the issue.
+Upgrade {kib} to version 8.11.3 to solve the issue.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -45,7 +45,7 @@ Review important information about {fleet-server} and {agent} for the 8.11.3 rel
 On the {fleet} UI in {kib}:
 
 * When adding a new {agent}, the user interface shows a previous version instead of the current version.
-* When attempting to upgrade, the modal window to pick the version shows an earlier version as the latest version.
+* When you attempt an upgrade, the modal window shows an earlier version as the latest version.
 
 *Impact* +
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -143,7 +143,7 @@ IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects W
 
 *Details*
 
-When attempting to upgrade an {agent}, {kib} tries to access (https://www.elastic.co/api/product_versions)[available versions]. 
+When attempting to upgrade an {agent}, {kib} tries to access https://www.elastic.co/api/product_versions.  
 In an air-gapped environment, this call will be blocked and the upgrade flow will therefore be blocked too.
 
 Upgrade {kib} to version 8.11.3 to solve the issue.

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -32,6 +32,81 @@ Also see:
 Review important information about {fleet-server} and {agent} for the 8.11.3 release.
 
 [discrete]
+[[known-issues-8.11.3]]
+=== Known issues
+
+[[known-issue-169825-8.11.3]]
+.Current stack version is not in the list of {agent} versions in {kib} {fleet} UI
+[%collapsible]
+====
+
+*Details*
+
+On the {fleet} UI in {kib}:
+
+* When adding a new {agent}, the user interface shows a previous version instead of the current version.
+* When attempting to upgrade, the modal window to pick the version shows an earlier version as the latest version.
+
+*Impact* +
+
+You can use the following steps as a workaround:
+
+*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+
+. Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
+. Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.
+
+*When upgrading {agent} currently on any version (more complex, requires API)*
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console. Each of the requests uses version `8.11.0` as an example, but this can be changed to any available version.
++
+* To upgrade a single {agent} to any version, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/<Elastic Agent ID>/upgrade
+{"version":"8.11.0"}
+----
++
+* To upgrade a set of {agents} based on a known set of agent IDs, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "version":"8.11.0",
+  "agents":["<Elastic Agent ID>","<Another Elastic Agent ID>"],
+  "start_time":"2023-11-10T09:41:39.850Z"
+}
+----
+* To upgrade a set of {agents} running a specific policy, and below a specific version (for example, `8.11.0`), run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:<Elastic Fleet Policy ID> and fleet-agents.agent.version<<VERSION>",
+  "version": "8.11.0"
+}
+----
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:uuid1-uuid2-uuid3-uuid4 and fleet-agents.agent.version<8.11.0",
+  "version": "8.11.0"
+}
+----
+
+TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and select **View agent** from the **Actions** menu. The agent ID and other details are shown.
+
+To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
+
+====
+
+[discrete]
 [[security-updates-8.11.3]]
 === Security updates
 
@@ -56,6 +131,24 @@ The 8.11.3 patch release contains a fix for a potential security vulnerability. 
 Review important information about {fleet-server} and {agent} for the 8.11.2 release.
 
 IMPORTANT: The memory leak <<known-issue-115-8.11.1,known issue>> that affects Windows users running {agent} is resolved in this release. If you're currently on {agent} version 8.11.0 or 8.11.1, we strongly recommend upgrading to 8.11.2 or a later release to avoid the issue. If you're on an earlier version, avoid upgrading to version 8.11.0 or 8.11.1 and update directly to version 8.11.2 or later.
+
+[discrete]
+[[known-issues-8.11.2]]
+=== Known issues
+
+[[known-issue-169826-8.11.2]]
+.Triggering {agent} upgrades from {kib} {fleet} UI in an air-gapped environement will fail
+[%collapsible]
+====
+
+*Details*
+
+When attempting to upgrade an {agent}, {kib} is trying to access https://www.elastic.co/api/product_versions to check the latest version available.
+In an air-gapped environment, this call will be blocked and the upgrade flow will therefore be blocked too.
+
+An upgrade for {kib} to version 8.11.3 is necessary to solve the issue.
+
+====
 
 [discrete]
 [[enhancements-8.11.2]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -54,7 +54,7 @@ You can use the following steps as a workaround:
 *When upgrading {agent} currently on versions 8.10.3 or earlier (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
-. Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.
+. Enter `8.11.0` or whichever version you want to upgrade the {agents} to. Do not choose a version later than the version of {kib} or {fleet-server} that you're running.
 
 *When upgrading {agent} currently on any version (more complex, requires API)*
 


### PR DESCRIPTION
Update release notes with the air-gapped upgrade issue and the latest version not available from Fleet