### PR TITLE
Add Fleet & Agent 7.17.18 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.18>>
+
 * <<release-notes-7.17.17>>
 
 * <<release-notes-7.17.16>>
@@ -54,6 +56,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.18 relnotes
+
+[[release-notes-7.17.18]]
+== {fleet} and {agent} 7.17.18
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.18 relnotes
 
 // begin 7.17.17 relnotes
 


### PR DESCRIPTION
This adds the 7.17.18 Fleet & Agent Release Notes:

Fleet: no RN entries in [Kibana PR](https://github.com/elastic/kibana/pull/176216)
Fleet Server: No fragments in [BC1](https://github.com/elastic/fleet-server/tree/595e77811fc27d53c095478c6bf7d0ed58433e67/changelog/fragment)
Elastic Agent: No changelog file in [BC1](https://staging.elastic.co/7.17.18-bdb3703e/summary-7.17.18.html)

---

![Screenshot 2024-02-05 at 10 50 50 AM](https://github.com/elastic/ingest-docs/assets/41695641/103279af-a794-46a7-853e-c0cc8621e6a5)
