### PR TITLE
Fix examples to use API key authentication

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -26,7 +26,7 @@ outputs:
     password: changeme
 ----
 
-This example is similar to the previous one, except that it uses
+This example is similar to the previous one, except that it uses the recommended
 <<output-elasticsearch-apikey-authentication-settings,token-based (API key) authentication>>:
 
 [source,yaml]
@@ -207,6 +207,8 @@ This user needs the privileges required to publish events to {es}.
 //To create a user like this, refer to <<privileges-to-publish-events>>.
 // end::username-setting[]
 
+Note that in an link:{serverless-docs}[{serverless-full}] environment you need to use <<output-elasticsearch-apikey-authentication-settings,token-based (API key) authentication>>.
+
 // =============================================================================
 
 |===
@@ -234,7 +236,7 @@ outputs:
 
 | (string) Instead of using a username and password, you can use {kibana-ref}/api-keys.html[API keys] to
 secure communication with {es}. The value must be the ID of the API key and the
-API key joined by a colon: `id:api_key`.
+API key joined by a colon: `id:api_key`. Token-based authentication is required in an link:{serverless-docs}[{serverless-full}] environment.
 // end::api_key-setting[]
 
 // =============================================================================

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-debug-input-configs.asciidoc
@@ -15,8 +15,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    username: elastic
-    password: changeme
+    apikey: <my-api-key>
 
 providers:
   local_dynamic:
@@ -98,11 +97,10 @@ inputs:
   type: logfile
 outputs:
   default:
+    apikey: <my-api-key>
     hosts:
     - 127.0.0.1:9200
-    password: changeme
     type: elasticsearch
-    username: elastic
 providers:
   local_dynamic:
     items:

--- a/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
@@ -40,9 +40,9 @@ To create an API key for {agent}:
 +
 In a {serverless-short} environment, in {kib} navigate to *Project settings* > *Management* > *API keys* and click *Create API key*.
 
-. Enter a name for your API key and select *Restrict privileges*. In the role
-descriptors box, copy and paste the following JSON. This example creates an
-API key with privileges for ingesting logs, metrics, traces, and synthetics:
+. Enter a name for your API key and select *Restrict privileges* (in a {serverless-short} environment, *Control security privileges*).
+
+. In the role descriptors box, copy and paste the following JSON. This example creates an API key with privileges for ingesting logs, metrics, traces, and synthetics:
 +
 [source,json]
 ----


### PR DESCRIPTION
This makes a few small touch-ups to indicate that API key authentication is required on serverless, and generally recommended over basic auth. For the changes to the "debugging" example, I tested an agent policy and the resulting output from the `elastic-agent inspect` command to make sure that the updated formatting is correct.

I've also updated the API key generation to note that the UI path is slightly different in a serverless project.

The examples in the nginx monitoring tutorials were fixed separately.

Closes: #693