### PR TITLE
Add instructions to prepare remote clusters with integration assets

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -9,6 +9,8 @@ the data to {es}. Follow the in-product steps to configure the {ls} pipeline.
 
 In the {fleet} <<output-settings,Output settings>>, make sure that the {ls} output type is selected.
 
+Before using the {ls} output, you need to make sure that for any integrations that have been <<add-integration-to-policy,added to your {agent} policy>>, the integration assets have been installed on the destination cluster. Refer to <<install-uninstall-integration-assets,Install and uninstall {agent} integration assets>> for the steps to add integration assets.
+
 To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 
 [cols="2*<a"]

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -286,6 +286,8 @@ After the output is created, you can update an {agent} policy to use the new rem
 
 The remote {es} cluster is now configured.
 
+As a final step before using the remote {es} output, you need to make sure that for any integrations that have been <<add-integration-to-policy,added to your {agent} policy>>, the integration assets have been installed on the remote {es} cluster. Refer to <<install-uninstall-integration-assets,Install and uninstall {agent} integration assets>> for the steps to add integration assets.
+
 [discrete]
 [[fleet-alerting]]
 = Enable alerts and ML jobs based on {fleet} and {agent} status

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -286,8 +286,6 @@ After the output is created, you can update an {agent} policy to use the new rem
 
 The remote {es} cluster is now configured.
 
-As a final step before using the remote {es} output, you need to make sure that for any integrations that have been <<add-integration-to-policy,added to your {agent} policy>>, the integration assets have been installed on the remote {es} cluster. Refer to <<install-uninstall-integration-assets,Install and uninstall {agent} integration assets>> for the steps to add integration assets.
-
 [discrete]
 [[fleet-alerting]]
 = Enable alerts and ML jobs based on {fleet} and {agent} status


### PR DESCRIPTION
This adds a paragraph to the [Logstash output settings](https://www.elastic.co/guide/en/fleet/8.12/ls-output-settings.html) section ~~and the [Send Elastic Agent monitoring data to a remote Elasticsearch cluster](https://www.elastic.co/guide/en/fleet/8.12/monitor-elastic-agent.html#external-elasticsearch-monitoring) section of the docs~~ instructing people to "prepare" the remote cluster by installing integration assets for any integrations added to the agent policy.

Edit: To avoid a merge conflict the remove ES change will instead be added via https://github.com/elastic/ingest-docs/pull/850

Closes: #845 

---
Added to the configure remote Elasticsearch steps:

![Screenshot 2024-01-23 at 10 16 27 AM](https://github.com/elastic/ingest-docs/assets/41695641/715881b5-926c-436e-b3a1-cf8b4c4d8013)

---
Added to the Logstash output docs:
![Screenshot 2024-01-23 at 10 14 06 AM](https://github.com/elastic/ingest-docs/assets/41695641/36336aa0-9367-429b-8f38-b0e44661f81f)



