### PR TITLE
Revert 785; new fleet server settings should not be in 8.12 docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -76,6 +76,12 @@ this setting may improve performance.
 `policy_throttle`:::
 How often a new policy is rolled out to the agents.
 
+`action_limit.interval`:::
+How quickly {fleet-server} dispatches pending actions to the agents.
+
+`action_limit.burst`:::
+Burst of actions that may be dispatched before falling back to the rate limit defined by `interval`.
+
 `checkin_limit.max`:::
 Maximum number of agents that can call the checkin API concurrently.
 

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -75,20 +75,6 @@ this setting may improve performance.
 `server.limits`::
 `policy_throttle`:::
 How often a new policy is rolled out to the agents.
-+
-Deprecated: Use the `policy_limit` settings instead.
-
-`action_limit.interval`:::
-How quickly {fleet-server} dispatches pending actions to the agents.
-
-`action_limit.burst`:::
-Burst of actions that may be dispatched before falling back to the rate limit defined by `interval`.
-
-`policy_limit.interval`:::
-How quickly {fleet-server} dispatches pending policies to the agents.
-
-`policy_limit.burst`:::
-Burst of pending policies that may be dispatched befoe falling back to the rate limit defined by `interval`.
 
 `checkin_limit.max`:::
 Maximum number of agents that can call the checkin API concurrently.


### PR DESCRIPTION
This reverts 8.12 out of the 8.12 docs.