### PR TITLE
Remove Fleet Server policy_limit settings

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -75,20 +75,12 @@ this setting may improve performance.
 `server.limits`::
 `policy_throttle`:::
 How often a new policy is rolled out to the agents.
-+
-Deprecated: Use the `policy_limit` settings instead.
 
 `action_limit.interval`:::
 How quickly {fleet-server} dispatches pending actions to the agents.
 
 `action_limit.burst`:::
 Burst of actions that may be dispatched before falling back to the rate limit defined by `interval`.
-
-`policy_limit.interval`:::
-How quickly {fleet-server} dispatches pending policies to the agents.
-
-`policy_limit.burst`:::
-Burst of pending policies that may be dispatched befoe falling back to the rate limit defined by `interval`.
 
 `checkin_limit.max`:::
 Maximum number of agents that can call the checkin API concurrently.


### PR DESCRIPTION
This removes the `policy_limit` settings from 8.13, from which they'll likely be pulled, and from 8.12 where they were never added.