### PR TITLE
Add missing options for Elastic Agent 'enroll' and 'install' commands

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -152,11 +152,17 @@ elastic-agent enroll --url <string>
                      [--certificate-authorities <string>]
                      [--elastic-agent-cert <string>]
                      [--elastic-agent-cert-key <string>]
+                     [--daemon-timeout <duration>]
                      [--delay-enroll]
                      [--force]
-                     [--non-interactive]
+                     [--header <strings>]
                      [--help]
                      [--insecure ]
+                     [--non-interactive]
+                     [--proxy-disabled]
+                     [--proxy-header <strings>]
+                     [--proxy-url <string>]
+                     [--staging <string>]
                      [--tag <string>]
                      [global-flags]
 ----
@@ -174,6 +180,7 @@ elastic-agent enroll --fleet-server-es <string>
                      [--certificate-authorities <string>]
                      [--elastic-agent-cert <string>]
                      [--elastic-agent-cert-key <string>]
+                     [--daemon-timeout <duration>]
                      [--delay-enroll]
                      [--fleet-server-cert <string>] <1>
                      [--fleet-server-cert-key <string>]
@@ -188,9 +195,15 @@ elastic-agent enroll --fleet-server-es <string>
                      [--fleet-server-insecure-http]
                      [--fleet-server-policy <string>]
                      [--fleet-server-port <uint16>]
+                     [--fleet-server-timeout <duration>]
                      [--force]
-                     [--non-interactive]
+                     [--header <strings>]
                      [--help]
+                     [--non-interactive]
+                     [--proxy-disabled]
+                     [--proxy-header <strings>]
+                     [--proxy-url <string>]
+                     [--staging <string>]
                      [--tag <string>]
                      [--url <string>] <3>
                      [global-flags]
@@ -216,7 +229,7 @@ verification.
 `--certificate-authorities <string>`::
 Comma-separated list of root certificates used for server verification.
 
-`--daemon-timeout`<duration>`::
+`--daemon-timeout <duration>`::
 Timeout waiting for {agent} daemon.
 
 `--delay-enroll`::
@@ -310,7 +323,7 @@ This flag is helpful when using automation software or scripted deployments.
 NOTE: If the {agent} is already installed on the host, using `--force` may
 result in unpredictable behavior with duplicate {agent}s appearing in {fleet}.
 
-`--header`<strings>`::
+`--header <strings>`::
 Headers used in communication with elasticsearch.
 
 `--help`::
@@ -328,6 +341,11 @@ verified. The content is encrypted, but the certificate is not verified.
 --
 +
 We strongly recommend that you use a secure connection.
+
+`--non-interactive`::
+Install {agent} in a non-interactive mode. This flag is helpful when
+using automation software or scripted deployments. If {agent} is
+already installed on the host, the installation will terminate.
 
 `--proxy-disabled`::
 Disable proxy support including environment variables.
@@ -534,13 +552,20 @@ elastic-agent install --url <string>
                       [--base-path <string>]
                       [--ca-sha256 <string>]
                       [--certificate-authorities <string>]
+                      [--daemon-timeout <duration>]
+                      [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
                       [--delay-enroll]
                       [--force]
-                      [--non-interactive]
+                      [--header <strings>]
                       [--help]
                       [--insecure ]
+                      [--non-interactive]
+                      [--proxy-disabled]
+                      [--proxy-header <strings>]
+                      [--proxy-url <string>]
+                      [--staging <string>]
                       [--tag <string>]
                       [global-flags]
 ----
@@ -557,6 +582,8 @@ elastic-agent install --fleet-server-es <string>
                       [--base-path <string>]
                       [--ca-sha256 <string>]
                       [--certificate-authorities <string>]
+                      [--daemon-timeout <duration>]
+                      [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
                       [--delay-enroll]
@@ -568,16 +595,22 @@ elastic-agent install --fleet-server-es <string>
                       [--fleet-server-es-ca-trusted-fingerprint <string>] <2>
                       [--fleet-server-es-cert <string>]
                       [--fleet-server-es-cert-key <string>]
+                      [--fleet-server-es-insecure]
                       [--fleet-server-host <string>]
                       [--fleet-server-insecure-http]
                       [--fleet-server-policy <string>]
                       [--fleet-server-port <uint16>]
+                      [--fleet-server-timeout <duration>]
                       [--force]
-                      [--non-interactive]
+                      [--header <strings>]
                       [--help]
+                      [--non-interactive]
+                      [--proxy-disabled]
+                      [--proxy-header <strings>]
+                      [--proxy-url <string>]
+                      [--staging <string>]
                       [--tag <string>]
                       [--url <string>] <3>
-                      [--fleet-server-es-insecure]
                       [global-flags]
 ----
 <1> If no `fleet-server-cert*` flags are specified, {agent} auto-generates a
@@ -607,7 +640,7 @@ verification.
 `--certificate-authorities <string>`::
 Comma-separated list of root certificates used for server verification.
 
-`--daemon-timeout`<duration>`::
+`--daemon-timeout <duration>`::
 Timeout waiting for {agent} daemon.
 
 `--delay-enroll::
@@ -704,7 +737,7 @@ This flag is helpful when using automation software or scripted deployments.
 NOTE: If the {agent} is already installed on the host, using `--force` may
 result in unpredictable behavior with duplicate {agent}s appearing in {fleet}.
 
-`--header`<strings>`::
+`--header <strings>`::
 Headers used in communication with elasticsearch.
 
 `--help`::

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -224,11 +224,9 @@ Delays enrollment to occur on first start of the {agent} service. This setting
 is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for
 example, when you're preparing an image that includes {agent}.
 
-// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert`::
 Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
 
-// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert-key`::
 Private key to use as for the {agent}'s connections to {fleet-server}.
 
@@ -245,9 +243,8 @@ Private key to use for exposed {fleet-server} HTTPS endpoint.
 `--fleet-server-cert-key-passphrase <string>`::
 Path to passphrase file for decrypting {fleet-server}'s private key if an encrypted private key is used.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-client-auth <string>`::
-One of `none`, `optional`, or `required`. Defaults to `none`. {fleet-server}'s `client_authenticatio` option
+One of `none`, `optional`, or `required`. Defaults to `none`. {fleet-server}'s `client_authentication` option
 for client mTLS connections. If `optional`, or `required` is specified, client certificates are verified
 using CAs specified in the `--certificate-authorities` flag.
 
@@ -263,11 +260,9 @@ The SHA-256 fingerprint (hash) of the certificate authority used to self-sign {e
 This fingerprint will be used to verify self-signed certificates presented by {fleet-server} and any inputs started by {agent} for communication.
 This flag is required when using self-signed certificates with {es}.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert`::
 The path to the client certificate that {fleet-server} will use when connecting to {es}.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert-key`::
 The path to the private key that {fleet-server} will use when connecting to {es}.
 
@@ -618,11 +613,9 @@ Timeout waiting for {agent} daemon.
 `--delay-enroll::
 Delays enrollment to occur on first start of the {agent} service.
 
-// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert`::
 Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
 
-// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert-key`::
 Private key to use as for the {agent}'s connections to {fleet-server}.
 
@@ -644,7 +637,6 @@ Private key to use for exposed {fleet-server} HTTPS endpoint.
 `--fleet-server-cert-key-passphrase <string>`::
 Path to passphrase file for decrypting {fleet-server}'s private key if an encrypted private key is used.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-client-auth <string>`::
 One of `none`, `optional`, or `required`. Defaults to `none`. {fleet-server}'s `client_authentication` option
 for client mTLS connections. If `optional`, or `required` is specified, client certificates are verified
@@ -662,11 +654,9 @@ The SHA-256 fingerprint (hash) of the certificate authority used to self-sign {e
 This fingerprint will be used to verify self-signed certificates presented by {fleet-server} and any inputs started by {agent} for communication.
 This flag is required when using self-signed certificates with {es}.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert`::
 The path to the client certificate that {fleet-server} will use when connecting to {es}.
 
-// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert-key`::
 The path to the private key that {fleet-server} will use when connecting to {es}.
 
@@ -747,7 +737,7 @@ Proxy headers used with CONNECT request.
 `--proxy-url <string>`::
 Configures the proxy URL.
 
-`--staging <string>::
+`--staging <string>`::
 Configures agent to download artifacts from a staging build.
 
 `--tag <strings>`::

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -216,16 +216,21 @@ verification.
 `--certificate-authorities <string>`::
 Comma-separated list of root certificates used for server verification.
 
-`--elastic-agent-cert`::
-Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
-
-`--elastic-agent-cert-key`::
-Private key to use as for the {agent}'s connections to {fleet-server}.
+`--daemon-timeout`<duration>`::
+Timeout waiting for {agent} daemon.
 
 `--delay-enroll`::
 Delays enrollment to occur on first start of the {agent} service. This setting
 is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for
 example, when you're preparing an image that includes {agent}.
+
+// NOT IN COMMAND OUTPUT
+`--elastic-agent-cert`::
+Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
+
+// NOT IN COMMAND OUTPUT
+`--elastic-agent-cert-key`::
+Private key to use as for the {agent}'s connections to {fleet-server}.
 
 `--enrollment-token <string>`::
 Enrollment token to use to enroll {agent} into {fleet}. You can use
@@ -240,6 +245,7 @@ Private key to use for exposed {fleet-server} HTTPS endpoint.
 `--fleet-server-cert-key-passphrase <string>`::
 Path to passphrase file for decrypting {fleet-server}'s private key if an encrypted private key is used.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-client-auth <string>`::
 One of `none`, `optional`, or `required`. Defaults to `none`. {fleet-server}'s `client_authenticatio` option
 for client mTLS connections. If `optional`, or `required` is specified, client certificates are verified
@@ -257,9 +263,11 @@ The SHA-256 fingerprint (hash) of the certificate authority used to self-sign {e
 This fingerprint will be used to verify self-signed certificates presented by {fleet-server} and any inputs started by {agent} for communication.
 This flag is required when using self-signed certificates with {es}.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert`::
 The path to the client certificate that {fleet-server} will use when connecting to {es}.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert-key`::
 The path to the private key that {fleet-server} will use when connecting to {es}.
 
@@ -297,6 +305,9 @@ Mutually exclusive with `--fleet-server-service-token-path`.
 Service token file to use for communication with {es}.
 Mutually exclusive with `--fleet-server-service-token`.
 
+`--fleet-server-timeout <duration>`::
+Timeout waiting for {fleet-server} to be ready to start enrollment.
+
 `--force`::
 Force overwrite of current configuration without prompting for confirmation.
 This flag is helpful when using automation software or scripted deployments.
@@ -304,10 +315,8 @@ This flag is helpful when using automation software or scripted deployments.
 NOTE: If the {agent} is already installed on the host, using `--force` may
 result in unpredictable behavior with duplicate {agent}s appearing in {fleet}.
 
-`--non-interactive`::
-Install {agent} in a non-interactive mode. This flag is helpful when
-using automation software or scripted deployments. If {agent} is
-already installed on the host, the installation will terminate.
+`--header`<strings>`::
+Headers used in communication with elasticsearch.
 
 `--help`::
 Show help for the `enroll` command.
@@ -324,6 +333,18 @@ verified. The content is encrypted, but the certificate is not verified.
 --
 +
 We strongly recommend that you use a secure connection.
+
+`--proxy-disabled`::
+Disable proxy support including environment variables.
+
+`--proxy-header <strings>`::
+Proxy headers used with CONNECT request.
+
+`--proxy-url <string>`::
+Configures the proxy URL.
+
+`--staging <string>`::
+Configures agent to download artifacts from a staging build.
 
 `--tag <string>`::
 A comma-separated list of tags to apply to {fleet}-managed {agent}s. You can
@@ -591,9 +612,17 @@ verification.
 `--certificate-authorities <string>`::
 Comma-separated list of root certificates used for server verification.
 
+`--daemon-timeout`<duration>`::
+Timeout waiting for {agent} daemon.
+
+`--delay-enroll::
+Delays enrollment to occur on first start of the {agent} service.
+
+// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert`::
 Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
 
+// NOT IN COMMAND OUTPUT
 `--elastic-agent-cert-key`::
 Private key to use as for the {agent}'s connections to {fleet-server}.
 
@@ -615,6 +644,7 @@ Private key to use for exposed {fleet-server} HTTPS endpoint.
 `--fleet-server-cert-key-passphrase <string>`::
 Path to passphrase file for decrypting {fleet-server}'s private key if an encrypted private key is used.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-client-auth <string>`::
 One of `none`, `optional`, or `required`. Defaults to `none`. {fleet-server}'s `client_authentication` option
 for client mTLS connections. If `optional`, or `required` is specified, client certificates are verified
@@ -632,9 +662,11 @@ The SHA-256 fingerprint (hash) of the certificate authority used to self-sign {e
 This fingerprint will be used to verify self-signed certificates presented by {fleet-server} and any inputs started by {agent} for communication.
 This flag is required when using self-signed certificates with {es}.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert`::
 The path to the client certificate that {fleet-server} will use when connecting to {es}.
 
+// NOT IN COMMAND OUTPUT
 `--fleet-server-es-cert-key`::
 The path to the private key that {fleet-server} will use when connecting to {es}.
 
@@ -672,6 +704,9 @@ Mutually exclusive with `--fleet-server-service-token-path`.
 Service token file to use for communication with {es}.
 Mutually exclusive with `--fleet-server-service-token`.
 
+`--fleet-server-timeout <duration>`::
+Timeout waiting for {fleet-server} to be ready to start enrollment.
+
 `--force`::
 Force overwrite of current configuration without prompting for confirmation.
 This flag is helpful when using automation software or scripted deployments.
@@ -679,10 +714,8 @@ This flag is helpful when using automation software or scripted deployments.
 NOTE: If the {agent} is already installed on the host, using `--force` may
 result in unpredictable behavior with duplicate {agent}s appearing in {fleet}.
 
-`--non-interactive`::
-Install {agent} in a non-interactive mode. This flag is helpful when
-using automation software or scripted deployments. If {agent} is
-already installed on the host, the installation will terminate.
+`--header`<strings>`::
+Headers used in communication with elasticsearch.
 
 `--help`::
 Show help for the `enroll` command.
@@ -700,7 +733,24 @@ verified. The content is encrypted, but the certificate is not verified.
 +
 We strongly recommend that you use a secure connection.
 
-`--tag <string>`::
+`--non-interactive`::
+Install {agent} in a non-interactive mode. This flag is helpful when
+using automation software or scripted deployments. If {agent} is
+already installed on the host, the installation will terminate.
+
+`--proxy-disabled`::
+Disable proxy support including environment variables.
+
+`--proxy-header <strings>`::
+Proxy headers used with CONNECT request.
+
+`--proxy-url <string>`::
+Configures the proxy URL.
+
+`--staging <string>::
+Configures agent to download artifacts from a staging build.
+
+`--tag <strings>`::
 A comma-separated list of tags to apply to {fleet}-managed {agent}s. You can
 use these tags to filter the list of agents in {fleet}.
 +


### PR DESCRIPTION
This adds options that were missing in the docs for the Elastic Agent `enroll` and `install` commands. Options have been confirmed using `sudo elastic-agent install -h` and `sudo elastic-agent enroll -h` in an 8.12 image. This also re-orders a few items to be alphabetical.

__DOCS PREVIEW__
 - [elastic-agent enroll](https://ingest-docs_bk_860.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-cmd-options.html#elastic-agent-enroll-command)
 - [elastic-agent install](https://ingest-docs_bk_860.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-cmd-options.html#elastic-agent-install-command)



__ADDITIONS__

`enroll` command:
--daemon-timeout
--fleet-server-timeout
--header
--proxy-disabled
--proxy-header
--proxy-url
--staging

`install` command:
--daemon-timeout
--delay-enroll
--fleet-server-timeout
--header
--proxy-disabled
--proxy-header
--proxy-url
--staging


Closes: #290
