### PR TITLE
[main] Update fleet-settings-output-kafka.asciidoc (#953)

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -7,8 +7,6 @@ Specify these settings to send data over a secure connection to Kafka. In the {f
 
 preview::[]
 
-TIP: Kafka output is currently not supported on {agents} using the {elastic-defend} integration.
-
 [discrete]
 == General settings
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.12` to `main`:
 - [Update fleet-settings-output-kafka.asciidoc (#953)](https://github.com/elastic/ingest-docs/pull/953)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)