### PR TITLE
[DOCS] Fix Elastic Agent input examples

### DIFF
--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -124,11 +124,11 @@ adjust it as needed.
 input {
   elastic_agent {
     port => 5044
-    ssl => true
+    ssl_enabled => true
     ssl_certificate_authorities => ["/path/to/ca.crt"]
     ssl_certificate => "/path/to/logstash.crt"
     ssl_key => "/path/to/logstash.pkcs8.key"
-    ssl_verify_mode => "force_peer"
+    ssl_client_authentication => "required"
   }
 }
 
@@ -153,11 +153,11 @@ Self-managed {es} cluster example:
 input {
   elastic_agent {
     port => 5044
-    ssl => true
+    ssl_enabled => true
     ssl_certificate_authorities => ["/path/to/ca.crt"]
     ssl_certificate => "/path/to/logstash.crt"
     ssl_key => "/path/to/logstash.pkcs8.key"
-    ssl_verify_mode => "force_peer"
+    ssl_client_authentication => "required"
   }
 }
 


### PR DESCRIPTION
`ssl` and `ssl_verify_mode` settings are deprecated for the Elastic Agent input (Logstash).
I adjusted the examples with current valid settings: `ssl_enabled` and `ssl_client_authentication` based of latest Logstash documentation: https://www.elastic.co/guide/en/logstash/current/plugins-inputs-elastic_agent.html#plugins-inputs-elastic_agent-ssl_client_authentication