### PR TITLE
Add troubleshooting for TSDB runtime issue

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -23,6 +23,16 @@ Have a question? Read our <<fleet-faq,FAQ>>, or contact us in the
 Running {agent} standalone? Also refer to <<debug-standalone-agents>>.
 
 [discrete]
+[[tsdb-illegal-argument]]
+== illegal_argument_exception when TSDB is enabled
+
+When you use an {agent} integration in which TSDB (Time Series Database) is enabled, you may encounter an `illegal_argument_exception` error in the {fleet} UI.
+
+This can occur if you have a component template defined that includes a `_source` attribute, which conflicts with the `_source: syntethic` setting used when TSDB is enabled.
+
+For details about the error and how to resolve it, refer to the section `Runtime fields cannot be used in TSDB indices` in the Innovation Hub article link:https://support.elastic.dev/knowledge/view/9363b9fd[TSDB enabled integrations for {agent}].
+
+[discrete]
 [[agents-in-cloud-stuck-at-updating]]
 == {agent}s hosted on {ecloud} are stuck in `Updating` or `Offline`
 
@@ -648,4 +658,3 @@ curl -u elastic:<password> --request POST \
 == Air-gapped {agent} upgrade can fail due to an inaccessible PGP key
 
 In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issue-3375[PGP key download fails in an air-gapped environment] known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
-


### PR DESCRIPTION
This updates the Fleet & Agent [Troubleshooting page](https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html) with an entry for the "Runtime fields cannot be used in TSDB indices" issue described in this [innovation hub](https://support.elastic.dev/knowledge/view/9363b9fd) article.

![Screenshot 2024-01-12 at 12 50 29 PM](https://github.com/elastic/ingest-docs/assets/41695641/5e854578-5709-43ad-b273-429f4707ffb2)

Closes: https://github.com/elastic/ingest-docs/issues/808
