### PR TITLE
Document that disk queues cannot be configured for Agent-managed Beats

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -162,7 +162,7 @@ configuration experience.
 
 |{filebeat-ref}/configuring-internal-queue.html[Internal queues]
 |{fleet}-managed {agent} and Standalone {agent} both support configuration of the internal memory
-queues by an end user. 
+queues by an end user. Neither support configuration of the internal disk queues by an end user.
 
 |{filebeat-ref}/elasticsearch-output.html#_loadbalance[Load balance output hosts]
 |Within the {fleet} UI, you can add YAML settings to configure multiple hosts


### PR DESCRIPTION
This PR documents explicitly that users cannot configure internal _disk_ queues for Agent-managed Beats in [this table](https://www.elastic.co/guide/en/fleet/current/beats-agent-comparison.html#supported-configurations) comparing configurations supported by Beats vs. Agent.