### PR TITLE
Update overview with link to general Adding Data to ES docs

### DIFF
--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -22,6 +22,8 @@ To learn about installation options, refer to <<elastic-agent-installation>>.
 
 IMPORTANT: Using {fleet} and {agent} with link:{serverless-docs}[{serverless-full}]? Please note these <<fleet-agent-serverless-restrictions,restrictions>>.
 
+TIP: Looking for a general guide that explores all of your options for ingesting data? Check out {cloud}/ec-cloud-ingest-data.html[Adding data to Elasticsearch].
+
 [discrete]
 [[unified-integrations]]
 == {integrations}


### PR DESCRIPTION
This advertises the more general and very helpful [Adding data to Elasticsearch](https://www.elastic.co/guide/en/cloud/current/ec-cloud-ingest-data.html) page from the Fleet & Agent overview.

Rel: https://github.com/elastic/platform-docs-team/issues/329