### PR TITLE
Update ingest pipeline docs with new integrations pattern naming

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -223,14 +223,14 @@ PUT _ingest/pipeline/logs@custom
 }
 ----
 
-`${type}-${package}`::
+`${type}-${package}.integration`::
 Apply processing to all events of a given type in an integration
 +
-For example, the following request creates a `logs-nginx@custom` pipeline that adds a new field `my-nginx-field` for all log events in the Nginx integration:
+For example, the following request creates a `logs-nginx.integration@custom` pipeline that adds a new field `my-nginx-field` for all log events in the Nginx integration:
 +
 [source,console]
 ----
-PUT _ingest/pipeline/logs-nginx@custom
+PUT _ingest/pipeline/logs-nginx.integration@custom
 {
   "processors": [
     {
@@ -243,6 +243,9 @@ PUT _ingest/pipeline/logs-nginx@custom
   ]
 }
 ----
++
+Note that `.integration` is included in the pipeline pattern to avoid possible collision with existing dataset pipelines.
+
 
 `${type}-${dataset}`::
 Apply processing to a specific dataset.


### PR DESCRIPTION
Note to self: Wait for 8.12.1 to merge.

This updates the "ingest pipelines" section of the data streams docs page to indicate the new naming pattern for custom integrations pipelines.

See [DOCS PREVIEW](https://ingest-docs_bk_863.docs-preview.app.elstc.co/guide/en/fleet/master/data-streams.html#data-streams-pipelines).

Rel: #861 

---

![screen](https://github.com/elastic/ingest-docs/assets/41695641/cce6a43d-c01b-4382-839a-05f14f9415f2)



