### PR TITLE
Simplify step to open Fleet for compatibility with Serverless

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -103,8 +103,6 @@ The following table illustrates the {fleet} user actions available to different 
 
 To manage your {agent}s and the data they collect, create a new policy:
 
-. In {kib}, go to **Management -> {fleet}**.
-
 . In {fleet}, click **Agent policies -> Create agent policy**.
 Name your policy. All other fields are optional and can be modified later.
 By default, each policy enables the _system_ integration, which collects system information and metrics.

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -103,8 +103,8 @@ The following table illustrates the {fleet} user actions available to different 
 
 To manage your {agent}s and the data they collect, create a new policy:
 
-. In {fleet}, click **Agent policies -> Create agent policy**.
-Name your policy. All other fields are optional and can be modified later.
+In {fleet}, open the **Agent policies** tab and click **Create agent policy**.
+. Name your policy. All other fields are optional and can be modified later.
 By default, each policy enables the _system_ integration, which collects system information and metrics.
 +
 [role="screenshot"]

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -45,7 +45,7 @@ You can also use matching patterns to give users access to data when creating us
 +
 By default the namespace defined for an {agent} policy is propagated to all integrations in that policy. if you'd like to define a more granular namespace for a policy:
 
-. In {kib}, go to **Management -> Integrations**.
+. In {kib}, go to **Integrations**.
 . On the **Installed integrations** tab, select the integration that you'd like to update.
 . Open the **Integration policies** tab.
 . From the **Actions** menu next to the integration, select *Edit integration*.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
@@ -129,7 +129,7 @@ image::images/guide-nginx-integration-added.png["Nginx Integration added confirm
 
 Rather than opt for {fleet} to centrally manage {agent}, you'll configure an agent to run in standalone mode, so it will be managed by hand.
 
-. Open the {kib} menu and go to **{fleet} -> Agents** and click **Add agent**.
+. In {fleet}, open the **Agents** tab and click **Add agent**.
 . For the **What type of host are you adding?** step, select `nginx-policy` from the drop-down menu if it's not already selected.
 . For the **Enroll in {fleet}?** step, select **Run standalone**.
 +

--- a/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
@@ -115,7 +115,7 @@ password to access {es} (and an API key is required in a {serverless} environmen
 assign it to a user, and specify the user's credentials in the
 `elastic-agent.yml` file.
 
-. In {kib}, for a go to *{stack-manage-app} > Roles*.
+. In {kib}, go to *{stack-manage-app} > Roles*.
 
 . Click *Create role* and enter a name for the role.
 

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -128,7 +128,7 @@ location of installed {agent} files.
 automatically if the system is rebooted.
 
 
-To confirm that {agent} is installed and running, in {fleet}, open the **Agents** tab.
+To confirm that {agent} is installed and running, open the **Agents** tab in {fleet}.
 
 [role="screenshot"]
 image::images/kibana-fleet-agents.png[{fleet} showing enrolled agents]

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -73,7 +73,7 @@ To install an {agent} and enroll it in {fleet}:
 // tag::agent-enroll[]
 
 // lint disable fleet
-. Open {fleet}, and on the **Agents** click **Add agent**.
+. In {fleet}, open the **Agents** tab and click **Add agent**.
 
 . In the *Add agent* flyout, select an existing agent policy or create a new
 one. If you create a new policy, {fleet} generates a new

--- a/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-fleet-managed-elastic-agent.asciidoc
@@ -73,7 +73,7 @@ To install an {agent} and enroll it in {fleet}:
 // tag::agent-enroll[]
 
 // lint disable fleet
-. In {kib}, go to **{fleet} > Agents**, and click **Add agent**.
+. Open {fleet}, and on the **Agents** click **Add agent**.
 
 . In the *Add agent* flyout, select an existing agent policy or create a new
 one. If you create a new policy, {fleet} generates a new
@@ -128,8 +128,7 @@ location of installed {agent} files.
 automatically if the system is rebooted.
 
 
-To confirm that {agent} is installed and running, go to the **Agents** tab in
-{fleet}.
+To confirm that {agent} is installed and running, in {fleet}, open the **Agents** tab.
 
 [role="screenshot"]
 image::images/kibana-fleet-agents.png[{fleet} showing enrolled agents]

--- a/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
@@ -21,7 +21,7 @@ These steps describe how to set up {fleet} components to use a proxy.
 
 . **Globally add proxy server details to {fleet}.**
 
-.. In {kib}, navigate to the **Fleet** page and go to the **Settings** tab.
+.. Open {fleet} and go to the **Settings** tab.
 .. Select **Add proxy**. The **Add proxy** or **Edit proxy** flyout opens.
 +
 image::images/elastic-agent-proxy-edit-proxy.png[Screen capture of the Edit Proxy UI in Fleet]
@@ -34,7 +34,7 @@ image::images/elastic-agent-proxy-edit-proxy.png[Screen capture of the Edit Prox
 +
 If the control plane traffic to/from the Fleet Server needs to also go through the proxy server, the proxy created needs to also be added to the definition of that Fleet Server.
 
-.. In {kib}, navigate to the **Fleet** page and go to the **Settings** tab.
+.. Open {fleet} and and go to the **Settings** tab.
 .. In the list of **Fleet Server Hosts**, choose a host and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +
@@ -52,7 +52,7 @@ Any invalid changes to the {fleet-server} definition that may cause connectivity
 +
 Similarly, if the data plane traffic to an output is to traverse via a proxy, that proxy definition would need to be added to the output defined in the Fleet.
 
-.. In {kib}, navigate to the **Fleet** page and go to the **Settings** tab.
+.. Open {fleet} and and go to the **Settings** tab.
 .. In the list of **Outputs**, choose an output and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +
@@ -72,7 +72,7 @@ beta[]
 +
 Likewise, if the download traffic to or from the artifact registry needs to go through the proxy server, that proxy definition also needs to be added to the agent binary source defined in {Fleet}.
 
-.. In {kib}, navigate to the **Fleet** page and go to the **Settings** tab.
+.. Open {fleet} and and go to the **Settings** tab.
 .. In the **Agent Binary Download** list, choose an agent binary source and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +

--- a/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
@@ -21,7 +21,7 @@ These steps describe how to set up {fleet} components to use a proxy.
 
 . **Globally add proxy server details to {fleet}.**
 
-.. Open {fleet} and go to the **Settings** tab.
+.. In {fleet}, open the **Settings** tab.
 .. Select **Add proxy**. The **Add proxy** or **Edit proxy** flyout opens.
 +
 image::images/elastic-agent-proxy-edit-proxy.png[Screen capture of the Edit Proxy UI in Fleet]
@@ -34,7 +34,7 @@ image::images/elastic-agent-proxy-edit-proxy.png[Screen capture of the Edit Prox
 +
 If the control plane traffic to/from the Fleet Server needs to also go through the proxy server, the proxy created needs to also be added to the definition of that Fleet Server.
 
-.. Open {fleet} and and go to the **Settings** tab.
+.. In {fleet}, open the **Settings** tab.
 .. In the list of **Fleet Server Hosts**, choose a host and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +
@@ -52,7 +52,7 @@ Any invalid changes to the {fleet-server} definition that may cause connectivity
 +
 Similarly, if the data plane traffic to an output is to traverse via a proxy, that proxy definition would need to be added to the output defined in the Fleet.
 
-.. Open {fleet} and and go to the **Settings** tab.
+.. In {fleet}, open the **Settings** tab.
 .. In the list of **Outputs**, choose an output and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +
@@ -72,7 +72,7 @@ beta[]
 +
 Likewise, if the download traffic to or from the artifact registry needs to go through the proxy server, that proxy definition also needs to be added to the agent binary source defined in {Fleet}.
 
-.. Open {fleet} and and go to the **Settings** tab.
+.. In {fleet}, open the **Settings** tab.
 .. In the **Agent Binary Download** list, choose an agent binary source and select the edit button to configure it.
 .. In the **Proxy** section dropdown list, select the proxy that you configured.
 +

--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -72,7 +72,7 @@ NOTE: If you do not specify the port for {es} as 443, the {agent} defaults to 92
 
 To confirm that an {integrations-server} is available in your deployment:
 
-. In {kib}, go to *Management* -> *{fleet}*.
+. Open {fleet}.
 . On the **Agents** tab, look for the **{ecloud} agent policy**. This policy is
 managed by {ecloud}, and contains a {fleet-server} integration and an Elastic
 APM integration. You cannot modify the policy. Confirm that the agent status is

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -104,7 +104,7 @@ and configures the {agent} running on the {fleet-server} host to launch a
 
 To create a {fleet-server} policy:
 
-. Open {fleet} and go to the **Agent policies** tab.
+. In {fleet}, open the **Agent policies** tab.
 
 . Click on the **Create agent policy** button, then:
 .. Provide a meaningful name for the policy that will help you identify this {fleet-server} (or cluster) in the future.

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -104,7 +104,7 @@ and configures the {agent} running on the {fleet-server} host to launch a
 
 To create a {fleet-server} policy:
 
-. In {kib}, navigate to the **{fleet}** page and go to the **Agent policies** tab.
+. Open {fleet} and go to the **Agent policies** tab.
 
 . Click on the **Create agent policy** button, then:
 .. Provide a meaningful name for the policy that will help you identify this {fleet-server} (or cluster) in the future.
@@ -136,8 +136,7 @@ The policy configures the agent to operate in a special mode to serve as a {flee
 
 To add a {fleet-server}:
 
-. In {kib}, go to *Management* -> *{fleet}*
-. Click the **Agents** tab.
+. In {fleet}, open the **Agents** tab.
 . Click *Add {fleet-server}*.
 
 . This will open in-product instructions for adding a {fleet-server} using 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -120,7 +120,7 @@ of agents you plan to support in your deployment.
 // tag::add-fleet-server-host[]
 To add a {fleet-server} host:
 
-. In {kib}, go to *Management* -> *{fleet}* -> *Settings*.
+. In {fleet}, open the *Settings* tab.
 For more information about these settings, see
 {fleet-guide}/fleet-settings.html[{fleet} settings].
 
@@ -160,8 +160,7 @@ The policy configures the agent to operate in a special mode to serve as a {flee
 
 To add a {fleet-server}:
 
-. In {kib}, go to *Management* -> *{fleet}*
-. Click the **Agents** tab if it isn't already selected.
+. In {fleet}, open the **Agents** tab.
 . Click *Add {fleet-server}*.
 . This opens in-product instructions to add a {fleet-server} using 
 one of two options: *Quick Start* or *Advanced*.

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -257,7 +257,7 @@ Make sure you have a plan or automation in place to update your artifact
 registry when new versions of {agent} are available.
 ====
 . Add the agent binary download location to {fleet} settings:
-.. In {kib}, go to **{fleet} -> Settings**.
+.. Open **{fleet} -> Settings**.
 .. Under **Agent Binary Download**, click **Add agent binary source** to add
 the location of your artifact registry. For more detail about these settings,
 refer to <<fleet-agent-binary-download-settings>>. If you want all {agent}s

--- a/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
@@ -13,7 +13,7 @@ new agent policy or use the existing Default {fleet-server} agent policy.
 
 To monitor {fleet-server}:
 
-. In {kib}, go to **Management > {fleet} > Agent Policies**.
+. In {fleet}, go to the **Agent Policies** tab.
 
 . Click the {fleet-server} policy name to edit the policy.
 

--- a/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-monitoring.asciidoc
@@ -13,7 +13,7 @@ new agent policy or use the existing Default {fleet-server} agent policy.
 
 To monitor {fleet-server}:
 
-. In {fleet}, go to the **Agent Policies** tab.
+. In {fleet}, open the **Agent policies** tab.
 
 . Click the {fleet-server} policy name to edit the policy.
 

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -27,7 +27,7 @@ image::images/fleet-server-hosted-container.png[{fleet-server} hosted agent]
 
 Next modify the {fleet-server} configuration by editing the agent policy:
 
-. In {kib}, go to **Management > {fleet} > Agent Policies**. Click the name of
+. In {fleet}, go to the **Agent Policies** tab. Click the name of
 the **{ecloud} agent policy** to edit the policy.
 
 . Open the **Actions** menu next to the {fleet-server} integration and click

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -27,8 +27,7 @@ image::images/fleet-server-hosted-container.png[{fleet-server} hosted agent]
 
 Next modify the {fleet-server} configuration by editing the agent policy:
 
-. In {fleet}, go to the **Agent Policies** tab. Click the name of
-the **{ecloud} agent policy** to edit the policy.
+. In {fleet}, open the **Agent policies** tab. Click the name of the **{ecloud} agent policy** to edit the policy.
 
 . Open the **Actions** menu next to the {fleet-server} integration and click
 **Edit integration**.

--- a/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
@@ -9,7 +9,7 @@ A remote {es} cluster supports the same <<es-output-settings,output settings>> a
 
 To configure a remote {es} cluster for your {agent} data:
 
-. In {kib}, go to **Management -> {fleet} -> Settings**.
+. In {fleet}, open the **Settings** tab.
 
 . In the **Outputs** section, select **Add output**.
 
@@ -47,7 +47,7 @@ NOTE: To prevent unauthorized access the {es} Service Token is stored as a secre
 
 After the output is created, you can update an {agent} policy to use the new remote {es} cluster:
 
-. In {kib}, go to **Management -> {fleet} -> Agent policies**.
+. In {fleet}, open the **Agent policies** tab.
 
 . Click the agent policy to edit it, then click **Settings**.
 

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -68,7 +68,7 @@ using {kibana-ref}/kuery-query.html[{kib} Query Language]. For example, enter
 
 In {fleet}, you can access the detailed status of an individual agent and the integrations that are associated with it through the agent policy.
 
-. In {kib}, go to **Management -> {fleet} -> Agents**.
+. In {fleet}, open the **Agents** tab.
 
 . In the **Host** column, click the agent's name.
 
@@ -103,7 +103,7 @@ When {fleet} reports an agent status like `Offline` or `Unhealthy`, you might
 want to view the agent logs to diagnose potential causes. If agent monitoring
 is configured to collect logs (the default), you can view agent logs in {fleet}.
 
-. In {kib}, go to **Management -> {fleet} -> Agents**.
+. In {fleet}, open the **Agents** tab.
 
 . In the **Host** column, click the agent's name.
 
@@ -165,7 +165,7 @@ logs informational messages, warnings, errors, and critical errors.
 An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state.
 To download the diagnostics bundle for local viewing:
 
-. In {kib}, go to **Management -> {fleet} -> Agents**.
+. In {fleet}, open the **Agents** tab.
 
 . In the **Host** column, click the agent's name.
 
@@ -191,7 +191,7 @@ help you identify problems and make decisions about scaling your deployment.
 
 To view agent metrics:
 
-. In {kib}, go to **Management -> {fleet} -> Agents**.
+. In {fleet}, open the **Agents** tab.
 
 . In the **Host** column, click the agent's name.
 
@@ -214,7 +214,7 @@ your needs.
 Agent monitoring is turned on by default in the agent policy. To change agent
 monitoring settings for all agents enrolled in a specific agent policy:
 
-. In {kib}, go to **Management -> {fleet} -> Agent policies**.
+. In {fleet}, open the **Agent policies** tab.
 
 . Click the agent policy to edit it, then click **Settings**.
 

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -8,7 +8,7 @@
 Policies consist of one or more integrations. To add a new integration to a
 policy:
 
-. In {kib}, go to **Management -> Integrations**.
+. In {kib}, go to the **Integrations** page.
 +
 Notice that the Integrations page shows {agent} integrations along with other
 types, such as {beats}.

--- a/docs/en/ingest-management/integrations/edit-or-delete-integration-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/edit-or-delete-integration-policy.asciidoc
@@ -8,7 +8,7 @@
 
 To edit or delete an integration policy:
 
-. In {kib}, go to *Management > Integrations > Installed*. Search
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search
 for and select the integration.
 
 . Click the *Policies* tab to see the list of integration policies.

--- a/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/install-integration-assets.asciidoc
@@ -15,7 +15,7 @@ index templates.
 [[install-integration-assets]]
 == Install integration assets
 
-. In {kib}, go to **Management > Integrations > Browse integrations**. Search for
+. In {kib}, go to the **Integrations** page and open the **Browse integrations** tab. Search for
 and select an integration. You can select a category to narrow your search.
 
 . Click the **Settings** tab.
@@ -45,7 +45,7 @@ by the integration.
 +
 Any {agent}s enrolled in the policy will stop using the deleted integration.
 
-. In {kib}, go to **Management > Integrations > Installed integrations**. Search for
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search for
 and select an integration.
 
 . Click the **Settings** tab.
@@ -68,7 +68,7 @@ installation or upgrade.
 
 To reinstall integration assets:
 
-. In {kib}, go to **Management > Integrations > Installed integrations**. Search for
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search for
 and select an integration.
 
 . Click the **Settings** tab.

--- a/docs/en/ingest-management/integrations/integrations.asciidoc
+++ b/docs/en/ingest-management/integrations/integrations.asciidoc
@@ -7,7 +7,7 @@
 
 ****
 Integrations are available for a wide array of popular services and platforms. To
-see the full list of available integrations, go to *Management > Integrations*
+see the full list of available integrations, go to the *Integrations* page
 in {kib}, or visit {integrations-docs}[Elastic Integrations].
 
 {agent} integrations provide a simple, unified way to collect data from popular

--- a/docs/en/ingest-management/integrations/upgrade-integration.asciidoc
+++ b/docs/en/ingest-management/integrations/upgrade-integration.asciidoc
@@ -23,7 +23,7 @@ TIP: In larger deployments, you should test integration upgrades on a sample
 [[upgrade-integration-to-latest-version]]
 == Upgrade an integration to the latest version
 
-. In {kib}, go to *Management > Integrations > Installed integrations*. Search
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search
 for and select the integration you want to upgrade. Notice there is a warning
 icon next to the version number to indicate a new version is available.
 
@@ -74,7 +74,7 @@ upgrade, your integration policies will not be upgraded, and you'll need to
 
 To keep integration policies up to data automatically:
 
-. In {kib}, go to *Management > Integrations > Installed Integrations*. Search for
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search for
 and select the integration you want to configure.
 
 . Click *Settings* and make sure

--- a/docs/en/ingest-management/integrations/view-integration-assets.asciidoc
+++ b/docs/en/ingest-management/integrations/view-integration-assets.asciidoc
@@ -10,7 +10,7 @@ searches, and visualizations for analyzing data.
 
 To view integration assets:
 
-. In {kib}, go to *Management > Integrations > Installed*. Search for and select
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search for and select
 the integration you want to view.
 
 . Click the *Assets* tab to see a list of assets. If this tab does not exist,

--- a/docs/en/ingest-management/integrations/view-integration-policies.asciidoc
+++ b/docs/en/ingest-management/integrations/view-integration-policies.asciidoc
@@ -10,7 +10,7 @@ policy.
 
 To view details about all the integration policies for a specific integration:
 
-. In {kib}, go to *Management > Integrations > Installed*. Search for and select
+. In {kib}, go to the **Integrations** page and open the **Installed integrations** tab. Search for and select
 the integration you want to view. You can select a category to narrow your search.
 
 . Click the *Policies* tab to see the list of integration policies.

--- a/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
+++ b/docs/en/ingest-management/migrate-beats-to-agent.asciidoc
@@ -258,8 +258,7 @@ You must define processors in each integration policy where they are required.
 
 To add processors to an integration policy:
 
-. In {kib}, go to *{fleet} > Agent policies*, and click the policy name to view
-its integration policies.
+. In {fleet}, open the *Agent policies* tab and click the policy name to view its integration policies.
 
 . Click the name of the integration policy to edit it.
 

--- a/docs/en/ingest-management/serverless-restrictions.asciidoc
+++ b/docs/en/ingest-management/serverless-restrictions.asciidoc
@@ -19,6 +19,17 @@ If you are using {agent} with link:{serverless-docs}[{serverless-full}], note th
 
 * On {serverless-short}, you can configure new {es} outputs to use a proxy, with the restriction that the output URL is fixed. Any new {es} outputs must use the default {es} host URL.
 
+
+[discrete]
+[[fleet-serverless-restrictions]]
+== {fleet}
+
+The path to get to the {fleet} application in {kib} differs across projects:
+
+* In {ess} deployments, navigate to **Management > Fleet**.
+* In {serverless-short} {observability} projects, navigate to **Project settings > Fleet**.
+* In {serverless-short} Security projects, navigate to **Assets > Fleet**.
+
 [discrete]
 [[fleet-server-serverless-restrictions]]
 == {fleet-server}

--- a/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/add-fleet-server/content.asciidoc
@@ -6,8 +6,8 @@ deployment.
 
 To confirm that an {integrations-server} is available in your deployment:
 
-. In {kib}, go to **Management > {fleet}**.
-. On the **Agents** tab, look for the **{ecloud} agent policy**. This policy is
+. In {fleet}, open the **Agents** tab.
+. Look for the **{ecloud} agent policy**. This policy is
 managed by {ecloud}, and contains a {fleet-server} integration and an Elastic
 APM integration. You cannot modify the policy. Confirm that the agent status is
 **Healthy**.
@@ -32,7 +32,7 @@ NOTE: You can install only a single {agent} per host, which means you cannot run
 {fleet-server} and another {agent} on the same host unless you deploy a
 containerized {fleet-server}.
 
-. In {kib}, go to **Management > {fleet} > Settings**. For more information
+. In {fleet}, open the **Settings** tab. For more information
 about these settings, see {fleet-guide}/fleet-settings.html[{fleet} settings].
 // lint ignore fleet-server
 . Under **Fleet Server hosts**, click **Edit hosts** and specify one or more host

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -418,7 +418,7 @@ elastic-agent diagnostics
 An agent can gather and upload diagnostics if it is online in a `Healthy` or `Unhealthy` state. The diagnostics are sent to {fleet-server} which in turn adds it into {es}. Therefore, this works even with {agents} that are not using the {es} output.
 To download the diagnostics bundle for local viewing:
 
-. In {kib}, go to **Management -> {fleet} -> Agents**.
+. In {fleet}, open the **Agents** tab.
 
 . In the **Host** column, click the agent's name.
 
@@ -745,7 +745,7 @@ There are two approaches to fixing this issue, depending on whether or not the t
 
 To recover the {agent}:
 
-. In {kib}, go to **Fleet > Agents**, and click **Add agent**.
+. In {fleet}, open the **Agents** tab and click **Add agent**.
 
 . In the **Add agent** flyout, select an agent policy that contains the **Fleet Server** integration. On Elastic Cloud you can use the **Elastic Cloud agent policy** which includes the integration.
 


### PR DESCRIPTION
The path to Fleet is different between hosted and serverless, and on serverless between Observability and Security deployments, so we'll update the path to simply "Open Fleet" or "In Fleet, ...".

This also makes a note of the different paths on the [serverless restrictions](https://www.elastic.co/guide/en/fleet/current/fleet-agent-serverless-restrictions.html) page:
![Screenshot 2024-04-01 at 5 42 51 PM](https://github.com/elastic/ingest-docs/assets/41695641/76ffc756-1b5b-4213-9cdf-062537316508)

Closes: #989