### PR TITLE
Add tutorial for standalone agent on serverless monitoring nginx

### DIFF
--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
@@ -1,22 +1,22 @@
 [[example-standalone-monitor-nginx]]
-= Example: Use standalone {agent} to monitor nginx ({ess} version))
+= Example: Use standalone {agent} with {ess} to monitor nginx
 
 This guide walks you through a simple monitoring scenario so you can learn the basics of setting up standalone {agent}, using it to work with {ess} and an Elastic integration. 
 
 Following these steps, you'll deploy the {stack}, install a standalone {agent} on a host to monitor an nginx web server instance, and access visualizations based on the collected logs.
 
-. <<nginx-guide-install-nginx,Install nginx>>.
-. <<nginx-guide-sign-up,Create an {ecloud} deployment>>.
-. <<nginx-guide-create-api-key>>.
-. <<nginx-guide-create-policy,Create an {agent} policy>>.
-. <<nginx-guide-add-integration,Add the Nginx Integration>>.
-. <<nginx-guide-configure-standalone-agent,Configure standalone {agent}>>.
-. <<nginx-guide-confirm-agent-data,Confirm that your {agent} data is flowing>>.
-. <<nginx-guide-view-system-data,View your system data>>.
-. <<nginx-guide-view-nginx-data,View your nginx logging data>>.
+. <<nginx-guide-install-nginx-ess,Install nginx>>.
+. <<nginx-guide-sign-up-ess,Create an {ecloud} deployment>>.
+. <<nginx-guide-create-api-key-ess,Create an {ecloud} API key.>>
+. <<nginx-guide-create-policy-ess,Create an {agent} policy>>.
+. <<nginx-guide-add-integration-ess,Add the Nginx Integration>>.
+. <<nginx-guide-configure-standalone-agent-ess,Configure standalone {agent}>>.
+. <<nginx-guide-confirm-agent-data-ess,Confirm that your {agent} data is flowing>>.
+. <<nginx-guide-view-system-data-ess,View your system data>>.
+. <<nginx-guide-view-nginx-data-ess,View your nginx logging data>>.
 
 [discrete]
-[[nginx-guide-prereqs]]
+[[nginx-guide-prereqs-ess]]
 === Prerequisites
 
 To get started, you need:
@@ -25,7 +25,7 @@ To get started, you need:
 . A Linux host machine on which you'll install an nginx web server. The commands in this guide use an Ubuntu image but any Linux distribution should be fine.
 
 [discrete]
-[[nginx-guide-install-nginx]]
+[[nginx-guide-install-nginx-ess]]
 === Step 1: Install nginx
 
 To start, we'll set up a basic link:https://docs.nginx.com/nginx/admin-guide/web-server/[nginx web server].
@@ -43,12 +43,12 @@ sudo apt install nginx
 image::images/guide-nginx-welcome.png["Browser window showing Welcome to nginx!"]
 
 [discrete]
-[[nginx-guide-sign-up]]
+[[nginx-guide-sign-up-ess]]
 === Step 2: Create an {ecloud} deployment
 
 NOTE: If you've already signed up for a trial deployment you can skip this step.
 
-Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} deployment offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
+Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} {ess} deployment offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
 
 . Go to our link:https://cloud.elastic.co/registration?elektra=guide-welcome-cta[{ecloud} Trial] page.
 
@@ -66,7 +66,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 . Once the deployment is ready, select *Continue*. At this point, you access {kib} and a selection of setup guides.
 
 [discrete]
-[[nginx-guide-create-api-key]]
+[[nginx-guide-create-api-key-ess]]
 === Step 3: Create an {ecloud} API key
 
 . From the {kib} menu and go to *Stack Management* -> *API keys*.
@@ -82,7 +82,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 . Copy the generated API key and store it in a safe place. You'll use it in a later step.
 
 [discrete]
-[[nginx-guide-create-policy]]
+[[nginx-guide-create-policy-ess]]
 === Step 4: Create an {agent} policy
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, and more. A single agent makes it easy and fast to deploy monitoring across your infrastructure. Each agent has a single policy (a collection of input settings) that you can update to add integrations for new data sources, security protections, and more.
@@ -98,7 +98,7 @@ image::images/guide-agent-policies.png["Agent policies tab in Fleet"]
 image::images/guide-create-agent-policy.png["Create agent policy UI"]
 
 [discrete]
-[[nginx-guide-add-integration]]
+[[nginx-guide-add-integration-ess]]
 === Step 5: Add the Nginx Integration
 
 Elastic integrations are a streamlined way to connect your data from popular services and platforms to the {stack}, including nginx.
@@ -124,7 +124,7 @@ image::images/guide-add-nginx-integration.png["Add Nginx Integration UI"]
 image::images/guide-nginx-integration-added.png["Nginx Integration added confirmation UI with Add {agent} later selected."]
 
 [discrete]
-[[nginx-guide-configure-standalone-agent]]
+[[nginx-guide-configure-standalone-agent-ess]]
 === Step 6: Configure standalone {agent}
 
 Rather than opt for {fleet} to centrally manage {agent}, you'll configure an agent to run in standalone mode, so it will be managed by hand.
@@ -179,7 +179,7 @@ with:
     api_key: '<your-api-key>'
 ----
 +
-where `your-api-key` is the API key that you generated in <<nginx-guide-create-api-key>>.
+where `your-api-key` is the API key that you generated in <<nginx-guide-create-api-key-ess>>.
 
 . Find the location of the default `elastic-agent.yml` policy file that is included in your {agent} install. Install directories for each platform are described in <<installation-layout,Installation layout>>. In our example Ubuntu image the default policy file can be found in `/etc/elastic-agent/elastic-agent.yml`.
 . Replace the default policy file with the version that you downloaded and updated. For example:
@@ -218,7 +218,7 @@ message: Running
 ----
 
 [discrete]
-[[nginx-guide-confirm-agent-data]]
+[[nginx-guide-confirm-agent-data-ess]]
 === Step 7: Confirm that your {agent} data is flowing
 
 Now that {agent} is running, it's time to confirm that the agent data is flowing into {es}.
@@ -239,10 +239,10 @@ like the agent logs, the agent metrics should be flowing into {es} and visible i
 image::images/guide-agent-metrics-flowing.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
 [discrete]
-[[nginx-guide-view-system-data]]
+[[nginx-guide-view-system-data-ess]]
 === Step 8: View your system data
 
-In the step to <<nginx-guide-create-policy,create an {agent} policy>> you chose to collect system logs and metrics, so you can access those now.
+In the step to <<nginx-guide-create-policy-ess,create an {agent} policy>> you chose to collect system logs and metrics, so you can access those now.
 
 . View your system logs.
 .. Open the {kib} menu and go to **Management -> Integrations -> Installed integrations**.
@@ -259,7 +259,7 @@ In the step to <<nginx-guide-create-policy,create an {agent} policy>> you chose 
 image::images/guide-system-metrics-dashboard.png["The System metrics host overview showing CPU usage, memory usage, and other visualizations"]
 
 [discrete]
-[[nginx-guide-view-nginx-data]]
+[[nginx-guide-view-nginx-data-ess]]
 === Step 9: View your nginx logging data
 
 Now let's view your nginx logging data.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -1,21 +1,22 @@
-[[example-standalone-monitor-nginx]]
-= Example: Use standalone {agent} to monitor nginx ({ess} version))
+[[example-standalone-monitor-nginx-serverless]]
+= Example: Use standalone {agent} to monitor nginx ({serverless-full} version)
 
-This guide walks you through a simple monitoring scenario so you can learn the basics of setting up standalone {agent}, using it to work with {ess} and an Elastic integration. 
+This guide walks you through a simple monitoring scenario so you can learn the basics of setting up standalone {agent}, using it to work with {serverless-full} and an Elastic integration. 
 
 Following these steps, you'll deploy the {stack}, install a standalone {agent} on a host to monitor an nginx web server instance, and access visualizations based on the collected logs.
 
-. <<nginx-guide-install-nginx,Install nginx>>.
-. <<nginx-guide-sign-up,Create an {ecloud} deployment>>.
-. <<nginx-guide-create-policy,Create an {agent} policy>>.
-. <<nginx-guide-add-integration,Add the Nginx Integration>>.
-. <<nginx-guide-configure-standalone-agent,Configure standalone {agent}>>.
-. <<nginx-guide-confirm-agent-data,Confirm that your {agent} data is flowing>>.
-. <<nginx-guide-view-system-data,View your system data>>.
-. <<nginx-guide-view-nginx-data,View your nginx logging data>>.
+. <<nginx-guide-install-nginx-serverless,Install nginx>>.
+. <<nginx-guide-sign-up-serverless,Create an {serverless-full} project>>.
+. <<nginx-guide-create-api-key-serverless,Create an API key>>.
+. <<nginx-guide-create-policy-serverless,Create an {agent} policy>>.
+. <<nginx-guide-add-integration-serverless,Add the Nginx Integration>>.
+. <<nginx-guide-configure-standalone-agent-serverless,Configure standalone {agent}>>.
+. <<nginx-guide-confirm-agent-data-serverless,Confirm that your {agent} data is flowing>>.
+. <<nginx-guide-view-system-data-serverless,View your system data>>.
+. <<nginx-guide-view-nginx-data-serverless,View your nginx logging data>>.
 
 [discrete]
-[[nginx-guide-prereqs]]
+[[nginx-guide-prereqs-serverless]]
 === Prerequisites
 
 To get started, you need:
@@ -24,7 +25,7 @@ To get started, you need:
 . A Linux host machine on which you'll install an nginx web server. The commands in this guide use an Ubuntu image but any Linux distribution should be fine.
 
 [discrete]
-[[nginx-guide-install-nginx]]
+[[nginx-guide-install-nginx-serverless]]
 === Step 1: Install nginx
 
 To start, we'll set up a basic link:https://docs.nginx.com/nginx/admin-guide/web-server/[nginx web server].
@@ -42,12 +43,12 @@ sudo apt install nginx
 image::images/guide-nginx-welcome.png["Browser window showing Welcome to nginx!"]
 
 [discrete]
-[[nginx-guide-sign-up]]
-=== Step 2: Create an {ecloud} deployment
+[[nginx-guide-sign-up-serverless]]
+=== Step 2: Create an {serverless-full} project
 
 NOTE: If you've already signed up for a trial deployment you can skip this step.
 
-Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} deployment offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
+Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} project offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
 
 . Go to our link:https://cloud.elastic.co/registration?elektra=guide-welcome-cta[{ecloud} Trial] page.
 
@@ -56,21 +57,41 @@ Now that your web server is running, let's get set up to monitor it in {ecloud}.
 [role="screenshot"]
 image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",width="50%"]
 
-. After you've link:https://cloud.elastic.co/login[logged in], select *Create deployment* and give your deployment a name. You can leave the default options or select a different cloud provider, region, hardware profile, or version.
+. After you've link:https://cloud.elastic.co/login[logged in], select *Create project*.
 
-. Select *Create deployment*.
+. On the *Observability* tab, select *Next*. The *Observability* and *Security* projects both include {fleet}, which you can use to create a policy for the {agent} that will monitor your nginx installation.
 
-. While the deployment sets up, make a note of your `elastic` superuser password and keep it in a safe place.
+. Give your project a name. You can leave the default options or select a different cloud provider and region.
 
-. Once the deployment is ready, select *Continue*. At this point, you access {kib} and a selection of setup guides.
+. Select *Create project*, and then wait a few minutes for the new project to set up.
+
+. Once the project is ready, select *Continue*. At this point, you access {kib} and a selection of setup guides.
+
+
 
 [discrete]
-[[nginx-guide-create-policy]]
-=== Step 3: Create an {agent} policy
+[[nginx-guide-create-api-key-serverless]]
+=== Step 3: Create an {ecloud} API key
+
+. When your {serverless-short} project is ready, open the {kib} menu and go to **Project settings** -> **Management -> API keys**.
+
+. Select *Create API key*.
+
+. Give the key a name, for example `nginx example API key`.
+
+. Leave the other default options and select *Create API key*.
+
+. In the *Create API key* confirmation dialog, select change the dropdown menu from `Encoded` to `Beats`. This sets the API key format for communication between {agent} (which is based on {beats}) and {es}. 
+
+. Copy the generated API key and store it in a safe place. You'll use it in a later step.
+
+[discrete]
+[[nginx-guide-create-policy-serverless]]
+=== Step 4: Create an {agent} policy
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, and more. A single agent makes it easy and fast to deploy monitoring across your infrastructure. Each agent has a single policy (a collection of input settings) that you can update to add integrations for new data sources, security protections, and more.
 
-. When your {ecloud} deployment is ready, open the {kib} menu and go to **{fleet} -> Agent policies**.
+. Open the {kib} menu and go to **Project settings** -> **{fleet} -> Agent policies**.
 +
 image::images/guide-agent-policies.png["Agent policies tab in Fleet"]
 . Click *Create agent policy*.
@@ -81,8 +102,8 @@ image::images/guide-agent-policies.png["Agent policies tab in Fleet"]
 image::images/guide-create-agent-policy.png["Create agent policy UI"]
 
 [discrete]
-[[nginx-guide-add-integration]]
-=== Step 4: Add the Nginx Integration
+[[nginx-guide-add-integration-serverless]]
+=== Step 5: Add the Nginx Integration
 
 Elastic integrations are a streamlined way to connect your data from popular services and platforms to the {stack}, including nginx.
 
@@ -107,8 +128,8 @@ image::images/guide-add-nginx-integration.png["Add Nginx Integration UI"]
 image::images/guide-nginx-integration-added.png["Nginx Integration added confirmation UI with Add {agent} later selected."]
 
 [discrete]
-[[nginx-guide-configure-standalone-agent]]
-=== Step 5: Configure standalone {agent}
+[[nginx-guide-configure-standalone-agent-serverless]]
+=== Step 6: Configure standalone {agent}
 
 Rather than opt for {fleet} to centrally manage {agent}, you'll configure an agent to run in standalone mode, so it will be managed by hand.
 
@@ -147,8 +168,24 @@ elastic-agent status
 +
 Since you're running the agent in standalone mode the `Not enrolled into Fleet` message is expected.
 . Open the `elastic-agent.yml` policy file that you saved.
-. Near the top of the file, replace `${ES_USERNAME}` with the username for the {ecloud} deployment that you created in <<nginx-guide-sign-up,Step 2>>. The default is `elastic`.
-. Similarly, replace `${ES_PASSWORD}` with your superuser password.
+
+. Near the top of the file, replace: 
++
+[source,yaml]
+----
+    username: '${ES_USERNAME}'
+    password: '${ES_PASSWORD}'
+----
++
+with:
++
+[source,yaml]
+----
+    api_key: '<your-api-key>'
+----
++
+where `your-api-key` is the API key that you generated in <<nginx-guide-create-api-key-serverless>>.
+
 . Find the location of the default `elastic-agent.yml` policy file that is included in your {agent} install. Install directories for each platform are described in <<installation-layout,Installation layout>>. In our example Ubuntu image the default policy file can be found in `/etc/elastic-agent/elastic-agent.yml`.
 . Replace the default policy file with the version that you downloaded and updated. For example:
 +
@@ -186,20 +223,20 @@ message: Running
 ----
 
 [discrete]
-[[nginx-guide-confirm-agent-data]]
-=== Step 6: Confirm that your {agent} data is flowing
+[[nginx-guide-confirm-agent-data-serverless]]
+=== Step 7: Confirm that your {agent} data is flowing
 
 Now that {agent} is running, it's time to confirm that the agent data is flowing into {es}.
 
 . Check that {agent} logs are flowing.
-.. Open the {kib} menu and go to **Analytics -> Discover**.
+.. Open the {kib} menu and go to **Observability -> Discover**.
 .. In the KQL query bar, enter the query `agent.id : "{agent-id}"` where `{agent-id}` is the ID you retrieved from the `elastic-agent status --output yaml` command. For example: `agent.id : "4779b439-1130-4841-a878-e3d7d1a457d0"`.
 +
 If {agent} has connected successfully with your {ecloud} deployment, the agent logs should be flowing into {es} and visible in {kib} Discover.
 +
 image::images/guide-agent-logs-flowing.png["Kibana Discover shows agent logs are flowing into Elasticsearch."]
 . Check that {agent} metrics are flowing.
-.. Open the {kib} menu and go to **Analytics -> Dashboard**.
+.. Open the {kib} menu and go to **Observability -> Dashboards**.
 .. In the search field, search for `Elastic Agent` and select `[Elastic Agent] Agent metrics` in the results.
 +
 like the agent logs, the agent metrics should be flowing into {es} and visible in {kib} Dashboard. You can view metrics on CPU usage, memory usage, open handles, events rate, and more.
@@ -207,19 +244,19 @@ like the agent logs, the agent metrics should be flowing into {es} and visible i
 image::images/guide-agent-metrics-flowing.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
 [discrete]
-[[nginx-guide-view-system-data]]
-=== Step 7: View your system data
+[[nginx-guide-view-system-data-serverless]]
+=== Step 8: View your system data
 
-In the step to <<nginx-guide-create-policy,create an {agent} policy>> you chose to collect system logs and metrics, so you can access those now.
+In the step to <<nginx-guide-create-policy-serverless,create an {agent} policy>> you chose to collect system logs and metrics, so you can access those now.
 
 . View your system logs.
-.. Open the {kib} menu and go to **Management -> Integrations -> Installed integrations**.
+.. Open the {kib} menu and go to **Project settings -> Integrations -> Installed integrations**.
 .. Select the **System** card and open the **Assets** tab. This is a quick way to access all of the dashboards, saved searches, and visualizations that come with each integration.
 .. Select `[Logs System] Syslog dashboard`. 
 .. Select the calandar icon and change the time setting to `Today`. The {kib} Dashboard shows visualizations of Syslog events, hostnames and processes, and more.
 . View your system metrics.
 
-.. Return to **Management -> Integrations -> Installed integrations**.
+.. Return to **Project settings -> Integrations -> Installed integrations**.
 .. Select the **System** card and open the **Assets** tab.
 .. This time, select `[Metrics System] Host overview`. 
 .. Select the calandar icon and change the time setting to `Today`. The {kib} Dashboard shows visualizations of host metrics including CPU usage, memory usage, running processes, and others.
@@ -227,8 +264,8 @@ In the step to <<nginx-guide-create-policy,create an {agent} policy>> you chose 
 image::images/guide-system-metrics-dashboard.png["The System metrics host overview showing CPU usage, memory usage, and other visualizations"]
 
 [discrete]
-[[nginx-guide-view-nginx-data]]
-=== Step 8: View your nginx logging data
+[[nginx-guide-view-nginx-data-serverless]]
+=== Step 9: View your nginx logging data
 
 Now let's view your nginx logging data.
 
@@ -241,7 +278,7 @@ image::images/guide-nginx-logs-dashboard.png["The nginx logs dashboard shows var
 +
 image::images/guide-nginx-browser-breakdown.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
-Congratulations! You have successfully set up monitoring for nginx logs using standalone {agent} and an {ecloud} deployment.
+You have now successfully set up monitoring for nginx logs using standalone {agent} and an {ecloud} deployment.
 
 [discrete]
 === What's next?

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -81,7 +81,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 
 . Leave the other default options and select *Create API key*.
 
-. In the *Create API key* confirmation dialog, select change the dropdown menu from `Encoded` to `Beats`. This sets the API key format for communication between {agent} (which is based on {beats}) and {es}. 
+. In the *Create API key* confirmation dialog, change the dropdown menu setting from `Encoded` to `Beats`. This sets the API key format for communication between {agent} (which is based on {beats}) and {es}. 
 
 . Copy the generated API key and store it in a safe place. You'll use it in a later step.
 

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -1,5 +1,5 @@
 [[example-standalone-monitor-nginx-serverless]]
-= Example: Use standalone {agent} to monitor nginx ({serverless-full} version)
+= Example: Use standalone {agent} with {serverless-full} to monitor nginx
 
 This guide walks you through a simple monitoring scenario so you can learn the basics of setting up standalone {agent}, using it to work with {serverless-full} and an Elastic integration. 
 
@@ -48,7 +48,7 @@ image::images/guide-nginx-welcome.png["Browser window showing Welcome to nginx!"
 
 NOTE: If you've already signed up for a trial deployment you can skip this step.
 
-Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} project offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
+Now that your web server is running, let's get set up to monitor it in {ecloud}. An {ecloud} {serverless-short} project offers you all of the features of the {stack} as a hosted service. To test drive your first deployment, sign up for a free {ecloud} trial:
 
 . Go to our link:https://cloud.elastic.co/registration?elektra=guide-welcome-cta[{ecloud} Trial] page.
 
@@ -81,7 +81,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 
 . Leave the other default options and select *Create API key*.
 
-. In the *Create API key* confirmation dialog, change the dropdown menu setting from `Encoded` to `Beats`. This sets the API key format for communication between {agent} (which is based on {beats}) and {es}. 
+. In the *Create API key* confirmation dialog, change the dropdown menu setting from `Encoded` to `Beats`. This sets the API key to the format used for communication between {agent} and {es}. 
 
 . Copy the generated API key and store it in a safe place. You'll use it in a later step.
 

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -269,7 +269,7 @@ image::images/guide-system-metrics-dashboard.png["The System metrics host overvi
 
 Now let's view your nginx logging data.
 
-. Open the {kib} menu and go to **Management -> Integrations -> Installed integrations**.
+. Open the {kib} menu and go to **Project settings -> Integrations -> Installed integrations**.
 . Select the **Nginx** card and open the **Assets** tab.
 . Select `[Logs Nginx] Overview`. The {kib} Dashboard opens with geographical log details, response codes and errors over time, top pages, and more.
 +
@@ -278,7 +278,7 @@ image::images/guide-nginx-logs-dashboard.png["The nginx logs dashboard shows var
 +
 image::images/guide-nginx-browser-breakdown.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
-You have now successfully set up monitoring for nginx logs using standalone {agent} and an {ecloud} deployment.
+Congratulations! You have successfully set up monitoring for nginx logs using standalone {agent} and an {serverless-full} project.
 
 [discrete]
 === What's next?

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -278,7 +278,7 @@ image::images/guide-nginx-logs-dashboard.png["The nginx logs dashboard shows var
 +
 image::images/guide-nginx-browser-breakdown.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
-Congratulations! You have successfully set up monitoring for nginx logs using standalone {agent} and an {serverless-full} project.
+Congratulations! You have successfully set up monitoring for nginx using standalone {agent} and an {serverless-full} project.
 
 [discrete]
 === What's next?

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx.asciidoc
@@ -7,6 +7,7 @@ Following these steps, you'll deploy the {stack}, install a standalone {agent} o
 
 . <<nginx-guide-install-nginx,Install nginx>>.
 . <<nginx-guide-sign-up,Create an {ecloud} deployment>>.
+. <<nginx-guide-create-api-key>>.
 . <<nginx-guide-create-policy,Create an {agent} policy>>.
 . <<nginx-guide-add-integration,Add the Nginx Integration>>.
 . <<nginx-guide-configure-standalone-agent,Configure standalone {agent}>>.
@@ -65,8 +66,24 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 . Once the deployment is ready, select *Continue*. At this point, you access {kib} and a selection of setup guides.
 
 [discrete]
+[[nginx-guide-create-api-key]]
+=== Step 3: Create an {ecloud} API key
+
+. From the {kib} menu and go to *Stack Management* -> *API keys*.
+
+. Select *Create API key*.
+
+. Give the key a name, for example `nginx example API key`.
+
+. Leave the other default options and select *Create API key*.
+
+. In the *Create API key* confirmation dialog, change the dropdown menu setting from `Encoded` to `Beats`. This sets the API key format for communication between {agent} (which is based on {beats}) and {es}. 
+
+. Copy the generated API key and store it in a safe place. You'll use it in a later step.
+
+[discrete]
 [[nginx-guide-create-policy]]
-=== Step 3: Create an {agent} policy
+=== Step 4: Create an {agent} policy
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, and more. A single agent makes it easy and fast to deploy monitoring across your infrastructure. Each agent has a single policy (a collection of input settings) that you can update to add integrations for new data sources, security protections, and more.
 
@@ -82,7 +99,7 @@ image::images/guide-create-agent-policy.png["Create agent policy UI"]
 
 [discrete]
 [[nginx-guide-add-integration]]
-=== Step 4: Add the Nginx Integration
+=== Step 5: Add the Nginx Integration
 
 Elastic integrations are a streamlined way to connect your data from popular services and platforms to the {stack}, including nginx.
 
@@ -108,7 +125,7 @@ image::images/guide-nginx-integration-added.png["Nginx Integration added confirm
 
 [discrete]
 [[nginx-guide-configure-standalone-agent]]
-=== Step 5: Configure standalone {agent}
+=== Step 6: Configure standalone {agent}
 
 Rather than opt for {fleet} to centrally manage {agent}, you'll configure an agent to run in standalone mode, so it will be managed by hand.
 
@@ -147,8 +164,23 @@ elastic-agent status
 +
 Since you're running the agent in standalone mode the `Not enrolled into Fleet` message is expected.
 . Open the `elastic-agent.yml` policy file that you saved.
-. Near the top of the file, replace `${ES_USERNAME}` with the username for the {ecloud} deployment that you created in <<nginx-guide-sign-up,Step 2>>. The default is `elastic`.
-. Similarly, replace `${ES_PASSWORD}` with your superuser password.
+. Near the top of the file, replace: 
++
+[source,yaml]
+----
+    username: '${ES_USERNAME}'
+    password: '${ES_PASSWORD}'
+----
++
+with:
++
+[source,yaml]
+----
+    api_key: '<your-api-key>'
+----
++
+where `your-api-key` is the API key that you generated in <<nginx-guide-create-api-key>>.
+
 . Find the location of the default `elastic-agent.yml` policy file that is included in your {agent} install. Install directories for each platform are described in <<installation-layout,Installation layout>>. In our example Ubuntu image the default policy file can be found in `/etc/elastic-agent/elastic-agent.yml`.
 . Replace the default policy file with the version that you downloaded and updated. For example:
 +
@@ -187,7 +219,7 @@ message: Running
 
 [discrete]
 [[nginx-guide-confirm-agent-data]]
-=== Step 6: Confirm that your {agent} data is flowing
+=== Step 7: Confirm that your {agent} data is flowing
 
 Now that {agent} is running, it's time to confirm that the agent data is flowing into {es}.
 
@@ -208,7 +240,7 @@ image::images/guide-agent-metrics-flowing.png["Kibana Dashboard shows agent metr
 
 [discrete]
 [[nginx-guide-view-system-data]]
-=== Step 7: View your system data
+=== Step 8: View your system data
 
 In the step to <<nginx-guide-create-policy,create an {agent} policy>> you chose to collect system logs and metrics, so you can access those now.
 
@@ -228,7 +260,7 @@ image::images/guide-system-metrics-dashboard.png["The System metrics host overvi
 
 [discrete]
 [[nginx-guide-view-nginx-data]]
-=== Step 8: View your nginx logging data
+=== Step 9: View your nginx logging data
 
 Now let's view your nginx logging data.
 

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx.asciidoc
@@ -241,7 +241,7 @@ image::images/guide-nginx-logs-dashboard.png["The nginx logs dashboard shows var
 +
 image::images/guide-nginx-browser-breakdown.png["Kibana Dashboard shows agent metrics are flowing into Elasticsearch."]
 
-Congratulations! You have successfully set up monitoring for nginx logs using standalone {agent} and an {ecloud} deployment.
+Congratulations! You have successfully set up monitoring for nginx using standalone {agent} and an {ecloud} deployment.
 
 [discrete]
 === What's next?

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -179,6 +179,8 @@ include::elastic-agent/grant-access-to-elasticsearch.asciidoc[leveloffset=+2]
 
 include::elastic-agent/example-standalone-monitor-nginx.asciidoc[leveloffset=+2]
 
+include::elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc[leveloffset=+2]
+
 include::elastic-agent/debug-standalone-elastic-agent.asciidoc[leveloffset=+2]
 
 include::elastic-agent/configuration/autodiscovery/elastic-agent-kubernetes-autodiscovery.asciidoc[leveloffset=+2]

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -177,9 +177,9 @@ include::elastic-agent/configuration/examples/config-file-examples.asciidoc[leve
 
 include::elastic-agent/grant-access-to-elasticsearch.asciidoc[leveloffset=+2]
 
-include::elastic-agent/example-standalone-monitor-nginx.asciidoc[leveloffset=+2]
-
 include::elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc[leveloffset=+2]
+
+include::elastic-agent/example-standalone-monitor-nginx-ess.asciidoc[leveloffset=+2]
 
 include::elastic-agent/debug-standalone-elastic-agent.asciidoc[leveloffset=+2]
 


### PR DESCRIPTION
This adds a new serverless version of the tutorial [Use standalone Elastic Agent with Elasticsearch Service to monitor nginx](https://www.elastic.co/guide/en/fleet/current/example-standalone-monitor-nginx.html).

For the new guide, all of the steps have been tested on a serverless project and modified accordingly.

A few things have also been fixed up in the original guide, most notably the switch to use API key authentication, as required on serverless and as recommended on stateless.

Closes: #904
Rel: #693

