### PR TITLE
Add details on load balance behaviour with Logstash output

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -302,6 +302,18 @@ load balances published events onto all {ls} hosts. If `false`,
 the output plugin sends all events to one host (determined at random) and
 switches to another host if the selected one becomes unresponsive.
 
+With `loadbalance` enabled:
+
+* {agent} reads batches of events and sends each batch to one {ls} worker dynamically, based on a work-queue shared between the outputs.
+* If a connection drops, {agent} takes the disconnected {ls} worker out of its pool.
+* {agent} tries to reconnect. If it succeeds, it re-adds the {ls} worker to the pool.
+* If one of the {ls} nodes is slow but "healthy", it sends a keep-alive signal until the full batch of data is processed. This prevents {agent} from sending further data until it receives an acknowledgement signal back from {ls}. {agent} keeps all events in memory until after that acknowledgement occurs.
+
+Without `loadbalance` enabled:
+
+* {agent} picks a random {ls} host and sends batches of events to it. Due to the random algorithm, the load on the {ls} nodes should be roughly equal.
+* In case of any errors, {agent} picks another {ls} node, also at random. If a connection to a host fails, the host is retried only if there are errors on the new connection.
+
 *Default:* `false`
 
 Example:


### PR DESCRIPTION
This updates the two Logstash output settings pages (one for standalone agent and one for Fleet-manged agent) to provide more detail on the `loadbalance` setting.

To preview changes, see the `loadbalance` setting [here](https://ingest-docs_bk_1024.docs-preview.app.elstc.co/guide/en/fleet/master/ls-output-settings.html).

Details are from the discussion in `https://github.com/elastic/beats/issues/12567`.

Closes: #1023


