### PR TITLE
Fix incorrect 'Agents tab' reference in Fleet Server setup

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -73,7 +73,7 @@ NOTE: If you do not specify the port for {es} as 443, the {agent} defaults to 92
 To confirm that an {integrations-server} is available in your deployment:
 
 . Open {fleet}.
-. On the **Agents** tab, look for the **{ecloud} agent policy**. This policy is
+. On the **Agent policies** tab, look for the **{ecloud} agent policy**. This policy is
 managed by {ecloud}, and contains a {fleet-server} integration and an Elastic
 APM integration. You cannot modify the policy. Confirm that the agent status is
 **Healthy**.


### PR DESCRIPTION
This fixes an issue reported in the docs feedback spreadsheet, specifically that we refer to a setting on the "Agents" tab that is actually on the "Agent policies" tab.

