### PR TITLE
Fix migrate integrations docs

### DIFF
--- a/docs/en/ingest-management/fleet/migrate-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/migrate-elastic-agent.asciidoc
@@ -123,8 +123,7 @@ On your target cluster, certain settings from the original {ecloud} {agent} poli
 
 To reset the {ecloud} {agent} policy:
 
-. Open {kib} and navigate to *Management -> Dev Tools*.
-. Choose one of the API requests below and submit it through the console.
+. Choose one of the API requests below and submit it through a terminal window.
 ** If you're using {kib} version 8.11 or higher, run:
 +
 [source,shell]
@@ -148,6 +147,17 @@ curl --request POST \
 ----
 +
 After running the command, your {ecloud} agent policy settings should all be updated appropriately.
+
+[NOTE]
+====
+After running the command, a warning message may appear in {fleet} indicating that {fleet-server} is not healthy. As well, the {agent} associated with the {ecloud} agent policy may disappear from the list of agents. To remedy this, you can restart {integrations-server}:
+
+. From the {kib} menu, select *Manage this deployment*.
+. In the deployment menu, select *Integrations Server*.
+. On the *Integrations Server* page, select *Force Restart*.
+
+After the restart, {integrations-server} will enroll a new {agent} for the {ecloud} agent policy and {fleet-server} should return to a healthy state.
+====
 
 [discrete]
 [[migrate-elastic-agent-confirm-policy]]


### PR DESCRIPTION
This fixes a few things in the "Reset the Elastic Cloud policy" section of the page [Migrate Fleet-managed Elastic Agents from one cluster to another](https://www.elastic.co/guide/en/fleet/current/migrate-elastic-agent.html), as suggested in https://github.com/elastic/ingest-docs/issues/922

Closes: #922 

---

![screen](https://github.com/elastic/ingest-docs/assets/41695641/1a592aae-33f5-4ca6-a309-b5e3cd1883dc)
