### PR TITLE
Deprecate the fleet-server policy_throttle, use action_limit instead.

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -76,6 +76,8 @@ this setting may improve performance.
 `policy_throttle`:::
 How often a new policy is rolled out to the agents.
 
+Deprecated: Use the `action_limit` settings instead.
+
 `action_limit.interval`:::
 How quickly {fleet-server} dispatches pending actions to the agents.
 


### PR DESCRIPTION
Merge after https://github.com/elastic/fleet-server/pull/3255

https://github.com/elastic/ingest-docs/pull/892 removed the `policy_limit` settings which are being replaced by (re) using the `action_limit` settings in the above PR