### PR TITLE
Fix known issue for stuck upgrade in 8.12.1 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -147,32 +147,60 @@ An issue discovered in {fleet-server} prevents {agents} that have been upgraded 
 
 *Impact* +
 
-As a workaround, we recommend you to use the {kib} {fleet} API to upgrade these agents using the `force` flag.
-
-To upgrade a single {agent}:
+As a workaround, we recommend you to use the {kib} {fleet} API to update any documents in which `upgrade_details` is either `null` or not defined. Note that these steps must be run as a superuser.
 
 [source,"shell"]
 ----
-POST kbn:/api/fleet/agents/<agent_id>/upgrade
-{
-  "version": "8.12.1",
-  "force": true
-}
-----
-
-To bulk upgrade a set of {agents}:
-
-[source,"shell"]
-----
-POST kbn:/api/fleet/agents/bulk_upgrade
-  {
-    "agents": "agent.version:8.12.0",
-    "version": "8.12.1",
-    "force": true
+ POST _security/role/fleet_superuser
+ {
+    "indices": [
+        {
+            "names": [".fleet*",".kibana*"],
+            "privileges": ["all"],
+            "allow_restricted_indices": true
+        }
+    ]
   }
 ----
 
-This issue is planned to be fixed in versions 8.12.2 and 8.13.0.
+[source,"shell"]
+----
+POST _security/user/fleet_superuser 
+ {
+    "password": "password",
+    "roles": ["superuser", "fleet_superuser"]
+ }
+----
+
+[source,"shell"]
+----
+curl -sk -XPOST --user fleet_superuser:password -H 'content-type:application/json' \
+  -H'x-elastic-product-origin:fleet' \
+  http://localhost:9200/.fleet-agents/_update_by_query \
+  -d '{
+  "script": {
+    "source": "ctx._source.remove(\"upgrade_details\")",
+    "lang": "painless"
+  },
+  "query": {
+    "bool": {
+        "must_not": {
+          "exists": {
+            "field": "upgrade_details"
+          }
+        }
+      }
+    }
+}'
+----
+
+[source,"shell"]
+----
+DELETE _security/user/fleet_superuser
+DELETE _security/role/fleet_superuser
+----
+
+After running these API requests, wait at least 10 minutes, and then the agents should be upgradeable again.
 
 ====
 
@@ -514,6 +542,8 @@ curl -sk -XPOST --user fleet_superuser:password -H 'content-type:application/jso
 DELETE _security/user/fleet_superuser
 DELETE _security/role/fleet_superuser
 ----
+
+After running these API requests, wait at least 10 minutes, and then the agents should be upgradeable again.
 ====
 
 [discrete]


### PR DESCRIPTION
in #908 I fixed the "stuck upgrade" known issue for 8.12.0 only, and forgot about 8.12.1. So this fixes that omission.

Also, I've added `After running these API requests, wait at least 10 minutes, and then the agents should be upgradeable again.` at the end of the workaround steps.

---

![Screenshot 2024-02-14 at 11 05 50 AM](https://github.com/elastic/ingest-docs/assets/41695641/1950e6f1-c682-4476-b2a8-e947ec5a2258)
![Screenshot 2024-02-14 at 11 06 01 AM](https://github.com/elastic/ingest-docs/assets/41695641/ddec2476-758f-40da-9c58-d2a6de1eeb5f)

