### PR TITLE
Remove tech preview notice from Kafka output docs

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -5,8 +5,6 @@
 
 Specify these settings to send data over a secure connection to Kafka. In the {fleet} <<output-settings,Output settings>>, make sure that the Kafka output type is selected. 
 
-preview::[]
-
 [discrete]
 == General settings
 


### PR DESCRIPTION
The Kafka output type GAed in 8.13 so this removes the tech preview notice from the associated docs.