### PR TITLE
Add Fleet & Agent 8.13.3 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.13.3>>
 * <<release-notes-8.13.2>>
 * <<release-notes-8.13.1>>
 * <<release-notes-8.13.0>>
@@ -22,6 +23,33 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.13.3 relnotes
+
+[[release-notes-8.13.3]]
+== {fleet} and {agent} 8.13.3
+
+Review important information about {fleet-server} and {agent} for the 8.13.3 release.
+
+[discrete]
+[[security-updates-8.13.3]]
+=== Security updates
+
+{agent}::
+* Update Go version to 1.21.9. {agent-pull}4508[#4508]
+
+[discrete]
+[[bug-fixes-8.13.3]]
+=== Bug fixes
+
+//{fleet}::
+//
+
+{agent}::
+* Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
+* Fix failing upgrade command when the connection to an {agent} is disconnected. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
+
+// end 8.13.3 relnotes
 
 // begin 8.13.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -50,9 +50,8 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 {agent}::
 * Fix unconditionally logging all 400 HTTP responses from {fleet-server} as API compatibility errors. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
 * Allow the `elastic-agent upgrade` command to succeed when the agent restarts before it has completely acknowledged the upgrade. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
-
-* Only allow installing Elastic Defend on Windows kernels newer than 6, i.e. Windows 10 /
-Server 2016 and newer
+* Only allow installing Elastic Defend on Windows kernels newer than 6, that is, Windows 10 /
+Server 2016 and newer.
 // end 8.13.3 relnotes
 
 // begin 8.13.2 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -42,8 +42,10 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 [[bug-fixes-8.13.3]]
 === Bug fixes
 
-//{fleet}::
-//
+{fleet}::
+* Fix managed agent policy preconfiguration update. ({kibana-pull}181624[#181624])
+* Use lowercase dataset name in template and pipeline names. ({kibana-pull}180887[#180887])
+* Fix KQL/kuery for getting {fleet-server} agent count. ({kibana-pull}180650[#180650])
 
 {agent}::
 * Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -48,7 +48,7 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 * Fix KQL/kuery for getting {fleet-server} agent count. ({kibana-pull}180650[#180650])
 
 {agent}::
-* Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
+* Fix unconditionally logging all 400 HTTP responses from {fleet-server} as API compatibility errors. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
 * Fix failing upgrade command when the connection to an {agent} is disconnected. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
 
 // end 8.13.3 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -49,7 +49,7 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 
 {agent}::
 * Fix unconditionally logging all 400 HTTP responses from {fleet-server} as API compatibility errors. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
-* Fix failing upgrade command when the connection to an {agent} is disconnected. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
+* Allow the `elastic-agent upgrade` command to succeed when the agent restarts before it has completely acknowledged the upgrade. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
 
 // end 8.13.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -51,6 +51,8 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 * Fix unconditionally logging all 400 HTTP responses from {fleet-server} as API compatibility errors. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
 * Allow the `elastic-agent upgrade` command to succeed when the agent restarts before it has completely acknowledged the upgrade. {agent-pull}4519[#4519] {agent-issue}3890[#3890s]
 
+* Only allow installing Elastic Defend on Windows kernels newer than 6, i.e. Windows 10 /
+Server 2016 and newer
 // end 8.13.3 relnotes
 
 // begin 8.13.2 relnotes


### PR DESCRIPTION
This adds the 8.13.3 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/182254)
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/43a5ff9822f3943c3c4feb07ff19c738bf8c8b5a/changelog/fragments) (No new entries)
* Elastic Agent contents from:
    * [BC1 "core" changelog](https://github.com/elastic/elastic-agent/tree/fe984fda6347991e6fe684b1c5c8821578842401/changelog/fragments)
    * [BC1 "package" changelog](https://github.com/elastic/elastic-agent/tree/fe984fda6347991e6fe684b1c5c8821578842401/changelog/fragments)

Closes: #1047

PREVIEW
---

![Screenshot 2024-05-01 at 11 27 10 AM](https://github.com/elastic/ingest-docs/assets/41695641/052cd7d0-d850-4fc9-baa9-3e8cfd8262fc)
