### PR TITLE
Add new policy settings available in Fleet

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -372,6 +372,13 @@ Select the name of the policy you want to edit.
 
 . Save your changes. 
 
+You can also set the log level for an individual agent:
+
+. In {fleet}, click **Agents**.
+Under the **Host** header, select the {agent} you want to edit.
+
+. On the **Logs** tab, set the **Agent logging level** and apply your changes. Or, you can choose to reset the agent to use the logging level specified in the agent policy.
+
 [discrete]
 [[agent-policy-scale]]
 == Policy scaling recommendations

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -353,9 +353,10 @@ Select the name of the policy you want to edit.
 
 . Click the **Settings** tab and scroll to **Advanced settings**.
 
-. Set **Agent HTTP monitoring** setting to enabled, and then specify a host and port for the monitoring data output.
+//. Set **Agent HTTP monitoring** setting to enabled, and then specify a host and port for the monitoring data output.
+. Specify a host and port for the monitoring data output.
 
-. Enable **buffer.enabled** if you'd like {agent} and {beats} to collect metrics into an in-memory buffer and expose these through a `/buffer` endpoint. This data can be useful for debugging or if the {agent} has issues communicating with {es}. Enabling this option may slightly increase process memory usage.
+//. Enable **buffer.enabled** if you'd like {agent} and {beats} to collect metrics into an in-memory buffer and expose these through a `/buffer` endpoint. This data can be useful for debugging or if the {agent} has issues communicating with {es}. Enabling this option may slightly increase process memory usage.
 
 [discrete]
 [[agent-policy-log-level]]

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -95,7 +95,29 @@ The following table illustrates the {fleet} user actions available to different 
 |<<change-policy-output,Change the output of a policy>>
 |{y}
 |{n}
+
+|<<add-fleet-server-to-policy>>
+|{y}
+|{n}
+
+|<<agent-policy-secret-values>>
+|{y}
+|{n}
+
+|<<agent-policy-limit-cpu>>
+|{y}
+|{n}
+
+|<<agent-policy-http-monitoring>>
+|{y}
+|{n}
+
+|<<agent-policy-log-level>>
+|{y}
+|{n}
 |===
+
+See also the <<agent-policy-scale,recommended scaling options>> for an {agent} policy.
 
 [discrete]
 [[create-a-policy]]
@@ -279,7 +301,7 @@ will still forward data to the cluster.
 
 [discrete]
 [[agent-policy-secret-values]]
-== Policy secret values
+== Configure secret values in a policy
 
 When you create an integration policy you often need to provide sensitive information such as an API key or a password. To help ensure that data can't be accessed inappropriately, any secret values used in an integration policy are stored separately from other policy details.
 
@@ -302,6 +324,53 @@ image::images/fleet-policy-hidden-secret.png[Screen capture showing a hidden sec
 // This graphic should be updated once a higher resolution version is available.
 
 . Click **Save integration**. The original secret value is overwritten in the policy.
+
+[discrete]
+[[agent-policy-limit-cpu]]
+== Set the maximum CPU usage
+
+You can limit the amount of CPU consumed by {agent}. This parameter limits the number of operating system threads that can be executing Go code simultaneously in each Go process. You can specify an integer value not less than `0`, which is the default value that stands for "all available CPUs".
+
+This limit applies independently to the agent and each underlying Go process that it supervises. For example, if {agent} is configured to supervise two {beats} with a CPU usage limit of `2` set in the policy, then the total CPU limit is six, where each of the three processes (one {agent} and two {beats}) may execute independently on two CPUs.
+
+This setting is similar to the {beats} {filebeat-ref}/configuration-general-options.html#_max_procs[`max_procs`] setting. For more detail, refer to the link:https://pkg.go.dev/runtime#GOMAXPROCS[GOMAXPROCS] function in the Go runtime documentation.
+
+. In {fleet}, click **Agent policies**.
+Select the name of the policy you want to edit.
+
+. Click the **Settings** tab and scroll to **Advanced settings**.
+
+. Set **Limit CPU usage** as needed. For example, to limit Go processes supervised by {agent} to two operating system threads each, set this value to `2`.
+
+[discrete]
+[[agent-policy-http-monitoring]]
+== Override the default monitoring port
+
+You can override the default port that {agent} uses to send monitoring data. It's useful to be able to adjust this setting if you have an application running on the machine on which the agent is deployed, and that is using the same port.
+
+. In {fleet}, click **Agent policies**.
+Select the name of the policy you want to edit.
+
+. Click the **Settings** tab and scroll to **Advanced settings**.
+
+. Set **Agent HTTP monitoring** setting to enabled, and then specify a host and port for the monitoring data output.
+
+. Enable **buffer.enabled** if you'd like {agent} and {beats} to collect metrics into an in-memory buffer and expose these through a `/buffer` endpoint. This data can be useful for debugging or if the {agent} has issues communicating with {es}. Enabling this option may slightly increase process memory usage.
+
+[discrete]
+[[agent-policy-log-level]]
+== Set the {agent} log level
+
+You can set the minimum log level that {agents} using the selected policy will send to the configured output. The default setting is `info`.
+
+. In {fleet}, click **Agent policies**.
+Select the name of the policy you want to edit.
+
+. Click the **Settings** tab and scroll to **Advanced settings**.
+
+. Set the **Agent logging level**.
+
+. Save your changes. 
 
 [discrete]
 [[agent-policy-scale]]

--- a/docs/en/ingest-management/override-policy-settings.asciidoc
+++ b/docs/en/ingest-management/override-policy-settings.asciidoc
@@ -1,41 +1,11 @@
 [[enable-custom-policy-settings]]
 = Enable custom settings in an agent policy
 
-In certain cases it can be useful to enable custom settings that are not available in {fleet}, and that override the default behavior for {agent}. Examples include limiting the amount of CPU consumed by an agent, configuring the agent download timeout, and overriding the default port used for monitoring.
+In certain cases it can be useful to enable custom settings that are not available in {fleet}, and that override the default behavior for {agent}.
 
 WARNING: Use these custom settings with caution as they are intended for special cases. We do not test all possible combinations of settings which will be passed down to the components of {agent}, so it is possible that certain custom configurations can result in breakages.
 
-* <<limit-cpu-usage>>
 * <<configure-agent-download-timeout>>
-* <<override-default-monitoring-port>>
-
-[discrete]
-[[limit-cpu-usage]]
-== Limit CPU usage
-
-If you need to limit the amount of CPU consumption you can use the `agent.limits.go_max_procs` configuration option. This parameter limits the number of operating system threads that can be executing Go code simultaneously in each Go process. The `agent.limits.go_max_procs` option accepts an integer value not less than `0`, which is the default value that stands for "all available CPUs".
-
-The `agent.limits.go_max_procs` limit applies independently to the agent and each underlying Go process that it supervises. For example, if {agent} is configured to supervise two {beats} with `agent.limits.go_max_procs: 2` in the policy, then the total CPU limit is six, where each of the three processes (one {agent} and two {Beats}) may execute independently on two CPUs.
-
-This setting is similar to the {beats} {filebeat-ref}/configuration-general-options.html#_max_procs[`max_procs`] setting. For more detail, refer to the link:https://pkg.go.dev/runtime#GOMAXPROCS[GOMAXPROCS] function in the Go runtime documentation.
-
-To enable `agent.limits.go_max_procs`, run a <<fleet-api-docs,{fleet} API>> request from the {kib} {kibana-ref}/console-kibana.html[Dev Tools console] to override your current {agent} policy and add the `go_max_procs` parameter. For example, to limit Go processes supervised by {agent} to two operating system threads each, run:
-
-[source,shell]
---
-PUT kbn:/api/fleet/agent_policies/<policy-id>
-{
-  "name": "<policy-name>",
-  "namespace": "default",
-  "overrides": {
-    "agent": {
-      "limits": {
-        "go_max_procs": 2
-      }
-    }
-  }
-}
---
 
 [discrete]
 [[configure-agent-download-timeout]]
@@ -55,24 +25,6 @@ PUT kbn:/api/fleet/agent_policies/<policy-id>
         "timeout": "120s"
       }
     }
-  }
-}
---
-
-[discrete]
-[[override-default-monitoring-port]]
-== Override the default monitoring port
-
-You can override the default port that {agent} uses to send monitoring data. It's useful to be able to adjust this setting if you have an application running on the machine on which the agent is deployed, and that is using the same port.
-
-[source,shell]
---
-PUT kbn:/api/fleet/agent_policies/<policy-id>
-{
-  "name": "Agent policy 1",
-  "namespace": "default",
-  "overrides": {
-    "agent.monitoring.http.port": 6792
   }
 }
 --


### PR DESCRIPTION
This updates the [Elastic Agent policies](https://www.elastic.co/guide/en/fleet/current/agent-policy.html) docs page with three settings added to the Fleet UI for 8.15:
 - Limit CPU usage
 - Agent HTTP monitoring
 - Agent logging level

@jen-huang and @juliaElastic This also removes the `Maximum CPU usage` and `HTTP monitoring endpoint` settings from the [Enable custom settings in an agent policy](https://www.elastic.co/guide/en/fleet/current/enable-custom-policy-settings.html) page. To avoid any broken links from the UI (and the Kibana CI link checker complaining), can you please update the UI "Learn more" links for these three settings to these URLs:

```
https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-limit-cpu
https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-http-monitoring
https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-log-level
```

Also, Jen, if https://github.com/elastic/elastic-agent/issues/4747 doesn't make 8.15 please let me know and I'll remove the log level section.

Target: 8.15
Closes: https://github.com/elastic/ingest-docs/issues/1073

P.S. I guess there are other settings soon to come, so please let me know whenever those need to be added to the docs.


**PREVIEW**
---

**Maximum CPU**
![Screenshot 2024-05-16 at 3 30 05 PM](https://github.com/elastic/ingest-docs/assets/41695641/99f2c7a6-e177-4fd7-a557-9edafe8e6fb6)

**Default monitoring port**
![Screenshot 2024-05-16 at 3 31 00 PM](https://github.com/elastic/ingest-docs/assets/41695641/99cbdb6d-345a-4d8d-91de-83146175d9f0)

**Log level**
![Screenshot 2024-05-17 at 9 43 57 AM](https://github.com/elastic/ingest-docs/assets/41695641/1b75726f-7e29-457d-a9f8-d93a72ffc6fb)

