### PR TITLE
Remove loadbalance references from agent docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
@@ -84,8 +84,7 @@ escaping.
 [id="{type}-worker-setting"]
 `worker`
 
-| (int) The number of workers per configured host publishing events. 
-This is best used with load balancing mode enabled. Example: If
+| (int) The number of workers per configured host publishing events. Example: If
 you have two hosts and three workers, in total six workers are started (three
 for each host).
 


### PR DESCRIPTION
The `loadbalance` setting shouldn't be mentioned in the Elastic Agent docs. It currently is mentioned in the `worker` setting description, for both Fleet-managed and standalone agent.

Re: https://github.com/elastic/sdh-beats/issues/4420#issuecomment-1976424040