### PR TITLE
Add Elastic-Agent event log documentation

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -75,6 +75,7 @@ This command is intended for debugging purposes only. The output format and stru
 ----
 elastic-agent diagnostics [--file <string>]
                           [-p]
+                          [--exclude-events]
                           [--help]
                           [global-flags]
 ----
@@ -90,6 +91,9 @@ Show help for the `diagnostics` command.
 
 `-p`::
 Additionally runs a 30-second CPU profile on each running component. This will generate an additional `cpu.pprof` file for each component.
+
+`--exclude-events`::
+Exclude the events log files from the diagnostics archive.
 
 {global-flags-link}
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -40,6 +40,10 @@ Having a different log file for raw events also prevents event data
 from drowning out the regular log files. Use
 `agent.logging.event_data` to configure the events logger.
 
+The events log file is not collected by the {agent} monitoring.
+If the events log files are needed, they can be collected with
+the diagnostics or directly copied from the host running {agent}.
+
 [cols="2*<a"]
 |===
 | *Setting* | *Description*

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-logging.asciidoc
@@ -29,6 +29,17 @@ agent.logging.files:
 You can specify the following settings in the Logging section of the
 `elastic-agent.yml` config file.
 
+Some outputs will log raw events on errors like indexing errors in the
+Elasticsearch output, to prevent logging raw events (that may contain
+sensitive information) together with other log messages, a different
+log file, only for log entries containing raw events, is used. It will
+use the same level, selectors and all other configurations from the
+default logger, but it will have it's own file configuration.
+
+Having a different log file for raw events also prevents event data
+from drowning out the regular log files. Use
+`agent.logging.event_data` to configure the events logger.
+
 [cols="2*<a"]
 |===
 | *Setting* | *Description*
@@ -118,5 +129,44 @@ Default: `0` (disabled)
 | `agent.logging.files.rotateonstartup` | Set to `true` to rotate existing logs on startup rather than to append to the existing file.
 
 Default: `true`
+
+
+| `agent.logging.event_data.to_files` | Set to `true` to log to rotating files. Set to `false` to disable logging to files.
+
+Default: `true`
+
+| `agent.logging.event_data.path` | The directory that log files is written to.
+
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/logging-widget.asciidoc[]
+
+Logs file names end with a date and optional number: log-date.ndjson, log-date-1.ndjson, and so on as new files are created during rotation.
+
+| `agent.logging.event_data.files.name` | The name of the file that logs are written to.
+
+Default: `elastic-agent-event-data`
+
+| `agent.logging.event_data.files.rotateeverybytes` | The maximum size limit of a log file. If the limit is reached, a new log file is generated.
+
+Default: `5242880` (5MB)
+
+|  `agent.logging.event_data.files.keepfiles` | The most recent number of rotated log files to keep on disk. Older files are deleted during log rotation.
+The value must be in the range of `2` to `1024` files.
+
+Default: `2`
+
+| `agent.logging.event_data.files.permissions` | The permissions mask to apply when rotating log files. The permissions option
+must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
+
+Default: `0600`
+
+| `agent.logging.event_data.files.interval` | Enable log file rotation on time intervals in addition to the size-based rotation. Intervals must be at least `1s`.
+Values of `1m`, `1h`, `24h`, `7*24h`, `30*24h`, and `365*24h` are boundary-aligned with minutes, hours, days, weeks, months, and years as
+reported by the local system clock. All other intervals get calculated from the Unix epoch.
+
+Default: `0` (disabled)
+
+| `agent.logging.event_data.files.rotateonstartup` | Set to `true` to rotate existing logs on startup rather than to append to the existing file.
+
+Default: `false`
 
 |===

--- a/docs/en/ingest-management/tab-widgets/logging.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/logging.asciidoc
@@ -1,29 +1,29 @@
 // tag::mac[]
 
-**/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+**/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent.ndjson**
 
 // end::mac[]
 
 // tag::linux[]
 
-**/opt/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+**/opt/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent.ndjson**
 
 // end::linux[]
 
 // tag::win[]
 
-**C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent-json.log**
+**C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent.ndjson**
 
 // end::win[]
 
 // tag::deb[]
 
-**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent.ndjson**
 
 // end::deb[]
 
 // tag::rpm[]
 
-**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log**
+**/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent.ndjson**
 
 // end::rpm[]


### PR DESCRIPTION
This PR adds documentation for the feature introduced by https://github.com/elastic/elastic-agent/pull/4549