### PR TITLE
Update 8.12.2 release notes for MSI slash issue

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -31,6 +31,25 @@ Also see:
 Review important information about {fleet-server} and {agent} for the 8.12.2 release.
 
 [discrete]
+[[known-issues-8.12.2]]
+=== Known issues
+
+[[known-issue-241-8.12.2]]
+.Beats MSI binaries do not support directories with a trailing slash
+[%collapsible]
+====
+
+*Details*
+
+Due to changes introduced to support customizing an MSI install folder (see link:https://github.com/elastic/elastic-stack-installers/pull/209[#209]), Beats MSI binaries, which currently are in beta, will not properly handle directories that end in a slash. This defect may affect many deployments using the {beats} MSI binaries.
+
+*Impact* +
+
+This issue has been link:https://github.com/elastic/elastic-stack-installers/pull/264[resolved] in version 8.14.0 and later releases. We recommend users of {beats} MSI to upgrade to 8.14 when that release becomes available.
+
+====
+
+[discrete]
 [[bug-fixes-8.12.2]]
 === Bug fixes
 


### PR DESCRIPTION
This is the same as https://github.com/elastic/ingest-docs/pull/1028, targetting the 8.12.2 Release Notes.