### PR TITLE
[8.13] Update air-gapped.asciidoc (#934)

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -193,7 +193,7 @@ from it.
 `https://artifacts.elastic.co/downloads/`. For example, the
 following cURL commands download all the artifacts that may be needed to upgrade
 {agent}s running on Linux x86_64. You may replace `x86_64` with `arm64` for the ARM64 version.
-The exact list depends on which integrations you're using.
+The exact list depends on which integrations you're using.  Make sure to also download the corresponding sha512, and PGP Signature (.asc) files for each binary.  These are used for file integrity validations during installations and upgrades.
 +
 ["source","shell",subs="attributes"]
 ----


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.12` to `8.13`:
 - [Update air-gapped.asciidoc (#934)](https://github.com/elastic/ingest-docs/pull/934)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)