### PR TITLE
Add known issue for Fleet setup > 1000 policies

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -62,7 +62,7 @@ sudo systemctl start elastic-agent
 
 
 [[known-issue-sec8366]]
-.{fleet} setup fails when thousands of {agent} policies are in place
+.{fleet} setup can fail when there are more than one thousand {agent} policies
 [%collapsible]
 ====
 
@@ -77,7 +77,7 @@ When you set up {fleet} with a very high volume of {agent} policies, one thousan
 		too_many_nested_clauses: Query contains too many nested clauses; maxClauseCount is set to 5173
 ----
 
-The exact number of policies that can cause the error depends in part on the size of the {es} cluster, but generally a volume above one thousand is required.
+The exact number of {agent} policies required to cause the error depends in part on the size of the {es} cluster, but generally it can happen with volumes above approximately one thousand policies.
 
 *Impact* +
 


### PR DESCRIPTION
This updates the 8.12.0 Release Notes with a Fleet setup known issue, as requested [here](https://github.com/elastic/dev/issues/2436#issuecomment-1898254941).

Josh, Kyle, let me know if I've misunderstood the issue.

![Screenshot 2024-01-18 at 9 54 32 AM](https://github.com/elastic/ingest-docs/assets/41695641/d807c925-d95b-40a5-9007-dc746b05f3cc)
