### PR TITLE
Remove duplicate restrictions from agent install page

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -14,15 +14,6 @@ invoking the wrong binary.
 * Running {agent} commands using the Windows PowerShell ISE is not supported.
 ====
 
-
-NOTE: You can install only a single {agent} per host. Due to the fact that the {agent} may read data sources that 
-are only accessible by a superuser, {agent} will therefore also need to be executed with superuser permissions.
-
-NOTE: You might need to log in as a root user (or Administrator on Windows) to
-run the commands described here. After the {agent} service is installed and running,
-make sure you run these commands without prepending them with `./` to avoid
-invoking the wrong binary.
-
 You have a few options for installing and managing an {agent}:
 
 * **Install a {fleet}-managed {agent} (recommended)**


### PR DESCRIPTION
This removes restrictions that are documented twice on the [Install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#elastic-agent-installation) page.

![Screenshot 2024-01-16 at 9 23 21 AM](https://github.com/elastic/ingest-docs/assets/41695641/b3399330-b4d3-46da-8280-70887dab4ce9)
