### PR TITLE
Improve agent uninstall docs to ensure correct directory

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -894,6 +894,18 @@ Permanently uninstall {agent} from the system.
 You must run this command as the root user (or Administrator on Windows)
 to remove files.
 
+[IMPORTANT] 
+==== 
+Be sure to run the `uninstall` command from the directory where {agent} is installed and not from the directory where you previously ran the `install` command.
+
+--
+
+include::{tab-widgets}/uninstall-widget.asciidoc[]
+
+--
+
+====
+
 [discrete]
 === Synopsis
 

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -5,7 +5,9 @@
 == Uninstall on macOS, Linux, and Windows
 
 To uninstall {agent}, run the `uninstall` command from the directory where
-{agent} is running:
+{agent} is running.
+
+IMPORTANT: Be sure to run the `uninstall` command from the directory where {agent} is running, as shown in the example below, and not from the directory where you previously ran the `install` command. Running the command from the wrong directory can leave the agent in an inconsistent state.
 
 --
 include::{tab-widgets}/uninstall-widget.asciidoc[]


### PR DESCRIPTION
Users sometimes run the agent uninstall command from the wrong location, causing instability, so we need clear warnings in the docs.

Closes: #795 

---

**Update to agent [uninstall instructions](https://www.elastic.co/guide/en/fleet/current/uninstall-elastic-agent.html#uninstall-elastic-agent):**

![Screenshot 2024-01-05 at 1 26 33 PM](https://github.com/elastic/ingest-docs/assets/41695641/efed0670-d59b-4dea-8015-0bf320e1d958)

---

**Update to the agent [`uninstall` command](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-uninstall-command):**
![Screenshot 2024-01-05 at 1 22 00 PM](https://github.com/elastic/ingest-docs/assets/41695641/f8162d77-452b-4e62-9109-70c09da4fba6)
