### PR TITLE
Add Fleet & Agent 8.12.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -44,7 +44,7 @@ Review important information about {fleet-server} and {agent} for the 8.12.2 rel
 {agent}::
 * On Windows, make sure the {agent} service is stopped before uninstalling. {agent-pull}4224[#4224] {agent-issue}4164[#4164]
 
-* Fix an issue where {agent} was not using the download settings when downloading the artifact signature file. {agent-pull}4270[#4270] {agent-issue}4237[#4237]
+* Fix {agent} download settings like proxy_url not being respected when download upgrade signature artifact signature files. {agent-pull}4270[#4270] {agent-issue}4237[#4237]
 
 // end 8.12.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -31,14 +31,6 @@ Also see:
 Review important information about {fleet-server} and {agent} for the 8.12.2 release.
 
 [discrete]
-[[enhancements-8.12.2]]
-=== Enhancements
-
-
-
-
-
-[discrete]
 [[bug-fixes-8.12.2]]
 === Bug fixes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -41,6 +41,9 @@ Review important information about {fleet-server} and {agent} for the 8.12.2 rel
 * Fix categories labels in integration overview. ({kibana-pull}176141[#176141])
 * Fix the ability to delete agent policies with inactive agents from UI, the inactive agents need to be unenrolled first. ({kibana-pull}175815[#175815])
 
+{fleet-server}::
+* Fix a bug where agents were stuck in a non-upgradeable state after upgrade. This resolves the <<known-issue-3263-8121,known issue>> that affected versions 8.12.0 and 8.12.1. {fleet-server-pull}3264[#3264] {fleet-server-issue}3263[#3263] 
+
 {agent}::
 * On Windows, make sure the {agent} service is stopped before uninstalling. {agent-pull}4224[#4224] {agent-issue}4164[#4164]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.12.2>>
 * <<release-notes-8.12.1>>
 * <<release-notes-8.12.0>>
 
@@ -21,6 +22,39 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.12.2 relnotes
+
+[[release-notes-8.12.2]]
+== {fleet} and {agent} 8.12.2
+
+Review important information about {fleet-server} and {agent} for the 8.12.2 release.
+
+[discrete]
+[[enhancements-8.12.2]]
+=== Enhancements
+
+
+
+
+
+[discrete]
+[[bug-fixes-8.12.2]]
+=== Bug fixes
+
+{fleet}::
+* Fix a popover about inactive agents not being dismissible. ({kibana-pull}176929[#176929])
+* Fix logstash output being link:https://www.rfc-editor.org/rfc/rfc952[RFC-952] compliant. ({kibana-pull}176298[#176298])
+* Fix assets being unintentionally moved to the default space during Fleet setup. ({kibana-pull}176173[#176173])
+* Fix categories labels in integration overview. ({kibana-pull}176141[#176141])
+* Fix the ability to delete agent policies with inactive agents from UI, the inactive agents need to be unenrolled first. ({kibana-pull}175815[#175815])
+
+{agent}::
+* On Windows, make sure the {agent} service is stopped before uninstalling. {agent-pull}4224[#4224] {agent-issue}4164[#4164]
+
+* Fix an issue where {agent} was not using the download settings when downloading the artifact signature file. {agent-pull}4270[#4270] {agent-issue}4237[#4237]
+
+// end 8.12.2 relnotes
 
 // begin 8.12.1 relnotes
 


### PR DESCRIPTION
This adds the 8.12.2 Fleet & Elastic Agent Release Notes:

 - Fleet contents from [Kibana 8.12.2 Release Notes PR](https://github.com/elastic/kibana/pull/177335)
 - Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/fa3452c5098931862a31be39051faf11dbc22740/changelog/fragments)
 - Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/de80b0d70174ba45dc869fdf121109763bbfcce0/changelog/fragments)

See [DOCS PREVIEW](https://ingest-docs_bk_939.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.12.2.html)

Rel: #933