### PR TITLE
Update air-gapped.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -182,7 +182,7 @@ from it.
 `https://artifacts.elastic.co/downloads/`. For example, the
 following cURL commands download all the artifacts that may be needed to upgrade
 {agent}s running on Linux x86_64. You may replace `x86_64` with `arm64` for the ARM64 version.
-The exact list depends on which integrations you're using.
+The exact list depends on which integrations you're using.  Make sure to also download the corresponding sha512, and PGP Signature (.asc) files for each binary.  These are used for file integrity validations during installations and upgrades.
 +
 ["source","shell",subs="attributes"]
 ----


### PR DESCRIPTION
added a note to also download the asc and sha512 files.  Agent upgrades fail without them.