### PR TITLE
Add Kafka output settings to standalone agent docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-configuration.asciidoc
@@ -35,7 +35,10 @@ A default output configuration is required.
 
 * <<elasticsearch-output>>
 * <<logstash-output>>
+* <<kafka-output>>
 
 include::output-elasticsearch.asciidoc[leveloffset=+1]
 
 include::output-logstash.asciidoc[leveloffset=+1]
+
+include::output-kafka.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
@@ -1,0 +1,551 @@
+:type: output-kafka
+
+[[kafka-output]]
+= Kafka output
+
+++++
+<titleabbrev>Kafka</titleabbrev>
+++++
+
+The Kafka output sends events to Apache Kafka.
+
+*Compatibility:* This output can connect to Kafka version 0.8.2.0 and later.
+Older versions might work as well, but are not supported.
+
+This example configures a Kafka output called `kafka-output` in the
+`elastic-agent.yml` file, with some basic settings as described further in:
+
+[source,yaml]
+----
+outputs:
+  kafka-output:
+    type: kafka
+    hosts:
+      - 'kafka1:9092'
+      - 'kafka2:9092'
+      - 'kafka3:9092'
+    client_id: Elastic
+    version: 1.0.0
+    compression: gzip
+    compression_level: 4
+    username: <my-kafka-username>
+    password: <my-kakfa-password>
+    sasl:
+      mechanism: SCRAM-SHA-256
+    partition:
+      round_robin:
+        group_events: 1
+    topics:
+      - topic: '%{[fields.log_topic]}'
+    headers: []
+    timeout: 30
+    broker_timeout: 30
+    required_acks: 1
+    ssl:
+      verification_mode: full
+----
+
+== Kafka output configuration settings
+
+The `kafka` output supports the following settings, grouped by category.
+Many of these settings have sensible defaults that allow you to run {agent} with
+minimal configuration.
+
+* <<output-kafka-commonly-used-settings>>
+* <<output-kafka-authentication-settings>>
+* <<output-kafka-memory-queue-settings>>
+* <<output-kafka-topics-settings>>
+* <<output-kafka-partition-settings>>
+* <<output-kafka-header-settings>>
+* <<output-kafka-configuration-settings>>
+
+[[output-kafka-commonly-used-settings]]
+== Commonly used settings
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+include::output-shared-settings.asciidoc[tag=enabled-setting]
+
+// =============================================================================
+
+|
+[id="kafka-hosts-setting"]
+`hosts`
+
+| The addresses your {agent}s will use to connect to one or more Kafka brokers. 
+
+Following is an example `hosts` setting with three hosts defined:
+
+[source,yaml]
+----
+    hosts:
+      - 'localhost:9092'
+      - 'mykafkahost01:9092'
+      - 'mykafkahost02:9092'
+----
+
+// =============================================================================
+
+|
+[id="kafka-version-setting"]
+`version`
+
+| Kafka protocol version that {agent} will request when connecting. Defaults to 1.0.0.
+
+The protocol version controls the Kafka client features available to {agent}; it does not prevent {agent} from connecting to Kafka versions newer than the protocol version.
+
+|===
+
+[[output-kafka-authentication-settings]]
+== Authentication settings
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+|
+[id="kafka-username-setting"]
+`username`
+
+| The username for connecting to Kafka. If username is configured, the password must be configured as well.
+
+// =============================================================================
+
+|
+[id="kafka-password-setting"]
+`password`
+
+| The password for connecting to Kafka.
+
+// =============================================================================
+
+|
+[id="kafka-sasl.mechanism-setting"]
+`sasl.mechanism`
+
+| The SASL mechanism to use when connecting to Kafka. It can be one of:
+
+* `PLAIN` for SASL/PLAIN.
+* `SCRAM-SHA-256` for SCRAM-SHA-256.
+* `SCRAM-SHA-512` for SCRAM-SHA-512.
+
+If `sasl.mechanism` is not set, `PLAIN` is used if `username` and `password` are provided. Otherwise, SASL authentication is disabled.
+
+// =============================================================================
+
+|
+[id="kafka-ssl-setting"]
+`ssl`
+
+| When sending data to a secured cluster through the `kafka`
+output, {agent} can use SSL/TLS. For a list of available settings, refer to
+<<elastic-agent-ssl-configuration>>, specifically the settings under
+<<common-ssl-options>> and <<client-ssl-options>>.
+
+|===
+
+[[output-kafka-memory-queue-settings]]
+== Memory queue settings
+
+The memory queue keeps all events in memory.
+
+The memory queue waits for the output to acknowledge or drop events. If
+the queue is full, no new events can be inserted into the memory queue. Only
+after the signal from the output will the queue free up space for more events to be accepted.
+
+The memory queue is controlled by the parameters `flush.min_events` and `flush.timeout`. If
+`flush.timeout` is `0s` or `flush.min_events` is `0` or `1` then events can be sent by the output as
+soon as they are available. If the output supports a `bulk_max_size` parameter it controls the
+maximum batch size that can be sent.
+
+If `flush.min_events` is greater than `1` and `flush.timeout` is greater than `0s`, events will only
+be sent to the output when the queue contains at least `flush.min_events` events or the
+`flush.timeout` period has expired. In this mode the maximum size batch that that can be sent by the
+output is `flush.min_events`. If the output supports a `bulk_max_size` parameter, values of
+`bulk_max_size` greater than `flush.min_events` have no effect. The value of `flush.min_events`
+should be evenly divisible by `bulk_max_size` to avoid sending partial batches to the output.
+
+This sample configuration forwards events to the output if 512 events are available or the oldest
+available event has been waiting for 5s in the queue:
+
+[source,yaml]
+------------------------------------------------------------------------------
+queue.mem:
+  events: 4096
+  flush.min_events: 512
+  flush.timeout: 5s
+------------------------------------------------------------------------------
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+include::output-shared-settings.asciidoc[tag=events-setting]
+
+// =============================================================================
+
+include::output-shared-settings.asciidoc[tag=flush.min_events-setting]
+
+// =============================================================================
+
+include::output-shared-settings.asciidoc[tag=flush.timeout-setting]
+
+|===
+
+
+
+[[output-kafka-topics-settings]]
+== Topics settings
+
+Use these options to dynamically set the Kafka topic for each {agent} event.
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+|
+[id="kafka-topic-setting"]
+`topic`
+
+| The default Kafka topic used for produced events.
+
+You can set the topic dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `fields.log_topic`, to set the topic for each event:
+
+[source,yaml]
+------------------------------------------------------------------------------
+topic: '%{[fields.log_topic]}'
+------------------------------------------------------------------------------
+
+// =============================================================================
+
+|
+[id="kafka-topics-setting"]
+`topics`
+
+| One or more topic processors including a condition, the event value to check against, and the resulting Kafka topic.
+
+Events that don't match against any defined processor are set to the default topic.
+
+Rule settings:
+
+`topic`::
+The topic format string to use. If this string contains field references, such as `%{[fields.name]}`, the fields must exist, or the rule fails.
+
+`mappings`::
+A dictionary that takes the value returned by `topic` and maps it to a new name.
+
+`default`::
+The default string value to use if `mappings` does not find a match.
+
+`when`::
+A condition that must succeed in order to execute the current rule. Refer to <<processor-conditions,conditions>> in the Elastic Agent processor syntax for condition descriptions. Currently the equals, contains, and regexp conditions are available.
+
+As an example for setting up your processors, you might want to route log events based on severity. To do so, you can specify a default topic for all events not matched by other processors:
+
+[source,yaml]
+----
+outputs:
+  kafka-output:
+    type: kafka
+    hosts:
+      - 'kafka1:9092'
+      - 'kafka2:9092'
+      - 'kafka3:9092'
+    topics:
+      - topic: 'critical-%{[agent.version]}'
+        when:
+          contains:
+            message: ' “CRITICAL”'
+      - topic: 'error-%{[agent.version]}'
+        when:
+          contains:
+            message: ' “ERR”'
+      - topic: '%{[fields.log_topic]}'
+----
+
+All non-critical and non-error events will then route to the default `%{[fields.log_topic]}` topic.
+
+|===
+
+[[output-kafka-partition-settings]]
+== Partition settings
+
+The number of partitions created is set automatically by the Kafka broker based on the list of topics. Records are then published to partitions either randomly, in round-robin order, or according to a calculated hash.
+
+In the following example, after each event is published to a partition, the partitioner selects the next partition in round-robin fashion.
+
+[source,yaml]
+----
+    partition:
+      round_robin:
+        group_events: 1
+----
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+|
+[id="kafka-random.group-events-setting"]
+`random.group_events`
+
+| Sets the number of events to be published to the same partition, before the partitioner selects a new partition by random. The default value is 1 meaning after each event a new partition is picked randomly.
+
+// =============================================================================
+
+|
+[id="kafka-round_robin.group_events-setting"]
+`round_robin.group_events`
+
+| Sets the number of events to be published to the same partition, before the partitioner selects the next partition. The default value is 1 meaning after each event the next partition will be selected.
+
+// =============================================================================
+
+|
+[id="kafka-hash.hash-setting"]
+`hash.hash`
+
+| List of fields used to compute the partitioning hash value from. If no field is configured, the events key value will be used.
+
+// =============================================================================
+
+|
+[id="kafka-hash.random-setting"]
+`hash.random`
+
+| Randomly distribute events if no hash or key value can be computed.
+
+// =============================================================================
+
+|===
+
+[[output-kafka-header-settings]]
+== Header settings
+
+A header is a key-value pair, and multiple headers can be included with the same key. Only string values are supported. These headers will be included in each produced Kafka message.
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+|
+[id="kafka-key-setting"]
+`key`
+
+| The key to set in the Kafka header.
+
+// =============================================================================
+
+|
+[id="kafka-value-setting"]
+`value`
+
+| The value to set in the Kafka header.
+
+// =============================================================================
+
+|
+[id="kafka-client_id-setting"]
+`client_id`
+
+| The configurable ClientID used for logging, debugging, and auditing purposes. The default is `Elastic`. The Client ID is part of the protocol to identify where the messages are coming from.
+
+|===
+
+
+
+
+[[output-kafka-configuration-settings]]
+== Other configuration settings
+
+You can specify these various other options in the `kafka-output` section of the agent configuration file.
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+|
+[id="{type}-backoff.init-setting"]
+`backoff.init`
+
+| (string) The number of seconds to wait before trying to reconnect to Kafka
+after a network error. After waiting `backoff.init` seconds, {agent} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset.
+
+*Default:* `1s`
+
+// =============================================================================
+
+|
+[id="kafka-backoff.max-setting"]
+`backoff.max`
+
+| (string) The maximum number of seconds to wait before attempting to connect to
+Kafka after a network error.
+
+*Default:* `60s`
+
+// =============================================================================
+
+|
+[id="kafka-broker_timeout-setting"]
+`broker_timeout`
+
+| The maximum length of time a Kafka broker waits for the required number of ACKs before timing out (see the `required_acks` setting further in).
+
+*Default:* `30` (seconds)
+
+// =============================================================================
+
+|
+[id="kafka-bulk_flush_frequency-setting"]
+`bulk_flush_frequency`
+
+| (int) Duration to wait before sending bulk Kafka request. `0`` is no delay. 
+
+*Default:* `0`
+
+// =============================================================================
+
+|
+[id="kafka-bulk_max_size-setting"]
+`bulk_max_size`
+
+| (int) The maximum number of events to bulk in a single Kafka
+request. 
+
+*Default:* `2048`
+
+// =============================================================================
+
+|
+[id="kafka-channel_buffer_size-setting"]
+`channel_buffer_size`
+
+| (int) Per Kafka broker number of messages buffered in output pipeline.
+
+*Default:* `256`
+
+// =============================================================================
+
+|
+[id="kafka-codec-setting"]
+`codec`
+
+| Output codec configuration. You can specify either the `json` or `format`
+codec. By default the `json` codec is used.
+
+*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
+
+*`json.escape_html`*: If `escape_html` is set to true, html symbols will be escaped in strings. The default is false.
+
+Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.json:
+    pretty: true
+    escape_html: false
+------------------------------------------------------------------------------
+
+*`format.string`*: Configurable format string used to create a custom formatted message.
+
+Example configurable that uses the `format` codec to print the events timestamp and message field to console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.format:
+    string: '%{[@timestamp]} %{[message]}'
+------------------------------------------------------------------------------
+
+// =============================================================================
+
+|
+[id="kafka-compression-setting"]
+`compression`
+
+| Select a compression codec to use. Supported codecs are `snappy`, `lz4` and `gzip`.
+
+// =============================================================================
+
+|
+[id="kafka-compression_level-setting"]
+`compression_level`
+
+| For the `gzip` codec you can choose a compression level. The level must be in the range of `1` (best speed) to `9` (best compression).
+
+Increasing the compression level reduces the network usage but increases the CPU usage.
+
+*Default:* `4`.
+
+
+// =============================================================================
+
+|
+[id="kafka-keep_alive-setting"]
+`keep_alive`
+
+| (string) The keep-alive period for an active network connection. If `0s`, keep-alives are disabled.
+
+*Default:* `0s`
+
+// =============================================================================
+
+|
+[id="kafka-max_message_bytes-setting"]
+`max_message_bytes`
+
+| (int) The maximum permitted size of JSON-encoded messages. Bigger messages will be dropped. This value should be equal to or less than the broker's `message.max.bytes`.
+
+*Default:* `1000000` (bytes)
+
+// =============================================================================
+
+|
+[id="kafka-metadata-setting"]
+`metadata`
+
+| Kafka metadata update settings. The metadata contains information about
+brokers, topics, partition, and active leaders to use for publishing.
+
+*`refresh_frequency`*:: Metadata refresh interval. Defaults to 10 minutes.
+
+*`full`*:: Strategy to use when fetching metadata. When this option is `true`, the 
+client will maintain a full set of metadata for all the available topics. When set
+to `false` it will only refresh the metadata for the configured topics. The default
+is false.
+
+*`retry.max`*:: Total number of metadata update retries. The default is 3.
+
+*`retry.backoff`*:: Waiting time between retries. The default is 250ms.
+
+// =============================================================================
+
+|
+[id="kafka-required_acks-setting"]
+`required_acks`
+
+| The ACK reliability level required from broker. 0=no response, 1=wait for local commit, -1=wait for all replicas to commit. The default is 1.
+
+Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
+
+*Default:* `1` (wait for local commit)
+
+// =============================================================================
+
+|
+[id="kafka-timeout-setting"]
+`timeout`
+
+| The number of seconds to wait for responses from the Kafka brokers before timing out. The default is 30 (seconds).
+
+*Default:* `1000000` (bytes)
+
+// =============================================================================
+
+|===

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
@@ -12,8 +12,8 @@ The Kafka output sends events to Apache Kafka.
 *Compatibility:* This output can connect to Kafka version 0.8.2.0 and later.
 Older versions might work as well, but are not supported.
 
-This example configures a Kafka output called `kafka-output` in the
-`elastic-agent.yml` file, with some basic settings as described further in:
+This example configures a Kafka output called `kafka-output` in the {agent}
+`elastic-agent.yml` file, with settings as described further in:
 
 [source,yaml]
 ----


### PR DESCRIPTION
The setting descriptions are based off of the [Beats Kafka output settings](https://www.elastic.co/guide/en/beats/filebeat/current/kafka-output.html#topics-option-kafka) and the [Fleet-managed agent Kafka output settings](http://localhost:8000/guide/kafka-output-settings.html#_general_settings) (we updated some of the Kafka output settings descriptions when the settings were made available in Fleet).

Please see [DOCS PREVIEW](https://ingest-docs_866.docs-preview.app.elstc.co/guide/en/fleet/master/kafka-output.html)

Closes: #637