### PR TITLE
Add docs for MSI install

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
@@ -1,0 +1,61 @@
+[[install-agent-msi]]
+= Install {agent} from an MSI package
+
+MSI is the file format and command line utility for the link:https://en.wikipedia.org/wiki/Windows_Installer[Windows Installer]. Windows Installer (previously known as Microsoft Installer) is an interface for Microsoft Windows that’s used to install and manage software on Windows systems. This section covers installing Elastic Agent through the MSI package repository.
+
+The MSI package installer must be run by an administrator account. The installer won't start without Windows admin permissions.
+
+[discrete]
+== Install {agent}
+
+. Download the latest Elastic Agent MSI binary from the link:https://www.elastic.co/downloads/elastic-agent[{agent} download page].
+
+. Run the installer:
++
+[source,shell]
+----
+elastic-agent-<VERSION>-windows-x86_64.msi INSTALLARGS="--url=<URL> --enrollment-token=<TOKEN>"
+----
++
+Where:
+
+* `VERSION` is the {stack} version you're installing, indicated in the MSI package name. For example, `8.13.2`.
+* `URL` is the {fleet-server} URL used to enroll the {agent} into {fleet}. You can find this on the {fleet} *Settings* tab in {kib}.
+* `TOKEN` is the authentication token used to enroll the {agent} into {fleet}. You can find this on the {fleet} *Enrollment tokens* tab.
+
++
+When you run the command, the value set for `INSTALLARGS` will be passed to the <<elastic-agent-install-command,`elastic-agent install`>> command verbatim.
+
+. If you need to troubleshoot, you can install using `msiexec` with the `-L*V "log.txt"` option to create installation logs:
++
+[source,shell]
+----
+msiexec -i elastic-agent-<VERSION>-windows-x86_64.msi INSTALLARGS="--url=<URL> --enrollment-token=<TOKEN>"  -L*V "log.txt"
+----
+
+[discrete]
+== Installation notes
+
+Installing using an MSI package has the following behaviors:
+
+* If `INSTALLARGS` are not provided, the MSI will copy the files to a temporary folder and finish.
+* If `INSTALLARGS` are provided, the MSI will copy the files to a temporary folder and then run the <<elastic-agent-install-command,`elastic-agent install`>> command with the provided parameters. If the install flow is successful, the temporary folder is deleted.
+* If `INSTALLARGS` are provided but the `elastic-agent install` command fails, the top-level folder is NOT deleted, in order to allow for further troubleshooting.
+* If the `elastic-agent install` command fails for any reason, the MSI will rollback all changes.
+* If the {agent} enrollment fails, the install will fail as well. To avoid this behavior you can add the <<elastic-agent-install-command,`--delay-enroll`>> option to the install command.
+
+[discrete]
+== Upgrading
+
+Upgrades are not supported and are prevented by the MSI itself. Instead, all of your {agent} upgrades can be managed in {fleet}.
+
+[discrete]
+== Installing in a custom location
+
+Starting in version 8.13, it's also possible to override the default installation folder by running the MSI from the command line, as shown:
+
+[source,shell]
+----
+msiexec /i "<full path to msi file>" INSTALLDIR="<path of custom folder>"
+----
+

--- a/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
@@ -56,6 +56,6 @@ Starting in version 8.13, it's also possible to override the default installatio
 
 [source,shell]
 ----
-msiexec /i "<full path to msi file>" INSTALLDIR="<path of custom folder>"
+elastic-agent-<VERSION>-windows-x86_64.msi INSTALLARGS="--url=<URL> --enrollment-token=<TOKEN>" INSTALLDIR="<path of custom folder>"
 ----
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -65,6 +65,8 @@ include::elastic-agent/ingest-pipeline-kubernetes.asciidoc[leveloffset=+3]
 
 include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]
 
+include::elastic-agent/install-agent-msi.asciidoc[leveloffset=+2]
+
 include::elastic-agent/installation-layout.asciidoc[leveloffset=+2]
 
 include::fleet/air-gapped.asciidoc[leveloffset=+2]


### PR DESCRIPTION
Adds docs for installing Elastic Agent via the newly supported MSI packages, which will GA in 8.14.

Thanks for the nice draft, Amit! Please see [PREVIEW PAGE](https://ingest-docs_bk_1039.docs-preview.app.elstc.co/guide/en/fleet/master/install-agent-msi.html)

Closes: #1036 
