### PR TITLE
Add details about agent namespaces cascading to integration policies

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -43,7 +43,7 @@ Using a namespace makes it easier to search data from a given source by using a 
 You can also use matching patterns to give users access to data when creating user roles.
 // Corresponds to the `data_stream.dataset` field.
 +
-By default the namespace defined for an agent policy is propagated to all integrations in that policy. if you'd like to define a more granular namespace for a policy:
+By default the namespace defined for an {agent} policy is propagated to all integrations in that policy. if you'd like to define a more granular namespace for a policy:
 
 . In {kib}, go to **Management -> Integrations**.
 . Open the **Integration policies** tab.

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -42,6 +42,13 @@ A `namespace` can be up to 100 bytes in length (multibyte characters will count 
 Using a namespace makes it easier to search data from a given source by using a matching pattern.
 You can also use matching patterns to give users access to data when creating user roles.
 // Corresponds to the `data_stream.dataset` field.
++
+By default the namespace defined for an agent policy is propagated to all integrations in that policy. if you'd like to define a more granular namespace for a policy:
+
+. In {kib}, go to **Management -> Integrations**.
+. Open the **Integration policies** tab.
+. From the **Actions** menu next to the integration that you'd like to update, select *Edit integration*.
+. Open the advanced options and update the **Namespace** field. Data streams from the integration will now use the specified namespace rather than the default namespace inherited from the {agent} policy.
 
 The naming scheme separates each components with a `-` character:
 


### PR DESCRIPTION
With https://github.com/elastic/kibana/pull/174776, agent policy namespaces will now cascade to integration policies unless otherwise specified. This adds a paragraph to clarify that behaviour in the docs:

![screen](https://github.com/elastic/ingest-docs/assets/41695641/e98985e3-edbc-4c95-aeca-a1052c8f94d9)


