### PR TITLE
Add information about elastic agent diagnostics flow

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -329,7 +329,7 @@ elastic-agent diagnostics
 **Get the diagnostics bundle through {fleet}**
 
 {fleet} provides the ability to remotely generate and gather an {agent}'s diagnostics bundle.
-An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state. The diagnostic is sent against the fleet server which in turn puts it into Elasticsearch. Therefore this works with Elastic Agents that are not using the Elasticsearch output as well.
+An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state. The diagnostics are sent to {fleet-server} which in turn adds it into {es}. Therefore, this works even with {agents} that are not using the {es} output.
 To download the diagnostics bundle for local viewing:
 
 . In {kib}, go to **Management -> {fleet} -> Agents**.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -329,7 +329,7 @@ elastic-agent diagnostics
 **Get the diagnostics bundle through {fleet}**
 
 {fleet} provides the ability to remotely generate and gather an {agent}'s diagnostics bundle.
-An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state.
+An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state. The diagnostic is sent against the fleet server which in turn puts it into Elasticsearch. Therefore this works with Elastic Agents that are not using the Elasticsearch output as well.
 To download the diagnostics bundle for local viewing:
 
 . In {kib}, go to **Management -> {fleet} -> Agents**.


### PR DESCRIPTION
I think we should mention how the data is flowing. Otherwise it can be confusing. How will be the elastic agent diagnostics be retrieved, if no Elasticsearch output is defined because logstash is used.

Maybe we can add a simplified version of the flow chart: https://user-images.githubusercontent.com/6766512/190254026-75cc900f-08c6-48c7-8789-56bd8304d933.png  from https://github.com/elastic/ingest-dev/issues/1224

thanks to @ckauf for digging the things up.