### PR TITLE
Update output-elasticsearch.asciidoc

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -535,14 +535,14 @@ Setting `bulk_max_size` to values less than or equal to 0 turns off the
 splitting of batches. When splitting is disabled, the queue decides on the
 number of events to be contained in a batch.
 
-*Default:* `50`
+*Default:* `1600`
 // end::bulk_max_size-setting[]
 
 // =============================================================================
 
 include::output-shared-settings.asciidoc[tag=compression_level-setting]
 
-*Default:* `0`
+*Default:* `1`
 
 // =============================================================================
 


### PR DESCRIPTION
the bulk-max-size and compression defaults are incorrect post 8.12

@kilfoyle I hope this is the right location to make the change that would get reflected for beats and agent. thank you.