### PR TITLE
Remove key:value spaces from Kafka processors doc

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -219,15 +219,15 @@ As an example for setting up your processors, you might want to route log events
 
 Then, create a processor to route critical events:
 
-* Condition: `Contains`
-* Value: `message: “CRITICAL”`  
-* Topic: `critical-%{[agent.version]}`
+* Condition:`Contains`
+* Value:`message: “CRITICAL”`  
+* Topic:`critical-%{[agent.version]}`
 
 And create another processor to route error events:
 
-* Condition: `Contains`
-* Value: `message: “ERR”`
-* Topic: `error-%{[agent.version]}`
+* Condition:`Contains`
+* Value:`message: “ERR”`
+* Topic:`error-%{[agent.version]}`
 
 All non-critical and non-error events will then route to the default `%{[fields.log_topic]}` topic.
 


### PR DESCRIPTION
Issue reported via Slack. The extra spaces cause the values not to be applied.

Note that the processors docs have been removed in later versions via https://github.com/elastic/ingest-docs/pull/943