### PR TITLE
Add Fleet & Agent 8.11.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.11.4>>
 * <<release-notes-8.11.3>>
 * <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
@@ -23,6 +24,98 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.11.4 relnotes
+
+[[release-notes-8.11.4]]
+== {fleet} and {agent} 8.11.4
+
+Review important information about {fleet-server} and {agent} for the 8.11.4 release.
+
+[discrete]
+[[known-issues-8.11.4]]
+=== Known issues
+
+[[known-issue-169825-8.11.4]]
+.Current stack version is not in the list of {agent} versions in {kib} {fleet} UI
+[%collapsible]
+====
+
+*Details*
+
+On the {fleet} UI in {kib}:
+
+* When adding a new {agent}, the user interface shows a previous version instead of the current version.
+* When you attempt an upgrade, the modal window shows an earlier version as the latest version.
+
+*Impact* +
+
+You can use the following steps as a workaround:
+
+*When upgrading {agent} currently on versions 8.10.4 or earlier (simpler)*
+
+. Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
+. Enter `8.11.0` or whichever version you want to upgrade the {agents} to. Do not choose a version later than the version of {kib} or {fleet-server} that you're running.
+
+*When upgrading {agent} currently on any version (more complex, requires API)*
+
+. Open {kib} and navigate to *Management -> Dev Tools*.
+. Choose one of the API requests below and submit it through the console. Each of the requests uses version `8.11.0` as an example, but this can be changed to any available version.
++
+* To upgrade a single {agent} to any version, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/<Elastic Agent ID>/upgrade
+{"version":"8.11.0"}
+----
++
+* To upgrade a set of {agents} based on a known set of agent IDs, run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "version":"8.11.0",
+  "agents":["<Elastic Agent ID>","<Another Elastic Agent ID>"],
+  "start_time":"2023-11-10T09:41:39.850Z"
+}
+----
+* To upgrade a set of {agents} running a specific policy, and below a specific version (for example, `8.11.0`), run:
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:<Elastic Fleet Policy ID> and fleet-agents.agent.version<<VERSION>",
+  "version": "8.11.0"
+}
+----
++
+[source,console]
+----
+POST kbn:/api/fleet/agents/bulk_upgrade
+{
+  "agents": "fleet-agents.policy_id:uuid1-uuid2-uuid3-uuid4 and fleet-agents.agent.version<8.11.0",
+  "version": "8.11.0"
+}
+----
+
+TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and select **View agent** from the **Actions** menu. The agent ID and other details are shown.
+
+To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
+
+====
+
+[discrete]
+[[bug-fixes-8.11.4]]
+=== Bug fixes
+
+//{fleet}::
+//* Fix a 500 error in the {fleet} API when a request for the product versions endpoint throws `ECONNREFUSED`. ({kibana-pull}172850[#172850])
+//* Fix {agent} policy timeout to accept only integers. ({kibana-pull}172222[#172222])
+
+// end 8.11.4 relnotes
 
 // begin 8.11.3 relnotes
 
@@ -51,7 +144,7 @@ On the {fleet} UI in {kib}:
 
 You can use the following steps as a workaround:
 
-*When upgrading {agent} currently on versions 8.10.3 or earlier (simpler)*
+*When upgrading {agent} currently on versions 8.10.4 or earlier (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
 . Enter `8.11.0` or whichever version you want to upgrade the {agents} to. Do not choose a version later than the version of {kib} or {fleet-server} that you're running.
@@ -166,7 +259,7 @@ On the {fleet} UI in {kib}:
 
 You can use the following steps as a workaround:
 
-*When upgrading {agent} currently on versions 8.10.3 or earlier (simpler)*
+*When upgrading {agent} currently on versions 8.10.4 or earlier (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
 . Enter `8.11.0` or whichever version you want to upgrade the {agents} to. Do not choose a version later than the version of {kib} or {fleet-server} that you're running.
@@ -309,7 +402,7 @@ On the {fleet} UI in {kib}:
 
 You can use the following steps as a workaround:
 
-*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+*When upgrading {agent} currently on versions 8.10.4 or lower (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
 . Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.
@@ -479,7 +572,7 @@ On the {fleet} UI in {kib}:
 
 You can use the following steps as a workaround:
 
-*When upgrading {agent} currently on versions 8.10.3 or lower (simpler)*
+*When upgrading {agent} currently on versions 8.10.4 or lower (simpler)*
 
 . Open the {fleet} UI. Under the *Agents* tab select *Upgrade agent* from the actions menu. The version field in the *Upgrade agent* UI allows you to enter any version.
 . Enter `8.11.0` or whichever version you want to upgrade the [agents] to. Do not choose a version above the version of {kib} or {fleet-server} that you're running.

--- a/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.11.asciidoc
@@ -33,6 +33,13 @@ Also see:
 Review important information about {fleet-server} and {agent} for the 8.11.4 release.
 
 [discrete]
+[[security-updates-8.11.4]]
+=== Security updates
+
+{agent}::
+* Updated Go version to 1.20.12. {agent-pull}3885[#3885]
+
+[discrete]
 [[known-issues-8.11.4]]
 === Known issues
 
@@ -106,14 +113,6 @@ TIP: To find the ID for any {agent}, open the **Agents** tab in {fleet} and sele
 To learn more about these requests, refer to the <<fleet-api-docs,{fleet} API documentation>>.
 
 ====
-
-[discrete]
-[[bug-fixes-8.11.4]]
-=== Bug fixes
-
-//{fleet}::
-//* Fix a 500 error in the {fleet} API when a request for the product versions endpoint throws `ECONNREFUSED`. ({kibana-pull}172850[#172850])
-//* Fix {agent} policy timeout to accept only integers. ({kibana-pull}172222[#172222])
 
 // end 8.11.4 relnotes
 


### PR DESCRIPTION
This adds the 8.11.4 Fleet & Elastic Agent Release Notes:

 - Fleet: no items in the [Kibana 8.11.4 Release Notes PR](https://github.com/elastic/kibana/pull/174636)
 - Fleet Server: [no fragments for 8.11.4 BC1](https://github.com/elastic/fleet-server/tree/b154b29c1744825e9295ea6fea63a3d2a3b70c67/changelog/fragment)
 - Elastic Agent: [fragments for 8.11.4 BC1](https://github.com/elastic/elastic-agent/tree/dccb92bd414e420df6844fcd477077bda349b55f/changelog/fragments)

---

![Screenshot 2024-01-08 at 1 25 20 PM](https://github.com/elastic/ingest-docs/assets/41695641/eaa329e7-2a2e-4095-8c98-8e1224e5d9e0)
