### PR TITLE
Add Fleet & Agent 8.13.1 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -34,14 +34,14 @@ Review important information about {fleet-server} and {agent} for the 8.13.1 rel
 === Enhancements
 
 {fleet}::
-* Feature/default fields ({kibana-pull}178020[#178020]).
+* Remove `index.query.default_field` setting from managed component template settings. ({kibana-pull}178020[#178020])
 
 [discrete]
 [[bug-fixes-8.13.1]]
 === Bug fixes
 
 {fleet}::
-* Use index exists check in fleet-metrics-task ({kibana-pull}179404[#179404]).
+* Use index exists check in fleet-metrics-task. ({kibana-pull}179404[#179404])
 
 // end 8.13.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -14,12 +14,22 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.13.1>>
 * <<release-notes-8.13.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.13.1 relnotes
+
+[[release-notes-8.13.1]]
+== {fleet} and {agent} 8.13.1
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 8.13.1 relnotes
 
 // begin 8.13.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -27,7 +27,21 @@ Also see:
 [[release-notes-8.13.1]]
 == {fleet} and {agent} 8.13.1
 
-There are no bug fixes for {fleet} or {agent} in this release.
+Review important information about {fleet-server} and {agent} for the 8.13.1 release.
+
+[discrete]
+[[enhancements-8.13.1]]
+=== Enhancements
+
+{fleet}::
+* Feature/default fields ({kibana-pull}178020[#178020]).
+
+[discrete]
+[[bug-fixes-8.13.1]]
+=== Bug fixes
+
+{fleet}::
+* Use index exists check in fleet-metrics-task ({kibana-pull}179404[#179404]).
 
 // end 8.13.1 relnotes
 


### PR DESCRIPTION
This adds the 8.13.1 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/179760)
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/3824b898d1e0a92d12e76f311cd3e9e0b08560e5/changelog/fragments) (No new entries)
* Elastic Agent contents from:
    * [BC1 "core" changelog](https://github.com/elastic/elastic-agent/tree/818d20468f031265ad7415ef5567b934ffff35c0/changelog/fragments) (No new entries)
    * [BC1 "package" changelog](https://github.com/elastic/elastic-agent/tree/1eb18c5ef69be30641aa415f9e40fabd38d2e4ad/changelog/fragments) (No new entries)

See [docs preview](https://ingest-docs_bk_992.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.13.1.html)

 Closes: #991
