### PR TITLE
Update serverless restrictions wrt proxy support

### DIFF
--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -15,8 +15,19 @@ If you are using {agent} with link:{serverless-docs}[{serverless-full}], note th
 * The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 
 [discrete]
+[[outputs-serverless-restrictions]]
+== Outputs
+
+On {serverless-short}, you can configure new {es} outputs to use a proxy, with the restriction that the output URL is fixed. Any new {es} outputs must use the default {es} host URL.
+
+[discrete]
 [[fleet-server-serverless-restrictions]]
 == {fleet-server}
 
-On-premises {fleet-server} is not currently available for use in a {serverless-short} environment.
+Note the following restrictions with using {fleet-server} on {serverless-short}:
+
+* On-premises {fleet-server} is not currently available for use in a {serverless-short} environment.
 We recommend using the hosted {fleet-server} that is included and configured automatically in {serverless-short} {observability} and Security projects.
+
+* On {serverless-short}, you can configure {fleet-server} to use a proxy, with the restriction that the {fleet-server} host URL is fixed. Any new {fleet-server} hosts must use the default {fleet-server} host URL. 
+

--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -14,11 +14,10 @@ If you are using {agent} with link:{serverless-docs}[{serverless-full}], note th
 * The number of {agents} that may be connected to an {serverless-full} project is limited to 10 thousand.
 * The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 
-[discrete]
 [[outputs-serverless-restrictions]]
-== Outputs
+**Outputs**
 
-On {serverless-short}, you can configure new {es} outputs to use a proxy, with the restriction that the output URL is fixed. Any new {es} outputs must use the default {es} host URL.
+* On {serverless-short}, you can configure new {es} outputs to use a proxy, with the restriction that the output URL is fixed. Any new {es} outputs must use the default {es} host URL.
 
 [discrete]
 [[fleet-server-serverless-restrictions]]


### PR DESCRIPTION
Agent and Fleet Server proxies are now supported on serverless. This updates the [serverless restrictions](https://www.elastic.co/guide/en/fleet/current/fleet-agent-serverless-restrictions.html) page to clarify the current limitations.

@jillguyonnet Thanks for the super clear issue! Please let me know if I've missed anything. One small thing I wonder is if "Outputs" should maybe be "Elastic Agent outputs", or instead maybe just a sub-heading of the "Elastic Agent" section.

Closes: https://github.com/elastic/ingest-docs/issues/887

---

![screen](https://github.com/elastic/ingest-docs/assets/41695641/bc7e6f47-19de-43d0-aaa4-168948c6a046)
