### PR TITLE
Document Fleet isAirGapped setting

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -22,6 +22,17 @@ When upgrading all the components in an air-gapped environment, it is recommende
 . In {fleet}, issue an upgrade for all the {agent}s.
 
 [discrete]
+[[air-gapped-mode-flag]]
+== Enable air-gapped mode for {fleet}
+
+Set the following property in {kib} to enable air-gapped mode in {fleet}. This allows {fleet} to intelligently skip certain requests or operations that shouldn't be attempted in air-gapped environments.
+
+[source,yaml]
+----
+xpack.fleet.isAirGapped: true
+----
+
+[discrete]
 [[air-gapped-proxy-server]]
 == Use a proxy server to access the {package-registry}
 


### PR DESCRIPTION
This adds a section on the [Air-gapped environments](https://www.elastic.co/guide/en/fleet/current/air-gapped.html) page about the new `isAirGapped` flag in Fleet, added in 8.13.

![Screenshot 2024-01-15 at 10 08 55 AM](https://github.com/elastic/ingest-docs/assets/41695641/b9e4de0d-33c6-41d5-ae20-ba2c3a147caf)


Closes: #790