### PR TITLE
Scrub book-level attributes from Fleet & Agent guide

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -1,3 +1,6 @@
+:y: image:images/green-check.svg[yes]
+:n: image:images/red-x.svg[no]
+
 [[agent-policy]]
 = {agent} policies
 
@@ -5,10 +8,10 @@
 <titleabbrev>Policies</titleabbrev>
 ++++
 
-A {policy} is a collection of inputs and settings that defines the data to be collected
-by an {agent}. Each {agent} can only be enrolled in a single {policy}.
+A policy is a collection of inputs and settings that defines the data to be collected
+by an {agent}. Each {agent} can only be enrolled in a single policy.
 
-Within an {agent} {policy} is a set of individual integration policies.
+Within an {agent} policy is a set of individual integration policies.
 These integration policies define the settings for each input type.
 The available settings in an integration depend on the version of
 the integration in use.
@@ -29,7 +32,7 @@ in the {fleet} UI.
 * Maintain flexibility in large-scale deployments by quickly testing changes before rolling them out.
 * Provide a way to group and manage larger swaths of your infrastructure landscape.
 
-For example, it might make sense to create a {policy} per operating system type:
+For example, it might make sense to create a policy per operating system type:
 Windows, macOS, and Linux hosts.
 Or, organize policies by functional groupings of how the hosts are
 used: IT email servers, Linux servers, user work-stations, etc.
@@ -137,7 +140,7 @@ Click the name of the policy you want to add an integration to.
 NOTE: Integration policy names must be globally unique across all agent
 policies.
 
-. Save the integration policy as part of the larger {agent} {policy}:
+. Save the integration policy as part of the larger {agent} policy:
 +
 --
 * To use the UI, click **Save and continue**.
@@ -145,10 +148,10 @@ policies.
 request.
 --
 
-{fleet} distributes this new {policy} to all {agent}s that are enrolled in the
-{agent} {policy}.
+{fleet} distributes this new policy to all {agent}s that are enrolled in the
+{agent} policy.
 
-After the {policy} has finished applying, the selected integration will be running on the host
+After the policy has finished applying, the selected integration will be running on the host
 and communicating with the {agent}.
 
 [discrete]
@@ -193,7 +196,7 @@ Open the **Actions** menu and select **Edit integration** or **Delete integratio
 Editing or deleting an integration is permanent and cannot be undone.
 If you make a mistake, you can always re-configure or re-add an integration.
 
-Any saved changes are immediately distributed and applied to all {agent}s enrolled in the given {policy}.
+Any saved changes are immediately distributed and applied to all {agent}s enrolled in the given policy.
 
 To update any secret values in an integration policy, refer to <<agent-policy-secret-values>>.
 

--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -1,3 +1,6 @@
+:y: image:images/green-check.svg[yes]
+:n: image:images/red-x.svg[no]
+
 [[beats-agent-comparison]]
 = {beats} and {agent} capabilities
 

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -1020,7 +1020,7 @@ Be sure to run the `uninstall` command from the directory where {agent} is insta
 
 --
 
-include::{tab-widgets}/uninstall-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/uninstall-widget.asciidoc[]
 
 --
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -87,7 +87,7 @@ Default: `true`
 
 | `agent.logging.files.path` | The directory that log files is written to.
 
-include::{tab-widgets}/logging-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/logging-widget.asciidoc[]
 
 Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/inputs/simplified-input-configuration.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/inputs/simplified-input-configuration.asciidoc
@@ -1,8 +1,6 @@
 [[elastic-agent-simplified-input-configuration]]
 = Simplified log ingestion
 
-include::{fleet-repo-dir}/standalone-note.asciidoc[]
-
 There is a simplified option for ingesting log files with {agent}.
 The simplest input configuration to ingest the file
 `/var/log/my-application/log-file.log` is:

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -19,6 +19,7 @@ This command allows environment variables to configure all properties, and runs 
 +
 --
 include::{observability-docs-root}/docs/en/shared/spin-up-the-stack/widget.asciidoc[]
+
 --
 
 [discrete]
@@ -92,7 +93,7 @@ docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent co
 [discrete]
 == Step 4: Run the {agent} image
 
-include::{tab-widgets}/run-agent-image/widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/run-agent-image/widget.asciidoc[]
 
 [discrete]
 == Step 5: View your data in {kib}

--- a/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-standalone-elastic-agent.asciidoc
@@ -1,5 +1,5 @@
 [[install-standalone-elastic-agent]]
-= Install standalone {agent}s (advanced users)
+= Install standalone {agent}s
 
 To run an {agent} in standalone mode, install the agent and manually configure
 the agent locally on the system where it’s installed. You are responsible for
@@ -26,7 +26,7 @@ To install and run {agent} standalone:
 --
 // tag::install-elastic-agent[]
 
-include::{tab-widgets}/download-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/download-widget.asciidoc[]
 
 // end::install-elastic-agent[]
 --
@@ -76,7 +76,7 @@ packages include a service unit for Linux systems with
 systemd, so just enable then start the service.
 +
 --
-include::{tab-widgets}/run-standalone-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/run-standalone-widget.asciidoc[]
 --
 
 Refer to <<installation-layout>> for the location of installed {agent} files.

--- a/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/installation-layout.asciidoc
@@ -3,4 +3,4 @@
 
 {agent} files are installed in the following locations.
 
-include::{tab-widgets}/install-layout-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/install-layout-widget.asciidoc[]

--- a/docs/en/ingest-management/elastic-agent/start-stop-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/start-stop-elastic-agent.asciidoc
@@ -10,7 +10,7 @@ it will no longer send data to {es}.
 If you've stopped the {agent} service and want to restart it, use the commands
 that work with your system:
 
-include::{tab-widgets}/start-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/start-widget.asciidoc[]
 
 [discrete]
 [[stop-elastic-agent-service]]
@@ -19,4 +19,4 @@ include::{tab-widgets}/start-widget.asciidoc[]
 To stop {agent} and its related executables, stop the {agent} service. Use the
 commands that work with your system:
 
-include::{tab-widgets}/stop-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/stop-widget.asciidoc[]

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -10,7 +10,7 @@ To uninstall {agent}, run the `uninstall` command from the directory where
 IMPORTANT: Be sure to run the `uninstall` command from the directory where {agent} is running, as shown in the example below, and not from the directory where you previously ran the `install` command. Running the command from the wrong directory can leave the agent in an inconsistent state.
 
 --
-include::{tab-widgets}/uninstall-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/uninstall-widget.asciidoc[]
 
 --
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -2,9 +2,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
 :doctype: book
-:fleet-repo-dir: {ingest-docs-root}/docs/en/ingest-management
-:tab-widgets: {fleet-repo-dir}/tab-widgets
-:code-path: {tab-widgets}/code
 
 = {fleet} and {agent} Guide
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -2,28 +2,9 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
 :doctype: book
-:beats-repo-dir: {beats-root}
 :fleet-repo-dir: {ingest-docs-root}/docs/en/ingest-management
-:apm-repo-dir: {apm-server-root}/docs
 :tab-widgets: {fleet-repo-dir}/tab-widgets
 :code-path: {tab-widgets}/code
-
-:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
-:policy: policy
-:artifact-registry: Elastic artifact registry
-
-:y: image:images/green-check.svg[yes]
-:n: image:images/red-x.svg[no]
-
-:apm-ios-ref-v:         https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-php-ref-v:         https://www.elastic.co/guide/en/apm/agent/php/{apm-php-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
 = {fleet} and {agent} Guide
 

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -37,7 +37,7 @@ request.
 --
 
 This action installs the integration (if it's not already installed) and saves
-the integration policy as a part of the larger {agent} {policy}. {fleet}
+the integration policy as a part of the larger {agent} policy. {fleet}
 distributes this new policy to all {agent}s that are enrolled in the agent
 policy.
 

--- a/docs/en/ingest-management/integrations/edit-or-delete-integration-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/edit-or-delete-integration-policy.asciidoc
@@ -20,4 +20,4 @@ Editing or deleting an integration is permanent and cannot be undone.
 If you make a mistake, you can always re-configure or re-add an integration.
 
 Any saved changes are immediately distributed and applied to all {agent}s
-enrolled in the given {policy}.
+enrolled in the given policy.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -649,7 +649,7 @@ When you uninstall {agent}, all the programs managed by {agent}, such as
 To remove {elastic-endpoint}, run the following commands:
 
 --
-include::{tab-widgets}/remove-endpoint-files/widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/remove-endpoint-files/widget.asciidoc[]
 
 --
 


### PR DESCRIPTION
This removes most of the book-level attributes in the Fleet & Agent guide. I'm leaving a few that have to do with the tab widgets, so for those I'll wait and see how the Observability folks fix things up.

Backporting this to 8.13 so that if I've broken anything we'll know sooner rather than later.

Closes: #974 