### PR TITLE
Add troubleshooting for Agent Out of Memory on K8s

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -714,3 +714,20 @@ sudo ./elastic-agent install --url=https://fleet-server:8220 --enrollment-token=
 ----
 
 After running these steps your {agents} should be able to connect with {fleet} again.
+
+[discrete]
+[[agent-oom-k8s]]
+== {agent} Out of Memory errors on Kubernetes
+
+On a Kubernetes environment, {agent} may be terminated due to inadequate memory.
+
+To detect the problem, run the `kubectl describe pod` command and check the results for the following content:
+
+[source,sh]
+----
+       Last State:   Terminated
+       Reason:       OOMKilled
+       Exit Code:    137
+----
+
+To resolve the problem, allocate additional memory to the agent and then restart it.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -719,7 +719,7 @@ After running these steps your {agents} should be able to connect with {fleet} a
 [[agent-oom-k8s]]
 == {agent} Out of Memory errors on Kubernetes
 
-On a Kubernetes environment, {agent} may be terminated due to inadequate memory.
+In a Kubernetes environment, {agent} may be terminated with reason `OOMKilled` due to inadequate available memory.
 
 To detect the problem, run the `kubectl describe pod` command and check the results for the following content:
 


### PR DESCRIPTION
This updates the Fleet & Agent [Troubleshooting page](https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html) with a description of how to detect and resolve OOM errors on Kubernetes.

Closes #839

---

PREVIEW

![Screenshot 2024-01-22 at 2 41 00 PM](https://github.com/elastic/ingest-docs/assets/41695641/531a50b2-1c9a-473e-a7d5-04ad1378580b)

