### PR TITLE
Add warning about storing certificates not locally

### DIFF
--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -95,7 +95,7 @@ securely.
 ====
 Certificate files used by {agent} must be on the local file system of the host where 
 {agent} is running. Using certificates from a network share is not supported and can 
-cause {agent} failing to start.
+cause {agent} to fail to start.
 ====
 
 For the steps in this section, imagine you have the following files:

--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -91,6 +91,13 @@ traffic between {agent}s and {fleet-server}.
 needs to expose a {fleet-server} certificate so other {agent}s can connect to it
 securely.
 
+[IMPORTANT]
+====
+Certificate files used by {agent} must be on the local file system of the host where 
+{agent} is running. Using certificates from a network share is not supported and can 
+cause {agent} failing to start.
+====
+
 For the steps in this section, imagine you have the following files:
 
 [cols=2*]


### PR DESCRIPTION
Some customers use network shares for storing certificates which leads to Elastic Agent service failing to run on OS startup.

<img width="879" alt="Screenshot 2024-04-26 at 14 28 56" src="https://github.com/elastic/ingest-docs/assets/887952/40322d77-3c87-4862-b2f7-a938ad90e06d">