### PR TITLE
Remove nonexistent option from enroll command

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -152,7 +152,6 @@ elastic-agent enroll --url <string>
                      [--certificate-authorities <string>]
                      [--delay-enroll]
                      [--force]
-                     [--non-interactive]
                      [--help]
                      [--insecure ]
                      [--tag <string>]


### PR DESCRIPTION
The synopsis for the enroll command listed `--non-interactive`, which is an option on the install command and doesn't apply to enroll.