### PR TITLE
[8.12] Update scaling-on-kubernetes.asciidoc (#977)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/scaling-on-kubernetes.asciidoc
@@ -67,8 +67,8 @@ Based on our tests we advise to configure only the `limit` section of the `resou
 ------------------------------------------------
 resources:
     limits:
-      cpu: "1000m"
-      memory: "200Mi"
+      cpu: "1500m"
+      memory: "800Mi"
 ------------------------------------------------
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Update scaling-on-kubernetes.asciidoc (#977)](https://github.com/elastic/ingest-docs/pull/977)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)