### PR TITLE
Update 8.11.2 release notes with Fleet UI upgrade issue

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -150,6 +150,77 @@ Upgrade {kib} to version 8.11.3 to solve the issue.
 
 ====
 
+[[known-issue-169825-8.11.2]]
+.Current stack version is not in the list of {agent} versions in {kib} {fleet} UI
+[%collapsible]
+====
+
+*Details*
+
+On the {fleet} UI in {kib}:
+
+* When adding a new {agent}, the user interface shows a previous version instead of the current version.
+* When you attempt an upgrade, the modal window shows an earlier version as the latest version.
+
+*Impact* +
+
+You can use the following steps as a workaround:
+
+*When upgrading {agent} currently on versions 8.10.3 or earlier (simpler)*
+
+. Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
+. Enter `8.11.0` or whichever version you want to upgrade the {agents} to. Do not choose a version later than the version of {kib} or {fleet-server} that you're running.
+
+*When upgrading {agent} currently on any version (more complex, requires API)*
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console. Each of the requests uses version `8.11.0` as an example, but this can be changed to any available version.
++
+* To upgrade a single {agent} to any version, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/<Elastic Agent ID>/upgrade
+{"version":"8.11.0"}
+----
++
+* To upgrade a set of {agents} based on a known set of agent IDs, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "version":"8.11.0",
+  "agents":["<Elastic Agent ID>","<Another Elastic Agent ID>"],
+  "start_time":"2023-11-10T09:41:39.850Z"
+}
+----
+* To upgrade a set of {agents} running a specific policy, and below a specific version (for example, `8.11.0`), run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:<Elastic Fleet Policy ID> and fleet-agents.agent.version<<VERSION>",
+  "version": "8.11.0"
+}
+----
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:uuid1-uuid2-uuid3-uuid4 and fleet-agents.agent.version<8.11.0",
+  "version": "8.11.0"
+}
+----
+
+TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and select **View agent** from the **Actions** menu. The agent ID and other details are shown.
+
+To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
+
+====
+
 [discrete]
 [[enhancements-8.11.2]]
 === Enhancements


### PR DESCRIPTION
This updates the 8.11.2 Release Notes with the "latest version not available from Fleet" issue, which was also added to 8.11.3 via https://github.com/elastic/ingest-docs/pull/775. This way, all affected 8.11.x versions are consistent.