### PR TITLE
[main] Remove nonexistent option from enroll command (#930)

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -158,7 +158,6 @@ elastic-agent enroll --url <string>
                      [--header <strings>]
                      [--help]
                      [--insecure ]
-                     [--non-interactive]
                      [--proxy-disabled]
                      [--proxy-header <strings>]
                      [--proxy-url <string>]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.12` to `main`:
 - [Remove nonexistent option from enroll command (#930)](https://github.com/elastic/ingest-docs/pull/930)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)