### PR TITLE
Add details about info shared, via proxy, with the EPR

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
@@ -17,3 +17,6 @@ example:
 xpack.fleet.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
+== What information is sent to the {package-registry}?
+
+In production environments, {kib}, through the {fleet} plugin, is the only service interacting with the {package-registry}. Communication happens when interacting with the Integrations UI, and when upgrading {kib}. The shared information is about discovery of Elastic packages and their available versions. In general, the only deployment-specific data that is shared is the {kib} version.


### PR DESCRIPTION
This adds the following to the [Set the proxy URL of the Elastic Package Registry](https://www.elastic.co/guide/en/fleet/current/epr-proxy-setting.html) page.

Closes: https://github.com/elastic/ingest-docs/issues/873

---

![Screenshot 2024-01-30 at 4 43 30 PM](https://github.com/elastic/ingest-docs/assets/41695641/56113163-b45d-419d-8194-5b12cdc2f0d1)
