### PR TITLE
Add link to 'communications amongst components' diagram

### DIFF
--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -33,6 +33,8 @@ By default, {agent}s require internet access to perform binary upgrades from
 NOTE: The upgrade feature is not supported for upgrading DEB/RPM packages or
 Docker images.
 
+For a detailed view of the {agent} upgrade process and the interactions between {fleet}, {agent}, and {es}, refer to the link:https://github.com/elastic/elastic-agent/blob/main/docs/upgrades.md[Communications amongst components] diagram in the `elastic-agent` GitHub repository.
+
 To upgrade your {agent}s, go to *Management > {fleet} > Agents* in {kib}. You
 can perform the following upgrade-related actions:
 


### PR DESCRIPTION
This updates the [Elastic Agent upgrade page](https://www.elastic.co/guide/en/fleet/current/upgrade-elastic-agent.html) with a link to this [Communications amongst components](https://github.com/elastic/elastic-agent/blob/main/docs/upgrades.md) diagram, detailing the Elastic Agent upgrade process.

![Screenshot 2024-01-18 at 11 49 18 AM](https://github.com/elastic/ingest-docs/assets/41695641/16fbfced-77e2-4ab2-a8cc-9dfdebb3ed98)

We decided that providing a link is more effective than rendering a graphic, since the latter would be more difficult to maintain as the process changes.

Closes: #823