### PR TITLE
Document possible collisions with '@custom ingest pipelines'

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -179,7 +179,7 @@ Starting in version 8.4, all default ingest pipelines call a non-existent and no
 If left uncreated, this pipeline has no effect on your data. However, if added to a data stream and customized,
 this pipeline can be used for custom data processing, adding fields, sanitizing data, and more.
 
-Staring in version 8.12, ingest pipelines can be configured to process events at various levels of customization.
+Starting in version 8.12, ingest pipelines can be configured to process events at various levels of customization.
 
 `global@custom`::
 Apply processing to all events
@@ -267,6 +267,18 @@ PUT _ingest/pipeline/metrics-system.cpu@custom
 
 Custom pipelines can directly contain processors or you can use the pipeline processor to call other pipelines that can be shared across multiple data streams or integrations.
 These pipelines will persist across all version upgrades.
+
+[[data-streams-pipelines-warning]]
+[WARNING]
+====
+If you have a custom pipeline defined that matches the naming scheme used for any {fleet} custom ingest pipelines, this can produce unintended results. For example, if you have a pipeline named like one of the following:
+
+* `global@custom`
+* `traces@custom`
+* `traces-apm@custom`
+
+The pipeline may be unexpectedly called for other data streams in other integrations. To avoid this problem, avoid the naming schemes defined above when naming your custom pipelines.
+====
 
 See <<data-streams-pipeline-tutorial>> to get started.
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -49,7 +49,7 @@ impact to your application.
 [%collapsible]
 ====
 *Details* +
-Starting in this release, {fleet} <<data-streams-pipelines,ingest pipelines>> can be configured to process events at various levels of customization. If you have a custom pipeline already defined that matches the name of a {fleet} custom ingest pipeline, it may be unexpectedly called for other data streams in other integrations. For more information, refer to {kibana-pull}PR[#170270] and the {fleet} ingest pipelines documentation.
+Starting in this release, {fleet} <<data-streams-pipelines,ingest pipelines>> can be configured to process events at various levels of customization. If you have a custom pipeline already defined that matches the name of a {fleet} custom ingest pipeline, it may be unexpectedly called for other data streams in other integrations. For more information, refer to {kibana-pull}PR[#175254] in which the problem is being investigated, and also the {fleet} ingest pipelines documentation.
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -49,7 +49,7 @@ impact to your application.
 [%collapsible]
 ====
 *Details* +
-Starting in this release, {fleet} <<data-streams-pipelines,ingest pipelines>> can be configured to process events at various levels of customization. If you have a custom pipeline already defined that matches the name of a {fleet} custom ingest pipeline, it may be unexpectedly called for other data streams in other integrations. For more information, refer to {kibana-pull}PR[#175254] in which the problem is being investigated, and also the {fleet} ingest pipelines documentation.
+Starting in this release, {fleet} <<data-streams-pipelines,ingest pipelines>> can be configured to process events at various levels of customization. If you have a custom pipeline already defined that matches the name of a {fleet} custom ingest pipeline, it may be unexpectedly called for other data streams in other integrations. For more information, refer to {kibana-issue}175254[#175254] in which the problem is being investigated, and also the {fleet} ingest pipelines documentation.
 ====
 
 [discrete]

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -36,6 +36,23 @@ Review important information about {fleet-server} and {agent} for the 8.12.0 rel
 * Update Go version to 1.20.12. {agent-pull}3885[#3885]
 
 [discrete]
+[[breaking-changes-8.12.0]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and
+performance. Before you upgrade, review the breaking changes, then mitigate the
+impact to your application.
+
+[discrete]
+[[breaking-170270]]
+.Possible naming collisions with {fleet} custom ingest pipelines
+[%collapsible]
+====
+*Details* +
+Starting in this release, {fleet} <<data-streams-pipelines,ingest pipelines>> can be configured to process events at various levels of customization. If you have a custom pipeline already defined that matches the name of a {fleet} custom ingest pipeline, it may be unexpectedly called for other data streams in other integrations. For more information, refer to {kibana-pull}PR[#170270] and the {fleet} ingest pipelines documentation.
+====
+
+[discrete]
 [[known-issues-8.12.0]]
 === Known issues
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -96,6 +96,7 @@ The 8.12.0 release Added the following new and notable features.
 {fleet}::
 * Add {agent} upgrade states and display each agent's progress through the upgrade process. See <<view-upgrade-status>> for details. ({kibana-pull}167539[#167539])
 * Add support for preconfigured output secrets. ({kibana-pull}172041[#172041])
+* Add support for pipelines to process events at various levels of customization. ({kibana-pull}170270[#170270])
 * Add UI components to create and edit output secrets. ({kibana-pull}169429[#169429])
 * Add support for remote ES output. ({kibana-pull}169252[#169252])
 * Add the ability to specify secrets in outputs. ({kibana-pull}169221[#169221])


### PR DESCRIPTION
This updates the [ingest pipelines](https://www.elastic.co/guide/en/fleet/current/data-streams.html#data-streams-pipelines) section of the docs as well as the Release Notes, to warn about possible naming collisions with the new custom ingest pipelines. 

Closes: #841

@kpollich I'm not sure if I've understood or explained this very well, so I'd appreciate if you can add any changes you think we need. Thanks!

---

**Release Notes "New features" update**
![Screenshot 2024-01-22 at 1 10 06 PM](https://github.com/elastic/ingest-docs/assets/41695641/0c447c5f-47e5-42a4-8611-428ab9116da0)

---

**Release Notes "Breaking changes" update**
![screen](https://github.com/elastic/ingest-docs/assets/41695641/0b37f0ed-2838-4945-a2f9-08d059a9d573)

---

**Data Streams page update**
![screen](https://github.com/elastic/ingest-docs/assets/41695641/78932cf4-a2bc-459e-bad1-4512c1de9c35)
