### PR TITLE
Add docs for Fleet Server with multiple ES hosts

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-multiple-hosts.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-multiple-hosts.asciidoc
@@ -1,0 +1,12 @@
+[[fleet-server-multiple-hosts]]
+= {fleet-server} with multiple Elasticsearch hosts
+
+{fleet-server} normally expects the Elasticsearch host that it enrolled with during installation to be available. In the event that that host becomes unavailable, other configured Elasticsearch hosts can be used, but with a few assumptions and restrictions:
+
+. The Elasticsearch host URL that is used to enroll a new {fleet-server} will never be removed from the {fleet-server} configuration.
+
+. In order for the output settings that {fleet-server} retrieves from the {fleet-server} policy to be considered valid, {fleet-server} must be able to connect to at least one of the hosts specified in the policy.
+
+. {fleet-server} gives precedence to attributes from the {fleet-server} policy when it is available. For example, if the flag `--fleet-server-es-ca` is used when {fleet-server} enrolls, and the output that {fleet-server} is currently using contains the flag `ssl.certificate_authorities`, {fleet-server} will attempt to use `ssl.certificate_authorities` as the authentication setting. If the output does not contain `ssl.certificate_authorities` then the value from when {fleet-server} initially enrolled is used.
++
+This behavior can cause issues when the agent in which {fleet-server} is running restarts or is upgraded. Settings that are specified in the {fleet-server} policy that were not used used during the agent's enrollment are lost when the agent restarts. To avoid issues, make sure that the settings used when the {fleet-server} instance first enrolled are always valid.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -31,6 +31,8 @@ include::fleet/fleet-server-secrets.asciidoc[leveloffset=+2]
 
 include::fleet/fleet-server-monitoring.asciidoc[leveloffset=+2]
 
+include::fleet/fleet-server-multiple-hosts.asciidoc[leveloffset=+2]
+
 include::elastic-agent/install-elastic-agent.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-elastic-agent.asciidoc[leveloffset=+2]


### PR DESCRIPTION
This adds a page explaining Fleet Servers behavior for supporting multiple Elasticsearch hosts.

Closes #1033

@michel-laterman Here's a [docs preview](https://ingest-docs_bk_1034.docs-preview.app.elstc.co/guide/en/fleet/master/fleet-server-multiple-hosts.html). I tried to rephrase things a bit so please let me know if I misunderstood anything.