### PR TITLE
Add Fleet & Agent 7.17.20 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.20>>
+
 * <<release-notes-7.17.19>>
 
 * <<release-notes-7.17.18>>
@@ -58,6 +60,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.20 relnotes
+
+[[release-notes-7.17.20]]
+== {fleet} and {agent} 7.17.20
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.20 relnotes
 
 // begin 7.17.19 relnotes
 


### PR DESCRIPTION
This adds the 7.17.20 Fleet & Agent Release Notes:

Fleet: no RN entries in [Kibana PR](https://github.com/elastic/kibana/pull/180265)
Fleet Server: No fragments in [BC1](https://github.com/elastic/fleet-server/tree/0cef32c516c94dfc3eb4203c0221c1abf8ce8a74/changelog/fragments)
Elastic Agent: no fragments in
 - [agent core BC1](https://github.com/elastic/elastic-agent/tree/ada5934fde471dd24481e62ae8a09d1808b69b39/changelog/fragments)
 - [agent package BC1](https://github.com/elastic/elastic-agent/tree/ada5934fde471dd24481e62ae8a09d1808b69b39/changelog/fragments)

Rel: #1002 

---
![Screenshot 2024-04-05 at 5 58 26 PM](https://github.com/elastic/ingest-docs/assets/41695641/40ee1a13-7135-4f8b-aed4-4ce8f09eaa06)
