### PR TITLE
Test link checker with respect to hard-coded guide URLs

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -11,7 +11,6 @@ TEST2: This investigation guide uses link:https://www.elastic.co/guide/en/securi
 
 TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
 
 
 [options,header]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -12,6 +12,21 @@ TEST2: This investigation guide uses link:https://www.elastic.co/guide/en/securi
 TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
 
 
+[source, markdown]
+----------------------------------
+
+I am a humble markdown codeblock.
+Remember to eat your leafy greens.
+
+TEST4: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+----------------------------------
+
+
 
 [options,header]
 |===

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -7,7 +7,11 @@ is not described here, please review the open issues in the following GitHub rep
 
 TEST1: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST2:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST2: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
 
 
 [options,header]

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -4,6 +4,12 @@
 We have collected the most common known problems and listed them here. If your problem
 is not described here, please review the open issues in the following GitHub repositories:
 
+
+TEST1: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+TEST2:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+
+
 [options,header]
 |===
 | Repository | To review or report issues about

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -24,6 +24,8 @@ TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/securi
 
 TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[6 placeholder fields] to dynamically pass alert data into Osquery queries.
 
+TEST7: This investigation guide uses [7 placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries.
+
 ----------------------------------
 
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -5,11 +5,11 @@ We have collected the most common known problems and listed them here. If your p
 is not described here, please review the open issues in the following GitHub repositories:
 
 
-TEST1: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST1: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[1 placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST2: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST2: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[2 placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[3 placeholder fields] to dynamically pass alert data into Osquery queries.
 
 
 [source, markdown]
@@ -18,11 +18,11 @@ TEST3:  This investigation guide uses {security-guide}/osquery-placeholder-field
 I am a humble markdown codeblock.
 Remember to eat your leafy greens.
 
-TEST4: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST4: This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[4 placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html[5 placeholder fields] to dynamically pass alert data into Osquery queries.
 
-TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[placeholder fields] to dynamically pass alert data into Osquery queries.
+TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[6 placeholder fields] to dynamically pass alert data into Osquery queries.
 
 ----------------------------------
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -25,7 +25,7 @@ TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/securi
 TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[6 placeholder fields] to dynamically pass alert data into Osquery queries.
 
 TEST7: This investigation guide uses [7 placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries.
-
+TEST8: This investigation guide uses https://www.elastic.co/guide/en/security/current/es-ui-overview.html
 ----------------------------------
 
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -25,6 +25,7 @@ TEST5: This investigation guide uses link:https://www.elastic.co/guide/en/securi
 TEST6:  This investigation guide uses {security-guide}/osquery-placeholder-fields.html[6 placeholder fields] to dynamically pass alert data into Osquery queries.
 
 TEST7: This investigation guide uses [7 placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries.
+
 TEST8: This investigation guide uses https://www.elastic.co/guide/en/security/current/es-ui-overview.html
 ----------------------------------
 


### PR DESCRIPTION
TEST PR ONLY

This adds three links, one using the `{security-guide}` attribute, one using a hard-coded URL, and one using a hard-coded URL preceded by "link:". Let's see if the link checker complains about these.


Here's how the output renders:

![screen](https://github.com/elastic/ingest-docs/assets/41695641/1ea8f60e-0576-4723-95ca-bf0e7b68f6f5)

I'm trying to understand the following link checking error from [this build](https://buildkite.com/elastic/docs-build-pr/builds/32693#018dd272-5385-42bb-9f12-8c63a653fae9):

```
2024-02-22 15:27:28 EST | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/current/suspicious-file-creation-in-etc-for-persistence.html contains broken links to:
-- | --
  | 2024-02-22 15:27:28 EST | INFO:build_docs:   - en/security/current/osquery-placeholder-fields.html[placeholder
```

Preview: https://ingest-docs_bk_947.docs-preview.app.elstc.co/guide/en/fleet/master/fleet-troubleshooting.html