### PR TITLE
Add Fleet & Agent 8.13.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.13.2>>
 * <<release-notes-8.13.1>>
 * <<release-notes-8.13.0>>
 
@@ -21,6 +22,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.13.2 relnotes
+
+[[release-notes-8.13.2]]
+== {fleet} and {agent} 8.13.2
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 8.13.2 relnotes
 
 // begin 8.13.1 relnotes
 


### PR DESCRIPTION
This adds the 8.13.1 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR]() TBD
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/128b75740ec726db1da6b57199add0e59ca45880/changelog/fragments) (No new entries)
* Elastic Agent contents from:
    * [BC1 "core" changelog](https://github.com/elastic/elastic-agent/tree/379dfc0203e9f5629740f6ac2bd7bf3f47861d56/changelog/fragments) (No new entries)
    * [BC1 "package" changelog](https://github.com/elastic/elastic-agent/tree/379dfc0203e9f5629740f6ac2bd7bf3f47861d56/changelog/fragments) (No new entries)

Closes: #1002

Docs preview:
![Screenshot 2024-04-05 at 5 38 21 PM](https://github.com/elastic/ingest-docs/assets/41695641/0c39e22d-af39-4b68-867b-60ba08b8f903)
