### PR TITLE
Move ECS note to new 'Notable changes' section in 8.13 RN

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -204,6 +204,13 @@ For more information, refer to ({beats-pull}37795[#37795]).
 [[notable-changes-8.13.0]]
 === Notable changes
 
+The following are notable, non-breaking updates to be aware of:
+
+* Changes to features that are in Technical Preview.
+* Changes to log formats.
+* Changes to non-public APIs.
+* Behaviour changes that repair critical bugs.
+
 {fleet}::
 * Adds reference to `ecs@mappings` for each index template ({kibana-pull}174855[#174855]).
 
@@ -364,6 +371,23 @@ The 8.13.0 release added the following new and notable features.
 //*Impact* +
 //<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
 //====
+
+//[discrete]
+//[[notable-changes-8.13.0]]
+//=== Notable changes
+
+//The following are notable, non-breaking updates to be aware of:
+
+//* Changes to features that are in Technical Preview.
+//* Changes to log formats.
+//* Changes to non-public APIs.
+//* Behaviour changes that repair critical bugs.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
 
 //[discrete]
 //[[known-issues-8.7.x]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -201,6 +201,13 @@ For more information, refer to ({beats-pull}37795[#37795]).
 ====
 
 [discrete]
+[[notable-changes-8.13.0]]
+=== Notable changes
+
+{fleet}::
+* Adds reference to `ecs@mappings` for each index template ({kibana-pull}174855[#174855]).
+
+[discrete]
 [[known-issues-8.13.0]]
 === Known issues
 
@@ -226,7 +233,6 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 The 8.13.0 release added the following new and notable features.
 
 {fleet}::
-* Adds reference to `ecs@mappings` for each index template ({kibana-pull}174855[#174855]).
 * Adds support for the `subobjects` setting on the object type mapping ({kibana-pull}171826[#171826]).
 
 {fleet-server}::


### PR DESCRIPTION
It's been suggested that we include a "Notable changes" section in the Fleet & Agent release notes for cases when non-breaking changes are added. This would match a recent, similar change to the [Elasticsearch release notes](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-8.13.0.html#notable-changes-8.13.0). 

This new section should be included only if we have an item that falls into it, as in the case of the ECS item as shown below. Our change log entries don't have a category for this type of change, so the writer (usually me) will need to try and catch items in this category.

![Screenshot 2024-05-08 at 4 13 15 PM](https://github.com/elastic/ingest-docs/assets/41695641/4236c517-8814-4a6c-a88d-437045443f60)
