### PR TITLE
Add steps to configure a PGP key for agent upgrade

### DIFF
--- a/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/upgrade-standalone-elastic-agent.asciidoc
@@ -34,6 +34,8 @@ As an alterative, you can do one of the following:
 * <<fleet-agent-proxy-support,Configure a proxy server>> for standalone {agent} to access the {artifact-registry}.
 * <<host-artifact-registry,Host your own artifact registry>> for standalone {agent} to access binary downloads.
 
+As well, starting from version 8.9.0, during the upgrade process {agent} needs to download a PGP/GPG key. Refer to <<air-gapped-pgp-fleet>> for the steps to configure the key download location in an air-gapped environment.
+
 Refer to <<air-gapped,Air-gapped environments>> for more details.
 
 [[upgrade-standalone-verify-package]]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -75,7 +75,7 @@ The setting `server.pgp.upstream_url` must point to a web server hosting the PGP
 Note that:
 
  * `server.pgp.upstream_url` may be specified as an `http` endpoint (instead of `https`).
- * For an `https` endpoint, the CA must be trusted by {fleet-server}.
+ * For an `https` endpoint, the CA for {fleet-server} to connect to `server.pgp.upstream_url` must be trusted by {fleet-server} using the `--certificate-authorities` setting that is used globally for {agent}.
 
 [discrete]
 [[air-gapped-proxy-server]]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -55,7 +55,7 @@ The key is served through the {fleet-server} endpoint `GET /api/agents/upgrades/
 
 If there isn't a `default.pgp` key in the `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp` directory, {fleet-server} instead will attempt to retrieve a PGP/GPG key from the URL that you can specify with the `server.pgp.upstream_url` setting.
 
-You can prevent {fleet} to download the PGP/GPG key from `server.pgp.upstream_url` by manually downloading it from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` and storing it at  `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
+You can prevent {fleet} from downloading the PGP/GPG key from `server.pgp.upstream_url` by manually downloading it from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` and storing it at  `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
 
 To set a custom URL for {fleet-server} to access a PGP/GPG key and make it available to {agents}:
 

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -63,11 +63,11 @@ To set a custom URL for {fleet-server} to access a PGP/GPG key and make it avail
 . Select a policy for the agents that you want to upgrade.
 . On the policy page, in the **Actions** menu for the {fleet-server} integration, select **Edit integration**.
 . In the {fleet-server} settings section expand **Change defaults** and **Advanced options**.
-. In the **Custom fleet-server configurations** field, add the setting `server.pgp.upstream_url` with the URL where the PGP/GPG key can be accessed. For example:
+. In the **Custom fleet-server configurations** field, add the setting `server.pgp.upstream_url` with the full URL where the PGP/GPG key can be accessed. For example:
 
 [source,yaml]
 ----
-server.pgp.upstream_url: <my-web-server-url>
+server.pgp.upstream_url: <http://my-web-server:8080/default.pgp>
 ----
 
 The setting `server.pgp.upstream_url` must point to a web server hosting the PGP/GPG key, which must be reachable by the host where {fleet-server} is installed.

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -55,6 +55,8 @@ The key is served through the {fleet-server} endpoint `GET /api/agents/upgrades/
 
 If there isn't a `default.pgp` key in the `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp` directory, {fleet-server} instead will attempt to retrieve a PGP/GPG key from the URL that you can specify with the `server.pgp.upstream_url` setting.
 
+You can prevent {fleet} to download the PGP/GPG key from `server.pgp.upstream_url` by manually downloading it from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` and storing it at  `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
+
 To set a custom URL for {fleet-server} to access a PGP/GPG key and make it available to {agents}:
 
 . In {kib}, go to *Management > {fleet} > Agent policies*.

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -38,14 +38,20 @@ xpack.fleet.isAirGapped: true
 
 Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent. This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
 
-In an air-gapped environment, the agent won't be able to download the remote key and therefore cannot be upgraded. For versions 8.9.0 to 8.10.3, you can resolve this problem following the steps described in the associated link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issues-8.9.0[known issue] documentation.
-
+In an air-gapped environment, an {agent} which doesn't have access to a PGP/GPG key from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` would fail to be upgraded.
+For versions 8.9.0 to 8.10.3, you can resolve this problem following the steps described in the associated link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issues-8.9.0[known issue] documentation.
 
 Starting in version 8.10.4, you can resolve this problem by configuring {agents} to download the PGP/GPG key from {fleet-server}.
 
+Starting in version 8.10.4, {agent} will:
+
+. Verify the binary signature with the key bundled in the agent.
+. If the verification doesn't pass, the agent will download the PGP/GPG key from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` and verify it.
+. If that verification doesn't pass, the agent will download the PGP/GPG key from {fleet-server} and verify it.
+. If that verification doesn't pass, the upgrade is blocked.
+
 By default, {fleet-server} serves {agents} with the key located in `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
-The key is served through the endpoint `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
-Accessing the endpoint requires a valid API key and the endpoint is rate limited.
+The key is served through the {fleet-server} endpoint `GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key`.
 
 If there isn't a `default.pgp` key in the `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp` directory, {fleet-server} instead will attempt to retrieve a PGP/GPG key from the URL that you can specify with the `server.pgp.upstream_url` setting.
 

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -72,7 +72,7 @@ GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key
 Accessing the endpoint requires a valid API key and the endpoint is rate limited.
 
 The endpoint will serve a PGP key from it's cache if one exists, otherwise it will serve the contents of a PGP key found on disk at `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`. Note that the directory can be changed through configuration.
-The key value is added to cache if it exists.
+The key value is added to the cache if it exists.
 
 [discrete]
 [[air-gapped-proxy-server]]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -62,6 +62,18 @@ Note that:
  * `server.pgp.upstream_url` may be specified as an `http` endpoint (instead of `https`).
  * For an `https` endpoint, the CA must be trusted by {fleet-server}.
 
+As an alternative, you can use a {fleet-server} endpoint to retrieve a PGP key:
+
+[source,shell]
+----
+GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key
+----
+
+Accessing the endpoint requires a valid API key and the endpoint is rate limited.
+
+The endpoint will serve a PGP key from it's cache if one exists, otherwise it will serve the contents of a PGP key found on disk at `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`. Note that the directory can be changed through configuration.
+The key value is added to cache if it exists.
+
 [discrete]
 [[air-gapped-proxy-server]]
 == Use a proxy server to access the {package-registry}

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -33,6 +33,36 @@ xpack.fleet.isAirGapped: true
 ----
 
 [discrete]
+[[air-gapped-pgp-fleet]]
+== Configure {agents} to download a PGP/GPG key from {fleet-server}
+
+Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first verifies the binary signature with the key bundled in the agent. This process has a backup mechanism that will use the key coming from `https://artifacts.elastic.co/GPG-KEY-elastic-agent` instead of the one it already has.
+
+In an air-gapped environment, the agent won't be able to download the remote key and therefore cannot be upgraded. For versions 8.9.0 to 8.10.3, you can resolve this problem following the steps described in the associated link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issues-8.9.0[known issue] documentation.
+
+Starting in version 8.10.4, you can resolve this problem by configuring {agents} to download the PGP/GPG key from a custom URL specified in {fleet-server}:
+
+To set a custom URL for {agents} to download a PGP/GPG key:
+
+. In {kib}, go to *Management > {fleet} > Agent policies*.
+. Select a policy for the agents that you want to upgrade.
+. On the policy page, in the **Actions** menu for the {fleet-server} integration, select **Edit integration**.
+. In the {fleet-server} settings section expand **Change defaults** and **Advanced options**.
+. In the **Custom fleet-server configurations** field, add the setting `server.pgp.upstream_url` with the URL where the PGP/GPG key can be downloaded. For example:
+
+[source,yaml]
+----
+server.pgp.upstream_url: <my-web-server-url>
+----
+
+The setting `server.pgp.upstream_url` must point to a web server hosting the PGP/GPG key, which must be reachable by the host where {fleet-server} is installed.
+
+Note that:
+
+ * `server.pgp.upstream_url` may be specified as an `http` endpoint (instead of `https`).
+ * For an `https` endpoint, the CA must be trusted by {fleet-server}.
+
+[discrete]
 [[air-gapped-proxy-server]]
 == Use a proxy server to access the {package-registry}
 

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -40,15 +40,22 @@ Starting from version 8.9.0, when {agent} tries to perform an upgrade, it first 
 
 In an air-gapped environment, the agent won't be able to download the remote key and therefore cannot be upgraded. For versions 8.9.0 to 8.10.3, you can resolve this problem following the steps described in the associated link:https://www.elastic.co/guide/en/fleet/8.9/release-notes-8.9.0.html#known-issues-8.9.0[known issue] documentation.
 
-Starting in version 8.10.4, you can resolve this problem by configuring {agents} to download the PGP/GPG key from a custom URL specified in {fleet-server}:
 
-To set a custom URL for {agents} to download a PGP/GPG key:
+Starting in version 8.10.4, you can resolve this problem by configuring {agents} to download the PGP/GPG key from {fleet-server}.
+
+By default, {fleet-server} serves {agents} with the key located in `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
+The key is served through the endpoint `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`.
+Accessing the endpoint requires a valid API key and the endpoint is rate limited.
+
+If there isn't a `default.pgp` key in the `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp` directory, {fleet-server} instead will attempt to retrieve a PGP/GPG key from the URL that you can specify with the `server.pgp.upstream_url` setting.
+
+To set a custom URL for {fleet-server} to access a PGP/GPG key and make it available to {agents}:
 
 . In {kib}, go to *Management > {fleet} > Agent policies*.
 . Select a policy for the agents that you want to upgrade.
 . On the policy page, in the **Actions** menu for the {fleet-server} integration, select **Edit integration**.
 . In the {fleet-server} settings section expand **Change defaults** and **Advanced options**.
-. In the **Custom fleet-server configurations** field, add the setting `server.pgp.upstream_url` with the URL where the PGP/GPG key can be downloaded. For example:
+. In the **Custom fleet-server configurations** field, add the setting `server.pgp.upstream_url` with the URL where the PGP/GPG key can be accessed. For example:
 
 [source,yaml]
 ----
@@ -61,18 +68,6 @@ Note that:
 
  * `server.pgp.upstream_url` may be specified as an `http` endpoint (instead of `https`).
  * For an `https` endpoint, the CA must be trusted by {fleet-server}.
-
-As an alternative, you can use a {fleet-server} endpoint to retrieve a PGP key:
-
-[source,shell]
-----
-GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key
-----
-
-Accessing the endpoint requires a valid API key and the endpoint is rate limited.
-
-The endpoint will serve a PGP key from it's cache if one exists, otherwise it will serve the contents of a PGP key found on disk at `FLEETSERVER_BINARY_DIR/elastic-agent-upgrade-keys/default.pgp`. Note that the directory can be changed through configuration.
-The key value is added to the cache if it exists.
 
 [discrete]
 [[air-gapped-proxy-server]]


### PR DESCRIPTION
This adds instructions for air-gapped environments on how to set `server.pgp.upstream_url` so that Elastic Agents can access the PGP/GPG key required for upgrade.

See [docs preview page](https://ingest-docs_bk_984.docs-preview.app.elstc.co/guide/en/fleet/master/air-gapped.html#air-gapped-pgp-fleet).

Please let me know if I've missed anything, especially in the "Note that" section under the steps.

Closes: #980 
Rel: https://github.com/elastic/sdh-beats/issues/4496