### PR TITLE
Add docs to configure remote ES output

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
@@ -1,0 +1,62 @@
+:type: output-elasticsearch-fleet-settings
+
+[[remote-elasticsearch-output]]
+= Remote {es} output
+
+Beginning in version 8.12.0, you can send {agent} data to a remote {es} cluster. This is especially useful for data that you want to keep separate and independent from the deployment where you use {fleet} to manage the agents.
+
+A remote {es} cluster supports the same <<es-output-settings,output settings>> as your main {es} cluster.
+
+To configure a remote {es} cluster for your {agent} data:
+
+. In {kib}, go to **Management -> {fleet} -> Settings**.
+
+. In the **Outputs** section, select **Add output**.
+
+. In the **Add new output** flyout, provide a name for the output and select **Remote Elasticsearch** as the output type.
+
+. In the **Hosts** field, add the URL that agents should use to access the remote {es} cluster.
+
+.. To find the remote host address, in the remote cluster open {kib} and go to **Management -> {fleet} -> Settings**.
+
+.. Copy the **Hosts** value for the default output.
+
+.. Back in your main cluster, paste the value you copied into the output **Hosts** field.
+
+. Create a service token to access the remote cluster.
+
+.. Below the **Service Token** field, copy the API request.
+
+.. In the remote cluster, open the {kib} menu and go to **Management -> Dev Tools**.
+
+.. Run the API request.
+
+.. Copy the value for the generated token.
+
+.. Back in your main cluster, paste the value you copied into the output **Service Token** field.
++
+NOTE: To prevent unauthorized access the {es} Service Token is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher. This setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
+
+. Choose whether or not the remote output should be the default for agent integrations or for agent monitoring data. When set, {agent}s use this output to send data if no other output is set in the <<agent-policy,agent policy>>.
+
+. Select which <<es-output-settings-performance-tuning-settings,performance tuning settings>> you'd prefer in order to optimize {agent} for throughput, scale, or latency, or leave the default `balanced` setting.
+
+. Add any <<es-output-settings-yaml-config,advanced YAML configuration settings>> that you'd like for the output.
+
+. Click **Save and apply settings**.
+
+After the output is created, you can update an {agent} policy to use the new remote {es} cluster:
+
+. In {kib}, go to **Management -> {fleet} -> Agent policies**.
+
+. Click the agent policy to edit it, then click **Settings**.
+
+. To send integrations data, set the **Output for integrations** option to use the output that you configured in the previous steps.
+
+. To send {agent} monitoring data, set the **Output for agent monitoring** option to use the output that you configured in the previous steps.
+
+. Click **Save changes**.
+
+The remote {es} cluster is now configured.
+
+As a final step before using the remote {es} output, you need to make sure that for any integrations that have been <<add-integration-to-policy,added to your {agent} policy>>, the integration assets have been installed on the remote {es} cluster. Refer to <<install-uninstall-integration-assets,Install and uninstall {agent} integration assets>> for the steps.

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -90,6 +90,7 @@ The **Add new output** UI opens.
 * <<es-output-settings>>
 * <<ls-output-settings>>
 * <<kafka-output-settings>>
+* <<remote-elasticsearch-output>>
 
 . Click **Save and apply settings**.
 

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -238,53 +238,7 @@ To turn off agent monitoring when creating a new agent policy:
 
 You may want to store all of the health and status data about your {agents} in a remote {es} cluster, so that it's separate and independent from the deployment where you use {fleet} to manage the agents.
 
-To configure a remote {es} cluster for your {agent} monitoring data:
-
-. In {kib}, go to **Management -> {fleet} -> Settings**.
-
-. In the **Outputs** section, select **Add output**.
-
-. In the **Add new output** flyout, provide a name for the output and select **Remote Elasticsearch** as the output type.
-
-. In the **Hosts** field, add the URL that agents should use to access the remote {es} cluster.
-
-.. To find the remote host address, in the remote cluster open {kib} and go to **Management -> {fleet} -> Settings**.
-
-.. Copy the **Hosts** value for the default output.
-
-.. Back in your main cluster, paste the value you copied into the output **Hosts** field.
-
-. Create a service token to access the remote cluster.
-
-.. Below the **Service Token** field, copy the API request.
-
-.. In the remote cluster, open the {kib} menu and go to **Management -> Dev Tools**.
-
-.. Run the API request.
-
-.. Copy the value for the generated token.
-
-.. Back in your main cluster, paste the value you copied into the output **Service Token** field.
-+
-NOTE: To prevent unauthorized access the {es} Service Token is stored as a secret value. While secret storage is recommended, you can choose to override this setting and store the password as plain text in the agent policy definition. Secret storage requires {fleet-server} version 8.12 or higher. This setting can also be stored as a secret value or as plain text for preconfigured outputs. See {kibana-ref}/fleet-settings-kb.html#_preconfiguration_settings_for_advanced_use_cases[Preconfiguration settings] in the {kib} Guide to learn more.
-
-. Choose whether or not the remote output should be the default for agent monitoring. When set, {agent}s use this output to send data if no other output is set in the <<agent-policy,agent policy>>.
-
-. Add any <<es-output-settings-yaml-config,advanced YAML configuration settings>> that you'd like for the output.
-
-. Click **Save and apply settings**.
-
-After the output is created, you can update an {agent} policy to use the new remote {es} cluster:
-
-. In {kib}, go to **Management -> {fleet} -> Agent policies**.
-
-. Click the agent policy to edit it, then click **Settings**.
-
-. Set the **Output for agent monitoring** option to use the output that you configured in the previous steps.
-
-. Click **Save changes**.
-
-The remote {es} cluster is now configured.
+To do so, follow the steps in <<remote-elasticsearch-output>>. After the new output is configured, follow the steps to update the {agent} policy and make sure that the **Output for agent monitoring** setting is enabled. {agent} monitoring data will use the remote {es} output that you configured.
 
 [discrete]
 [[fleet-alerting]]

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -121,6 +121,8 @@ include::fleet/fleet-settings-output-logstash.asciidoc[leveloffset=+3]
 
 include::fleet/fleet-settings-output-kafka.asciidoc[leveloffset=+3]
 
+include::fleet/fleet-settings-remote-elasticsearch.asciidoc[leveloffset=+3]
+
 include::fleet/fleet-manage-agents.asciidoc[leveloffset=+2]
 
 include::fleet/unenroll-elastic-agent.asciidoc[leveloffset=+3]


### PR DESCRIPTION
Previously, the steps to configure a remote Elasticsearch output were documented in the "Agent Monitoring" section of the docs, since I thought only monitoring data was supported.

Since both integrations and monitoring data are now supported, I've made a new Remote Elasticsearch Output page.

![screen](https://github.com/elastic/ingest-docs/assets/41695641/f5d1cfe2-ae9f-44ee-9cb9-621717fdf7c0)

Please see previews:
 - New [Remote Elasticsearch Output](https://ingest-docs_850.docs-preview.app.elstc.co/guide/en/fleet/master/remote-elasticsearch-output.html) page
 - Updated [Send Elastic Agent monitoring data to a remote Elasticsearch cluster](https://ingest-docs_850.docs-preview.app.elstc.co/guide/en/fleet/master/monitor-elastic-agent.html#external-elasticsearch-monitoring) section

Closes: https://github.com/elastic/ingest-docs/issues/848
Closes: #759

