### PR TITLE
Update fleet-settings-output-kafka.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -7,8 +7,6 @@ Specify these settings to send data over a secure connection to Kafka. In the {f
 
 preview::[]
 
-TIP: Kafka output is currently not supported on {agents} using the {elastic-defend} integration.
-
 [discrete]
 == General settings
 


### PR DESCRIPTION
The Kafka output is supported with Elastic Agents using the Elastic defend integration.   Tip needs to be removed version 8.12+.

See references 
- https://github.com/elastic/kibana/pull/177717
- https://github.com/elastic/security-docs/issues/4379#issuecomment-1875184778