### PR TITLE
Add troubleshooting note for removed Fleet Server integration

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -645,12 +645,12 @@ Unable to create package policy. Package 'apm' already exists on this agent poli
 
 To work around this problem, you can reset the {ecloud} agent policy with an API call. Note that this will remove any custom integration policies that you've added to the policy, such as Synthetics monitors.
 
-[source,sh]
+[source,shell]
 ----
 curl -u elastic:<password> --request POST \
   --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \
   --header 'Content-Type: application/json' \
-  --header 'kbn-xsrf: xyz' \
+  --header 'kbn-xsrf: xyz'
 ----
 
 [discrete]
@@ -658,3 +658,20 @@ curl -u elastic:<password> --request POST \
 == Air-gapped {agent} upgrade can fail due to an inaccessible PGP key
 
 In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't access a PGP key required to verify the binary signature. For details and a workaround, refer to the link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issue-3375[PGP key download fails in an air-gapped environment] known issue in the version 8.9.0 Release Notes or to the link:https://github.com/elastic/elastic-agent/blob/main/docs/pgp-workaround.md[workaround documentation] in the elastic-agent GitHub repository.
+
+[discrete]
+[[fleet-server-integration-removed]]
+== {agents} unable to connect after removing {fleet-server} integration
+
+When you use {fleet}-managed {agent}, at least one {agent} is running the link:https://docs.elastic.co/integrations/fleet_server[{fleet-server} integration]. In case the policy containing this integration is accidentally removed from {agent], all other agents will not be able to be managed. However, the {agents} will continue to send data to their configured output.
+
+One way to fix this issue is to deploy a new {agent} with the {fleet-server} integration on the same host and port, with TLS certificates that are accepted by the existing {agents}.
+
+To resolve this problem:
+
+. Follow the {agent} <<elastic-agent-installation-steps,installation steps>> as though you are installing a new {agent}. This will give you the CLI arguments that you need.
+
+. Next, you can either:
+
+.. Run the `./elastic-agent enroll` command on the {agent} that previously had the {fleet-server} integration. This effectively returns the agent to use the former {fleet-server} policy.
+.. Run `./elastic-agent install` to reinstall the {agent} from scratch using the former {fleet-server} policy.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -645,7 +645,7 @@ Unable to create package policy. Package 'apm' already exists on this agent poli
 
 To work around this problem, you can reset the {ecloud} agent policy with an API call. Note that this will remove any custom integration policies that you've added to the policy, such as Synthetics monitors.
 
-[source,shell]
+[source,sh]
 ----
 curl -u elastic:<password> --request POST \
   --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -661,17 +661,56 @@ In versions 8.9 and above, an {agent} upgrade may fail when the upgrader can't a
 
 [discrete]
 [[fleet-server-integration-removed]]
-== {agents} unable to connect after removing {fleet-server} integration
+== {agents} are unable to connect after removing the {fleet-server} integration
 
-When you use {fleet}-managed {agent}, at least one {agent} is running the link:https://docs.elastic.co/integrations/fleet_server[{fleet-server} integration]. In case the policy containing this integration is accidentally removed from {agent], all other agents will not be able to be managed. However, the {agents} will continue to send data to their configured output.
+When you use {fleet}-managed {agent}, at least one {agent} needs to be running the link:https://docs.elastic.co/integrations/fleet_server[{fleet-server} integration]. In case the policy containing this integration is accidentally removed from {agent}, all other agents will not be able to be managed. However, the {agents} will continue to send data to their configured output.
 
-One way to fix this issue is to deploy a new {agent} with the {fleet-server} integration on the same host and port, with TLS certificates that are accepted by the existing {agents}.
+There are two approaches to fixing this issue, depending on whether or not the the {agent} that was running the {fleet-server} integration is still installed and healthy (but is now running another policy).
 
-To resolve this problem:
+To recover the {agent}:
 
-. Follow the {agent} <<elastic-agent-installation-steps,installation steps>> as though you are installing a new {agent}. This will give you the CLI arguments that you need.
+. In {kib}, go to **Fleet > Agents**, and click **Add agent**.
 
-. Next, you can either:
+. In the **Add agent** flyout, select an agent policy that contains the **Fleet Server** integration. On Elastic Cloud you can use the **Elastic Cloud agent policy** which includes the integration.
 
-.. Run the `./elastic-agent enroll` command on the {agent} that previously had the {fleet-server} integration. This effectively returns the agent to use the former {fleet-server} policy.
-.. Run `./elastic-agent install` to reinstall the {agent} from scratch using the former {fleet-server} policy.
+. Follow the instructions in the flyout, and stop before running the CLI commands.
+
+. Depending on the state of the original {fleet-server} {agent}, do one of the following:
++
+* **The original {fleet-server} {agent} is still running and healthy**
++
+In this case, you only need to re-enroll the agent with {fleet}:
+
+.. Copy the `elastic-agent install` command from the {kib} UI.
+.. In the command, replace `install` with `enroll`.
+.. In the directory where {agent} is running (for example `/opt/Elastic/Agent/` on Linux), run the command as `root`. 
++
+For example, if {kib} gives you the command:
++
+[source,sh]
+----
+sudo ./elastic-agent install --url=https://fleet-server:8220 --enrollment-token=bXktc3VwZXItc2VjcmV0LWVucm9sbWVudC10b2tlbg==
+----
++
+Instead run:
++
+[source,sh]
+----
+sudo ./elastic-agent enroll --url=https://fleet-server:8220 --enrollment-token=bXktc3VwZXItc2VjcmV0LWVucm9sbWVudC10b2tlbg==
+----
+
+* **The original {fleet-server} {agent} is no longer installed**
++
+In this case, you need to install the agent again:
+
+.. Copy the commands from the {kib} UI. The commands don't need to be changed.
+.. Run the commands in order. The first three commands will download a new {agent} install package, expand the archive, and change directories.
++
+The final command will install {agent}. For example: 
++
+[source,sh]
+----
+sudo ./elastic-agent install --url=https://fleet-server:8220 --enrollment-token=bXktc3VwZXItc2VjcmV0LWVucm9sbWVudC10b2tlbg==
+----
+
+After running these steps your {agents} should be able to connect with {fleet} again.


### PR DESCRIPTION
This adds steps to the [Troubleshooting](https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html) page to resolve when a Fleet Server integration has been removed from an agent policy.

(I also included a super small change to fix a code example in a previous troubleshooting item.)

Closes: #745

PREVIEW

![Screenshot 2024-01-15 at 2 40 01 PM](https://github.com/elastic/ingest-docs/assets/41695641/e3e33b67-e7a6-4253-8683-016b4b57afff)
