### PR TITLE
Remove duplicate --delay-enroll commands from Elastic Agent install command reference

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -555,7 +555,6 @@ elastic-agent install --url <string>
                       [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
-                      [--delay-enroll]
                       [--force]
                       [--header <strings>]
                       [--help]
@@ -585,7 +584,6 @@ elastic-agent install --fleet-server-es <string>
                       [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
-                      [--delay-enroll]
                       [--fleet-server-cert <string>] <1>
                       [--fleet-server-cert-key <string>]
                       [--fleet-server-cert-key-passphrase <string>]


### PR DESCRIPTION
Remove duplicate --delay-enroll commands from Elastic Agent install command reference