### PR TITLE
Test link checker on links in markdown codeblock

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -4,6 +4,22 @@
 We have collected the most common known problems and listed them here. If your problem
 is not described here, please review the open issues in the following GitHub repositories:
 
+[source, markdown]
+----------------------------------
+I am a humble markdown codeblock.
+
+TEST 1 - Here is a URL in mid-sentence:
+This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html to dynamically pass alert data into Osquery queries.
+
+TEST 2 - Here is a URL with no following text:
+This investigation guide uses https://www.elastic.co/guide/en/security/current/es-ui-overview.html
+
+TEST 3 - Here is a URL demarkated by single quotes:
+This investigation guide uses 'https://www.elastic.co/guide/en/security/current/security-assistant.html'
+
+----------------------------------
+
+
 [options,header]
 |===
 | Repository | To review or report issues about


### PR DESCRIPTION
This tests three raw link formats inside a markdown codeblock:

```
[source, markdown]
----------------------------------
I am a humble markdown codeblock.

TEST 1 - Here is a URL in mid-sentence:
This investigation guide uses https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html to dynamically pass alert data into Osquery queries.

TEST 2 - Here is a URL with no following text:
This investigation guide uses https://www.elastic.co/guide/en/security/current/es-ui-overview.html

TEST 3 - Here is a URL demarkated by single quotes:
This investigation guide uses 'https://www.elastic.co/guide/en/security/current/security-assistant.html'
----------------------------------
```
Interestingly, the URL renders much more nicely if we wrap it inside single quotes (Test 3), but I don't know which of these will pass our docs build CI check.

![Screenshot 2024-02-23 at 5 17 38 AM](https://github.com/elastic/ingest-docs/assets/41695641/20e0efbd-60fa-42ed-9c40-baa03b373376)

---

And the results are in:

```
2024-02-23 05:36:59 EST | INFO:build_docs:Bad cross-document links:
-- | --
  | 2024-02-23 05:36:59 EST | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/fleet/master/fleet-troubleshooting.html contains broken links to:
  | 2024-02-23 05:36:59 EST | INFO:build_docs:   - en/security/current/security-assistant.html'
  | 2024-02-23 05:37:26 EST | 🚨 Error: The command exited with status 255
```

Only Test 3 failed, so it seems the link _should_ pass CI checks as long as there is whitespace after the `.html`. So I guess the full URL must be surrounded, before and after, by whitespace.
