### PR TITLE
Update aws-s3 known issue in 8.12 to include units in workaround

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -243,9 +243,9 @@ For more details see {beats-issue}37754[#37754].
 
 *Impact* +
 
-If you are using the Elasticsearch output, and your configuration uses a performance preset, switch it to `preset: latency`. If you use no preset or use `preset: custom`, then set `queue.mem.flush.timeout: 1` in your output configuration.
+If you are using the Elasticsearch output, and your configuration uses a performance preset, switch it to `preset: latency`. If you use no preset or use `preset: custom`, then set `queue.mem.flush.timeout: 1s` in your output configuration.
 
-If you are not using the Elasticsearch output, set `queue.mem.flush.timeout: 1` in your output configuration.
+If you are not using the Elasticsearch output, set `queue.mem.flush.timeout: 1s` in your output configuration.
 
 To configure the output parameters for a {fleet}-managed agent, see <<es-output-settings-yaml-config>>. For a standalone agent, see <<elastic-agent-output-configuration>>.
 


### PR DESCRIPTION
Use `queue.mem.flush.timeout: 1s` instead of `queue.mem.flush.timeout: 1` to ensure the correct behavior and match the rest of our documentation.