### PR TITLE
Update title for Fleet settings section

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -1,5 +1,5 @@
 [[fleet-settings]]
-= {fleet} UI settings
+= {fleet} settings
 
 NOTE: The settings described here are configurable through the {fleet} UI. Refer to
 {kibana-ref}/fleet-settings-kb.html[{fleet} settings in {kib}] for a list of


### PR DESCRIPTION
Luca rightly points out that the [Fleet UI settings](https://www.elastic.co/guide/en/fleet/current/fleet-settings.html) section title is a bit misleading, so this fixes that problem.