### PR TITLE
Add Fleet & Agent 7.17.21 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.21>>
+
 * <<release-notes-7.17.20>>
 
 * <<release-notes-7.17.19>>
@@ -60,6 +62,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.21 relnotes
+
+[[release-notes-7.17.21]]
+== {fleet} and {agent} 7.17.21
+
+The <<known-issue-3435,known issue>> introduced in version 7.17.20, that was causing {fleet-server} to fail to bootstrap with self-signed certificates, is resolved in this release. {fleet-server-pull}13473[#3473]  
+
+// end 7.17.21 relnotes
 
 // begin 7.17.20 relnotes
 


### PR DESCRIPTION
This adds the 7.17.21 Fleet & Agent Release Notes:

 - Fleet: no entries in [Kibana RN PR](https://github.com/elastic/kibana/pull/182258)
 - Fleet Server: [No new fragments](https://github.com/elastic/fleet-server/tree/1de2432998bbfc96e98bc23fbfb72694d02f4829/changelog/fragments) in BC1
 - Elastic Agent: no fragments in
    - [agent core BC1](https://github.com/elastic/elastic-agent/tree/0c3ad3aafa4dc7482cd2fd568445cbe6cf6643fe/changelog/fragments)
    - [agent package BC1](https://github.com/elastic/elastic-agent/tree/0c3ad3aafa4dc7482cd2fd568445cbe6cf6643fe/changelog/fragments)

Rel: https://github.com/elastic/ingest-docs/issues/1047

Here's the [link](https://www.elastic.co/guide/en/fleet/7.17/release-notes-7.17.20.html#known-issues-7.17.20) to the known issue that indicated as being fixed in this release.

---

![Screenshot 2024-04-24 at 1 56 30 PM](https://github.com/elastic/ingest-docs/assets/41695641/a0ce0c18-5eb1-4eb6-bb58-99236fa57ac5)
