### PR TITLE
Add Fleet & Agent 8.13.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.13.4>>
 * <<release-notes-8.13.3>>
 * <<release-notes-8.13.2>>
 * <<release-notes-8.13.1>>
@@ -23,6 +24,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.13.4 relnotes
+
+[[release-notes-8.13.4]]
+== {fleet} and {agent} 8.13.4
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 8.13.4 relnotes
 
 // begin 8.13.3 relnotes
 


### PR DESCRIPTION
This adds the 8.13.4 Fleet & Elastic Agent Release Notes. There are no entries needed for this small patch release.

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/182795) (No entries)
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/46b4306a845f41844435c3a36fab02aeeebad4ee/changelog/fragments) (No new entries)
* Elastic Agent contents from [BC1 "core" changelog](https://github.com/elastic/elastic-agent/tree/a2e31a1c99df431b43ee5058b2e603eeba5e0421/changelog/fragments) (No new entries)

PREVIEW
---

![Screenshot 2024-05-07 at 10 10 10 AM](https://github.com/elastic/ingest-docs/assets/41695641/578d3d79-0277-4c73-9f6f-5fdb9405d905)
