### PR TITLE
Add Fleet & Agent 8.14.0 Release Notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -209,7 +209,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.13.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.14.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -95,7 +95,7 @@ The 8.14.0 release added the following new and notable features.
 === Bug fixes
 
 {fleet}::
-* Adds validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
+* Add validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
 * Fixes rollback input package install on failure. ({kibana-pull}182665[#182665])
 * Fixes cloudflare template error. ({kibana-pull}182645[#182645])
 * Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -47,7 +47,7 @@ The 8.14.0 release added the following new and notable features.
 
 {fleet}::
 * (Technical preview) Kibana administrators can now assign granular subfeature privileges for {fleet}, {agents}, agent policies, and settings to user roles. ({kibana-pull}179889[#179889]).
-* Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
+* The `index.mapping.total_fields.limit` field on integration index templates is now set to 1000 by default instead of 10000. If an integration data stream includes more than 500 fields, the limit will be increased to 10000. ({kibana-pull}178398[#178398])
 * `index_template.mappings.subobjects: false` is now the default for custom integration data streams to avoid subobject and scalar mapping conflicts. ({kibana-pull}178397[#178397])
 * Fleet no longer sets `index.query.default_field` on integration component templates, favoring the Elasticsearch default value of `index.query.default_field: *`. This allows queries without a field specified to be run against all integration fields by default. ({kibana-pull}178020[#178020])
 * Relaxes delete restrictions for managed content installed by {fleet}. ({kibana-pull}179113[#179113])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -50,7 +50,7 @@ The 8.14.0 release added the following new and notable features.
 * The `index.mapping.total_fields.limit` field on integration index templates is now set to 1000 by default instead of 10000. If an integration data stream includes more than 500 fields, the limit will be increased to 10000. ({kibana-pull}178398[#178398])
 * `index_template.mappings.subobjects: false` is now the default for custom integration data streams to avoid subobject and scalar mapping conflicts. ({kibana-pull}178397[#178397])
 * Fleet no longer sets `index.query.default_field` on integration component templates, favoring the Elasticsearch default value of `index.query.default_field: *`. This allows queries without a field specified to be run against all integration fields by default. ({kibana-pull}178020[#178020])
-* Relaxes delete restrictions for managed content installed by {fleet}. ({kibana-pull}179113[#179113])
+* Allow managed content installed by {fleet} to be deleted. Note: this content will be recreated when an integration is upgraded or reinstalled. ({kibana-pull}179113[#179113])
 
 {agent}::
 * The Kubernetes secrets provider has been improved to update a Kubernetes secret  when the secret value changes. {agent-pull}4371[#4371] {agent-issue}4168[#4168]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -98,7 +98,7 @@ The 8.14.0 release added the following new and notable features.
 * Add validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
 * Fix rollback input package install on failure. ({kibana-pull}182665[#182665])
 * Fix cloudflare template error. ({kibana-pull}182645[#182645])
-* Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
+* Fix displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
 * Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -94,7 +94,7 @@ The 8.14.0 release added the following new and notable features.
 * Fixes rollback input package install on failure. ({kibana-pull}182665[#182665])
 * Fixes cloudflare template error. ({kibana-pull}182645[#182645])
 * Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
-* Fixes allowing fleet-server agent upgrade to newer than {fleet-server}. ({kibana-pull}181575[#181575])
+* Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
 * Adds callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
 * Removes unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -47,7 +47,6 @@ The 8.14.0 release added the following new and notable features.
 
 {fleet}::
 * (Technical preview) Kibana administrators can now assign granular subfeature privileges for {fleet}, {agents}, agent policies, and settings to user roles. ({kibana-pull}179889[#179889]).
-* Implements state machine behavior for package install. ({kibana-pull}178657[#178657])
 * Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
 * Avoids subobject and scalar mapping conflicts by setting `subobjects: false` on custom integrations. ({kibana-pull}178397[#178397])
 * Adds functionality to `default_fields` field, so a query can run against all fields in the mapping. ({kibana-pull}178020[#178020])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -49,7 +49,7 @@ The 8.14.0 release added the following new and notable features.
 * (Technical preview) Kibana administrators can now assign granular subfeature privileges for {fleet}, {agents}, agent policies, and settings to user roles. ({kibana-pull}179889[#179889]).
 * Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
 * `index_template.mappings.subobjects: false` is now the default for custom integration data streams to avoid subobject and scalar mapping conflicts. ({kibana-pull}178397[#178397])
-* Adds functionality to `default_fields` field, so a query can run against all fields in the mapping. ({kibana-pull}178020[#178020])
+* Fleet no longer sets `index.query.default_field` on integration component templates, favoring the Elasticsearch default value of `index.query.default_field: *`. This allows queries without a field specified to be run against all integration fields by default. ({kibana-pull}178020[#178020])
 * Relaxes delete restrictions for managed content installed by {fleet}. ({kibana-pull}179113[#179113])
 
 {agent}::

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -109,7 +109,7 @@ The 8.14.0 release added the following new and notable features.
 
 {agent}::
 * Use `IgnoreCommas` in default configuration options to correct parse functions used as part of variable substitutions. {agent-pull}4436[#4436]
-* Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
+* Stop logging all `400` errors as {fleet-server} API incompatibility errors. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
 * Fix failing upgrade command when the gRPC server connection is interrupted. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
 * Fix an issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]
 * Always select the more recent watcher during the {agent} upgrade/downgrade process. {agent-pull}4491[#4491] {agent-issue}4072[#4072]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -82,9 +82,9 @@ The 8.14.0 release added the following new and notable features.
 * Enable `--unprivileged` on Mac OS, allowing {agent} to run as an unprivileged user. {agent-pull}4362[#4362] {agent-issue}3867[#3867]
 * Make the `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
 * Reduce the overall download and on-disk size of {agent}. {agent-pull}4516[#4516] {agent-issue}3364[#3364]
-** Linux: -44% reduction from 1.8G to 1.0G compared to 8.13.4 when extracted
-** Windows: -43% reduction from 893M to 505M compared to 8.13.4 when extracted
-** MacOS: -45% reduction from 1G to 542M compared to 8.13.4 when extracted
+** Linux: -43% reduction from 1800MB to 1018MB compared to 8.13.4 when extracted
+** MacOS: -44% reduction from 1100MB to 619MB compared to 8.13.4 when extracted
+** Windows: -43% reduction from 891MB to 504MB compared to 8.13.4 when extracted
 * Remove `cloud-defend` from Linux `.tar.gz` archives; it now appears only in Docker images where it is required. {agent-pull}4584[#4584]
 * Reduce the disk usage of {agent} self-monitoring logs shipped to {fleet} by 16% by dropping "Non-zero metrics..." logs automatically. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -70,7 +70,7 @@ The 8.14.0 release added the following new and notable features.
 ** A "review errors" button now appears above the agent listing table when new activity events are loaded that include errors. Clicking the button will open the activity flyout with these errors shown.
 ** Agent activity now supports pagination. Click the "show more" button at the bottom of the list to load additional activity events.
 ** Agent activity from a given date can now be loaded by clicking the "Go to date" button and selecting a date. 
-* Adds unhealthy reason (input/output/other) to agent metrics. ({kibana-pull}178605[#178605])
+* Surface `unhealthy_reason` in agent metrics that indicates which component (input/output/other) is causing an agent to be considered unhealthy. ({kibana-pull}178605[#178605])
 * Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
 
 {fleet-server}::

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -72,7 +72,7 @@ The 8.14.0 release added the following new and notable features.
 * Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
 
 {fleet-server}::
-* When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managing agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]
+* When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managed agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]
 * Allow specification in the {fleet-server} settings for whether or not a diagnostics bundle should contain additional CPU metrics. {fleet-server-pull}3333[3333] {agent-issue}3491[3491]
 * Allow {fleet} to set the trace level for logging. {fleet-server-pull}3350[3350]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -1,0 +1,238 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.14.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.14.0 relnotes
+
+[[release-notes-8.14.0]]
+== {fleet} and {agent} 8.14.0
+
+Review important information about {fleet-server} and {agent} for the 8.14.0 release.
+
+//[discrete]
+//[[security-updates-8.14.0]]
+//=== Security updates
+
+//{agent}::
+//* Update Go version to 1.21.8. {agent-pull}4221[#4221]
+
+//[discrete]
+//[[breaking-changes-8.14.0]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[notable-changes-8.14.0]]
+//=== Notable changes
+
+//The following are notable, non-breaking updates to be aware of:
+
+//* Changes to features that are in Technical Preview.
+//* Changes to log formats.
+//* Changes to non-public APIs.
+//* Behaviour changes that repair critical bugs.
+
+//{fleet}::
+//* Adds reference to `ecs@mappings` for each index template ({kibana-pull}174855[#174855]).
+
+//[discrete]
+//[[known-issues-8.13.0]]
+//=== Known issues
+
+//[discrete]
+//[[new-features-8.14.0]]
+//=== New features
+
+The 8.14.0 release added the following new and notable features.
+
+//{fleet}::
+//* Adds support for the `subobjects` setting on the object type mapping ({kibana-pull}171826[#171826]).
+
+//{fleet-server}::
+//* Add support for storing output secrets in a new `secrets` block. {fleet-server-pull}3061[3061] {fleet-server-issue}2966[2966]
+
+//{agent}::
+//* Log a summary of each policy configuration change received from {fleet}. {agent-pull}4050[#4050] {agent-issue}3406[#3406]
+
+[discrete]
+[[enhancements-8.14.0]]
+=== Enhancements
+
+{fleet}::
+
+{fleet-server}::
+* When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managing agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]
+* Allow specification in the {fleet-server} settings for whether or not a diagnostics bundle should contain additional CPU metrics. {fleet-server-pull}3333[3333] {agent-issue}3491[3491]
+* Allow {fleet} to set the trace level for logging. {fleet-server-pull}3350[3350]
+
+
+
+{agent}::
+//* Move the control socket path to always be inside of the top level of the {agent} installation directory. {agent-pull}3909[#3909] {agent-issue}3840[#3840]
+
+[discrete]
+[[bug-fixes-8.14.0]]
+=== Bug fixes
+
+//{fleet}::
+//* Fixes a bug where secret values were not deleted on output type change ({kibana-pull}178964[#178964]).
+
+{fleet-server}::
+* Respond with a `429` error, instead of a misleading `401 unauthorized response`, when an Elasticsearch API key authentication returns a `429` error. {fleet-server-pull}3278[#3278]
+* Add an `unhealthy_reason` value (`input`/`output`/`other`) to {fleet-server} metrics published regularly in agent documents. {agent-pull}3338[#3338]
+* Update endpoints to return `400` status code instead of `500` for bad requests. {fleet-server-pull}3407[#3407] {fleet-server-issue}3110[3110]
+
+{agent}::
+//* Fix component control protocol to allow checkin to be chunked across multiple messages. Fixes errors related to the gRPC max message size being exceeded. {agent-pull}3884[#3884] {agent-issue}
+
+// end 8.14.0 relnotes
+
+
+
+// ---------------------
+//TEMPLATE
+//Use the following text as a template. Remember to replace the version info.
+
+// begin 8.7.x relnotes
+
+//[[release-notes-8.7.x]]
+//== {fleet} and {agent} 8.7.x
+
+//Review important information about the {fleet} and {agent} 8.7.x release.
+
+//[discrete]
+//[[security-updates-8.7.x]]
+//=== Security updates
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[breaking-changes-8.7.x]]
+//=== Breaking changes
+
+//Breaking changes can prevent your application from optimal operation and
+//performance. Before you upgrade, review the breaking changes, then mitigate the
+//impact to your application.
+
+//[discrete]
+//[[breaking-PR#]]
+//.Short description
+//[%collapsible]
+//====
+//*Details* +
+//<Describe new behavior.> For more information, refer to {kibana-pull}PR[#PR].
+
+//*Impact* +
+//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
+//====
+
+//[discrete]
+//[[notable-changes-8.13.0]]
+//=== Notable changes
+
+//The following are notable, non-breaking updates to be aware of:
+
+//* Changes to features that are in Technical Preview.
+//* Changes to log formats.
+//* Changes to non-public APIs.
+//* Behaviour changes that repair critical bugs.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[known-issues-8.7.x]]
+//=== Known issues
+
+//[[known-issue-issue#]]
+//.Short description
+//[%collapsible]
+//====
+
+//*Details*
+
+//<Describe known issue.>
+
+//*Impact* +
+
+//<Describe impact or workaround.>
+
+//====
+
+//[discrete]
+//[[deprecations-8.7.x]]
+//=== Deprecations
+
+//The following functionality is deprecated in 8.7.x, and will be removed in
+//8.7.x. Deprecated functionality does not have an immediate impact on your
+//application, but we strongly recommend you make the necessary updates after you
+//upgrade to 8.7.x.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[new-features-8.7.x]]
+//=== New features
+
+//The 8.7.x release Added the following new and notable features.
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[enhancements-8.7.x]]
+//=== Enhancements
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+//[discrete]
+//[[bug-fixes-8.7.x]]
+//=== Bug fixes
+
+//{fleet}::
+//* add info
+
+//{agent}::
+//* add info
+
+// end 8.7.x relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -96,7 +96,7 @@ The 8.14.0 release added the following new and notable features.
 
 {fleet}::
 * Add validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
-* Fixes rollback input package install on failure. ({kibana-pull}182665[#182665])
+* Fix rollback input package install on failure. ({kibana-pull}182665[#182665])
 * Fixes cloudflare template error. ({kibana-pull}182645[#182645])
 * Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -65,7 +65,7 @@ The 8.14.0 release added the following new and notable features.
 * Add `time_series_dimension: true` to dynamic field mappings defined in integrations with `dimension: true`. ({kibana-pull}180023[#180023])
 * Allow additional CPU metrics to be collected when requesting diagnostics from an agent. ({kibana-pull}179819[#179819])
 * Add new "advanced settings" section to agent policy settings page sourced from configuration. ({kibana-pull}179795[#179795])
-* Adds an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
+* Add an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
 * Adds {agent} activity flyout enhancements. ({kibana-pull}179161[#179161])
 * Adds unhealthy reason (input/output/other) to agent metrics. ({kibana-pull}178605[#178605])
 * Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -102,7 +102,7 @@ The 8.14.0 release added the following new and notable features.
 * Remove unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
 * Fix secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
 * Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
-* Fixes KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])
+* Fix overly strict KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])
 
 {fleet-server}::
 * Respond with a `429` error, instead of a misleading `401 unauthorized response`, when an Elasticsearch API key authentication returns a `429` error. {fleet-server-pull}3278[#3278]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -100,7 +100,7 @@ The 8.14.0 release added the following new and notable features.
 * Fix cloudflare template error. ({kibana-pull}182645[#182645])
 * Fix displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
-* Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
+* Fix flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
 * Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
 * Remove unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
 * Fix secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -46,7 +46,7 @@ Review important information about {fleet-server} and {agent} for the 8.14.0 rel
 The 8.14.0 release added the following new and notable features.
 
 {fleet}::
-* Adds subfeatures privileges for {fleet}, {agents}, agent policies, and settings, this feature is in technical preview. ({kibana-pull}179889[#179889]).
+* (Technical preview) Kibana administrators can now assign granular subfeature privileges for {fleet}, {agents}, agent policies, and settings to user roles. ({kibana-pull}179889[#179889]).
 * Implements state machine behavior for package install. ({kibana-pull}178657[#178657])
 * Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
 * Avoids subobject and scalar mapping conflicts by setting `subobjects: false` on custom integrations. ({kibana-pull}178397[#178397])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -62,7 +62,7 @@ The 8.14.0 release added the following new and notable features.
 === Enhancements
 
 {fleet}::
-* Adds support for dimension mappings in dynamic templates. ({kibana-pull}180023[#180023])
+* Add `time_series_dimension: true` to dynamic field mappings defined in integrations with `dimension: true`. ({kibana-pull}180023[#180023])
 * Adds CPU metrics to request diagnostics. ({kibana-pull}179819[#179819])
 * Adds Settings Framework API and UI. ({kibana-pull}179795[#179795])
 * Adds an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -71,7 +71,7 @@ The 8.14.0 release added the following new and notable features.
 ** Agent activity now supports pagination. Click the "show more" button at the bottom of the list to load additional activity events.
 ** Agent activity from a given date can now be loaded by clicking the "Go to date" button and selecting a date. 
 * Surface `unhealthy_reason` in agent metrics that indicates which component (input/output/other) is causing an agent to be considered unhealthy. ({kibana-pull}178605[#178605])
-* Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
+* Add a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
 
 {fleet-server}::
 * When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managed agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -48,7 +48,7 @@ The 8.14.0 release added the following new and notable features.
 {fleet}::
 * (Technical preview) Kibana administrators can now assign granular subfeature privileges for {fleet}, {agents}, agent policies, and settings to user roles. ({kibana-pull}179889[#179889]).
 * Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
-* Avoids subobject and scalar mapping conflicts by setting `subobjects: false` on custom integrations. ({kibana-pull}178397[#178397])
+* `index_template.mappings.subobjects: false` is now the default for custom integration data streams to avoid subobject and scalar mapping conflicts. ({kibana-pull}178397[#178397])
 * Adds functionality to `default_fields` field, so a query can run against all fields in the mapping. ({kibana-pull}178020[#178020])
 * Relaxes delete restrictions for managed content installed by {fleet}. ({kibana-pull}179113[#179113])
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -45,7 +45,13 @@ Review important information about {fleet-server} and {agent} for the 8.14.0 rel
 
 The 8.14.0 release added the following new and notable features.
 
-//{fleet}::
+{fleet}::
+* Adds subfeatures privileges for {fleet}, {agents}, agent policies, and settings, this feature is in technical preview. ({kibana-pull}179889[#179889]).
+* Implements state machine behavior for package install. ({kibana-pull}178657[#178657])
+* Lowers the default `total_fields` limit to 1000 from 10k. ({kibana-pull}178398[#178398])
+* Avoids subobject and scalar mapping conflicts by setting `subobjects: false` on custom integrations. ({kibana-pull}178397[#178397])
+* Adds functionality to `default_fields` field, so a query can run against all fields in the mapping. ({kibana-pull}178020[#178020])
+* Relaxes delete restrictions for managed content installed by {fleet}. ({kibana-pull}179113[#179113])
 
 {agent}::
 * The Kubernetes secrets provider has been improved to update a Kubernetes secret  when the secret value changes. {agent-pull}4371[#4371] {agent-issue}4168[#4168]
@@ -56,7 +62,14 @@ The 8.14.0 release added the following new and notable features.
 [[enhancements-8.14.0]]
 === Enhancements
 
-//{fleet}::
+{fleet}::
+* Adds support for dimension mappings in dynamic templates. ({kibana-pull}180023[#180023])
+* Adds CPU metrics to request diagnostics. ({kibana-pull}179819[#179819])
+* Adds Settings Framework API and UI. ({kibana-pull}179795[#179795])
+* Adds an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
+* Adds {agent} activity flyout enhancements. ({kibana-pull}179161[#179161])
+* Adds unhealthy reason (input/output/other) to agent metrics. ({kibana-pull}178605[#178605])
+* Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
 
 {fleet-server}::
 * When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managing agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]
@@ -64,10 +77,10 @@ The 8.14.0 release added the following new and notable features.
 * Allow {fleet} to set the trace level for logging. {fleet-server-pull}3350[3350]
 
 {agent}::
-* Change the behavior of the monitoring beats so they also monitor and report metrics on themselves. {agent-pull}4326[#4326] {agent-issue}4082[#4082]
+* Change the behavior of the monitoring {beats} so they also monitor and report metrics on themselves. {agent-pull}4326[#4326] {agent-issue}4082[#4082]
 * Add the optional CPU profile collection to the {fleet} diagnostics action handler. {agent-pull}4394[#4394] {agent-issue}3491[#3491]
 * Enable `--unprivileged` on Mac OS, allowing {agent} to run as an unprivileged user. {agent-pull}4362[#4362] {agent-issue}3867[#3867]
-* Make `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
+* Make the `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
 * Reduce the overall download and on-disk size of {agent}. {agent-pull}4516[#4516] {agent-issue}3364[#3364]
 * Remove `cloud-defend` from Linux `.tar.gz` archives; it now appears only in Docker images where it is required. {agent-pull}4584[#4584]
 * Reduce {agent} logs by default by dropping "Non-zero metrics..." logs before ingestion into {es}. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
@@ -76,19 +89,30 @@ The 8.14.0 release added the following new and notable features.
 [[bug-fixes-8.14.0]]
 === Bug fixes
 
-//{fleet}::
+{fleet}::
+* Adds validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
+* Fixes rollback input package install on failure. ({kibana-pull}182665[#182665])
+* Fixes cloudflare template error. ({kibana-pull}182645[#182645])
+* Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
+* Fixes allowing fleet-server agent upgrade to newer than {fleet-server}. ({kibana-pull}181575[#181575])
+* Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
+* Adds callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
+* Removes unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
+* Fixes secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
+* Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
+* Fixes KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])
 
 {fleet-server}::
 * Respond with a `429` error, instead of a misleading `401 unauthorized response`, when an Elasticsearch API key authentication returns a `429` error. {fleet-server-pull}3278[#3278]
 * Add an `unhealthy_reason` value (`input`/`output`/`other`) to {fleet-server} metrics published regularly in agent documents. {agent-pull}3338[#3338]
-* Update endpoints to return `400` status code instead of `500` for bad requests. {fleet-server-pull}3407[#3407] {fleet-server-issue}3110[3110]
+* Update endpoints to return a `400` status code instead of `500` for bad requests. {fleet-server-pull}3407[#3407] {fleet-server-issue}3110[3110]
 
 {agent}::
 * Use `IgnoreCommas` in default configuration options to prevent breakages during the configuration set up process. {agent-pull}4436[#4436]
 * Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
-* Fix failing upgrade command when gRPC server interrupts connection. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
-* Fix issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]
-* Always select the more recent watcher during {agent} upgrade/downgrade process. {agent-pull}4491[#4491] {agent-issue}4072[#4072]
+* Fix failing upgrade command when the gRPC server connection is interrupted. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
+* Fix an issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]
+* Always select the more recent watcher during the {agent} upgrade/downgrade process. {agent-pull}4491[#4491] {agent-issue}4072[#4072]
 * Disable collection of the {beats} `state` metricset for {agent} self-monitoring components. {agent-pull}4579[#4579] {agent-issue}4153[#4153]
 
 // end 8.14.0 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -83,7 +83,7 @@ The 8.14.0 release added the following new and notable features.
 * Make the `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
 * Reduce the overall download and on-disk size of {agent}. {agent-pull}4516[#4516] {agent-issue}3364[#3364]
 * Remove `cloud-defend` from Linux `.tar.gz` archives; it now appears only in Docker images where it is required. {agent-pull}4584[#4584]
-* Reduce {agent} logs by default by dropping "Non-zero metrics..." logs before ingestion into {es}. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
+* Reduce the disk usage of {agent} self-monitoring logs shipped to {fleet} by 16% by dropping "Non-zero metrics..." logs automatically. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
 
 [discrete]
 [[bug-fixes-8.14.0]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -99,7 +99,7 @@ The 8.14.0 release added the following new and notable features.
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
 * Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
-* Removes unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
+* Remove unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
 * Fixes secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
 * Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
 * Fixes KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -66,7 +66,10 @@ The 8.14.0 release added the following new and notable features.
 * Allow additional CPU metrics to be collected when requesting diagnostics from an agent. ({kibana-pull}179819[#179819])
 * Add new "advanced settings" section to agent policy settings page sourced from configuration. ({kibana-pull}179795[#179795])
 * Add an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
-* Adds {agent} activity flyout enhancements. ({kibana-pull}179161[#179161])
+* The "agent activity" flyout now includes several new features: ({kibana-pull}179161[#179161])
+** A "review errors" button now appears above the agent listing table when new activity events are loaded that include errors. Clicking the button will open the activity flyout with these errors shown.
+** Agent activity now supports pagination. Click the "show more" button at the bottom of the list to load additional activity events.
+** Agent activity from a given date can now be loaded by clicking the "Go to date" button and selecting a date. 
 * Adds unhealthy reason (input/output/other) to agent metrics. ({kibana-pull}178605[#178605])
 * Adds a warning which is displayed when trying to upgrade agent to version > max {fleet-server} version. ({kibana-pull}178079[#178079])
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -28,76 +28,55 @@ Also see:
 
 Review important information about {fleet-server} and {agent} for the 8.14.0 release.
 
-//[discrete]
-//[[security-updates-8.14.0]]
-//=== Security updates
+[discrete]
+[[security-updates-8.14.0]]
+=== Security updates
 
-//{agent}::
-//* Update Go version to 1.21.8. {agent-pull}4221[#4221]
+{fleet-server}::
+* Update {fleet-server} Go version to 1.21.10. {fleet-server-pull}3528[#3528]
 
-//[discrete]
-//[[breaking-changes-8.14.0]]
-//=== Breaking changes
+{agent}::
+* Update {agent} Go version to 1.21.10. {agent-pull}4718[#4718]
+* Update all `opentelemetry-collector-contrib` packages. {agent-pull}4572[#4572]
 
-//Breaking changes can prevent your application from optimal operation and
-//performance. Before you upgrade, review the breaking changes, then mitigate the
-//impact to your application.
-
-//[discrete]
-//[[notable-changes-8.14.0]]
-//=== Notable changes
-
-//The following are notable, non-breaking updates to be aware of:
-
-//* Changes to features that are in Technical Preview.
-//* Changes to log formats.
-//* Changes to non-public APIs.
-//* Behaviour changes that repair critical bugs.
-
-//{fleet}::
-//* Adds reference to `ecs@mappings` for each index template ({kibana-pull}174855[#174855]).
-
-//[discrete]
-//[[known-issues-8.13.0]]
-//=== Known issues
-
-//[discrete]
-//[[new-features-8.14.0]]
-//=== New features
+[discrete]
+[[new-features-8.14.0]]
+=== New features
 
 The 8.14.0 release added the following new and notable features.
 
 //{fleet}::
-//* Adds support for the `subobjects` setting on the object type mapping ({kibana-pull}171826[#171826]).
 
-//{fleet-server}::
-//* Add support for storing output secrets in a new `secrets` block. {fleet-server-pull}3061[3061] {fleet-server-issue}2966[2966]
-
-//{agent}::
-//* Log a summary of each policy configuration change received from {fleet}. {agent-pull}4050[#4050] {agent-issue}3406[#3406]
+{agent}::
+* The Kubernetes secrets provider has been improved to update a Kubernetes secret  when the secret value changes. {agent-pull}4371[#4371] {agent-issue}4168[#4168]
+* The OpenTelemetry link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor[filterprocessor] is now available to users running {agent} in `otel` mode. {agent-pull}4708[#4708]
+* The OpenTelemetry link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter[elasticsearchexporter] is now available to users running {agent} in `otel` mode. {agent-pull}4707[#4707]
 
 [discrete]
 [[enhancements-8.14.0]]
 === Enhancements
 
-{fleet}::
+//{fleet}::
 
 {fleet-server}::
 * When running in `agent` mode, {fleet-server} will use the APMConfig settings of the expected input if it's set over the settings in `inputs[0].server.instrumentation`. This should make it easier for managing agents to inject APM configuration data. {fleet-server-pull}3277[3277] {fleet-server-issue}2868[2868]
 * Allow specification in the {fleet-server} settings for whether or not a diagnostics bundle should contain additional CPU metrics. {fleet-server-pull}3333[3333] {agent-issue}3491[3491]
 * Allow {fleet} to set the trace level for logging. {fleet-server-pull}3350[3350]
 
-
-
 {agent}::
-//* Move the control socket path to always be inside of the top level of the {agent} installation directory. {agent-pull}3909[#3909] {agent-issue}3840[#3840]
+* Change the behavior of the monitoring beats so they also monitor and report metrics on themselves. {agent-pull}4326[#4326] {agent-issue}4082[#4082]
+* Add the optional CPU profile collection to the {fleet} diagnostics action handler. {agent-pull}4394[#4394] {agent-issue}3491[#3491]
+* Enable `--unprivileged` on Mac OS, allowing {agent} to run as an unprivileged user. {agent-pull}4362[#4362] {agent-issue}3867[#3867]
+* Make `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
+* Reduce the overall download and on-disk size of {agent}. {agent-pull}4516[#4516] {agent-issue}3364[#3364]
+* Remove `cloud-defend` from Linux `.tar.gz` archives; it now appears only in Docker images where it is required. {agent-pull}4584[#4584]
+* Reduce {agent} logs by default by dropping "Non-zero metrics..." logs before ingestion into {es}. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
 
 [discrete]
 [[bug-fixes-8.14.0]]
 === Bug fixes
 
 //{fleet}::
-//* Fixes a bug where secret values were not deleted on output type change ({kibana-pull}178964[#178964]).
 
 {fleet-server}::
 * Respond with a `429` error, instead of a misleading `401 unauthorized response`, when an Elasticsearch API key authentication returns a `429` error. {fleet-server-pull}3278[#3278]
@@ -105,10 +84,14 @@ The 8.14.0 release added the following new and notable features.
 * Update endpoints to return `400` status code instead of `500` for bad requests. {fleet-server-pull}3407[#3407] {fleet-server-issue}3110[3110]
 
 {agent}::
-//* Fix component control protocol to allow checkin to be chunked across multiple messages. Fixes errors related to the gRPC max message size being exceeded. {agent-pull}3884[#3884] {agent-issue}
+* Use `IgnoreCommas` in default configuration options to prevent breakages during the configuration set up process. {agent-pull}4436[#4436]
+* Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
+* Fix failing upgrade command when gRPC server interrupts connection. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
+* Fix issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]
+* Always select the more recent watcher during {agent} upgrade/downgrade process. {agent-pull}4491[#4491] {agent-issue}4072[#4072]
+* Disable collection of the {beats} `state` metricset for {agent} self-monitoring components. {agent-pull}4579[#4579] {agent-issue}4153[#4153]
 
 // end 8.14.0 relnotes
-
 
 
 // ---------------------

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -77,7 +77,7 @@ The 8.14.0 release added the following new and notable features.
 * Allow {fleet} to set the trace level for logging. {fleet-server-pull}3350[3350]
 
 {agent}::
-* Change the behavior of the monitoring {beats} so they also monitor and report metrics on themselves. {agent-pull}4326[#4326] {agent-issue}4082[#4082]
+* The CPU and memory usage of the internal monitoring {beats} is now included in the agent CPU and memory usage calculations in {fleet}. {agent-pull}4326[#4326] {agent-issue}4082[#4082]
 * Add the optional CPU profile collection to the {fleet} diagnostics action handler. {agent-pull}4394[#4394] {agent-issue}3491[#3491]
 * Enable `--unprivileged` on Mac OS, allowing {agent} to run as an unprivileged user. {agent-pull}4362[#4362] {agent-issue}3867[#3867]
 * Make the `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -98,7 +98,7 @@ The 8.14.0 release added the following new and notable features.
 * Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
-* Adds callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
+* Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
 * Removes unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
 * Fixes secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
 * Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -101,7 +101,7 @@ The 8.14.0 release added the following new and notable features.
 * Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
 * Remove unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
 * Fix secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
-* Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
+* Fix not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
 * Fix overly strict KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])
 
 {fleet-server}::

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -97,7 +97,7 @@ The 8.14.0 release added the following new and notable features.
 {fleet}::
 * Add validation to dataset field in input packages to disallow special characters. ({kibana-pull}182925[#182925])
 * Fix rollback input package install on failure. ({kibana-pull}182665[#182665])
-* Fixes cloudflare template error. ({kibana-pull}182645[#182645])
+* Fix cloudflare template error. ({kibana-pull}182645[#182645])
 * Fixes displaying `Config` and `API reference` tabs if they are not needed. ({kibana-pull}182518[#182518])
 * Allow upgrading an agent to a newer version when that agent is also a {fleet-server}. ({kibana-pull}181575[#181575])
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -113,7 +113,7 @@ The 8.14.0 release added the following new and notable features.
 * Fix failing upgrade command when the gRPC server connection is interrupted. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
 * Fix an issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]
 * Always select the more recent watcher during the {agent} upgrade/downgrade process. {agent-pull}4491[#4491] {agent-issue}4072[#4072]
-* Disable collection of the {beats} `state` metricset for {agent} self-monitoring components. {agent-pull}4579[#4579] {agent-issue}4153[#4153]
+* Reduce the disk usage of {agent} self-monitoring metrics shipped to {fleet} by 13% by dropping the {beats} `state` metricset. {agent-pull}4579[#4579] {agent-issue}4153[#4153]
 
 // end 8.14.0 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -108,7 +108,7 @@ The 8.14.0 release added the following new and notable features.
 * Update endpoints to return a `400` status code instead of `500` for bad requests. {fleet-server-pull}3407[#3407] {fleet-server-issue}3110[3110]
 
 {agent}::
-* Use `IgnoreCommas` in default configuration options to prevent breakages during the configuration set up process. {agent-pull}4436[#4436]
+* Use `IgnoreCommas` in default configuration options to correct parse functions used as part of variable substitutions. {agent-pull}4436[#4436]
 * Reduce false positives in logging an API switch request from {fleet-server}. {agent-pull}4481[#4481] {agent-issue}4477[#4477]
 * Fix failing upgrade command when the gRPC server connection is interrupted. {agent-pull}4519[#4519] {agent-issue}3890[#3890]
 * Fix an issue where the `kubernetes_leaderelection` provider would not try to reacquire the lease once lost. {agent-pull}4542[#4542] {agent-issue}4543[#4543]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -100,7 +100,7 @@ The 8.14.0 release added the following new and notable features.
 * Fixes flattened inputs in the configuration tab. ({kibana-pull}181155[#181155])
 * Add callout when editing an output about plain text secrets being re-saved to secret storage. ({kibana-pull}180334[#180334])
 * Remove unnecessary field definitions for custom integrations. ({kibana-pull}178293[#178293])
-* Fixes secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
+* Fix secrets UI inputs in forms when secrets storage is disabled server side. ({kibana-pull}178045[#178045])
 * Fixes not being able to preview or download files with special characters. ({kibana-pull}176822[#176822])
 * Fixes KQL validation being applied in search boxes. ({kibana-pull}176806[#176806])
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -64,7 +64,7 @@ The 8.14.0 release added the following new and notable features.
 {fleet}::
 * Add `time_series_dimension: true` to dynamic field mappings defined in integrations with `dimension: true`. ({kibana-pull}180023[#180023])
 * Allow additional CPU metrics to be collected when requesting diagnostics from an agent. ({kibana-pull}179819[#179819])
-* Adds Settings Framework API and UI. ({kibana-pull}179795[#179795])
+* Add new "advanced settings" section to agent policy settings page sourced from configuration. ({kibana-pull}179795[#179795])
 * Adds an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
 * Adds {agent} activity flyout enhancements. ({kibana-pull}179161[#179161])
 * Adds unhealthy reason (input/output/other) to agent metrics. ({kibana-pull}178605[#178605])

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -82,6 +82,9 @@ The 8.14.0 release added the following new and notable features.
 * Enable `--unprivileged` on Mac OS, allowing {agent} to run as an unprivileged user. {agent-pull}4362[#4362] {agent-issue}3867[#3867]
 * Make the `enroll` command more stable by handling temporary server errors. {agent-pull}4523[#4523] {agent-issue}4513[#4513]
 * Reduce the overall download and on-disk size of {agent}. {agent-pull}4516[#4516] {agent-issue}3364[#3364]
+** Linux: -44% reduction from 1.8G to 1.0G compared to 8.13.4 when extracted
+** Windows: -43% reduction from 893M to 505M compared to 8.13.4 when extracted
+** MacOS: -45% reduction from 1G to 542M compared to 8.13.4 when extracted
 * Remove `cloud-defend` from Linux `.tar.gz` archives; it now appears only in Docker images where it is required. {agent-pull}4584[#4584]
 * Reduce the disk usage of {agent} self-monitoring logs shipped to {fleet} by 16% by dropping "Non-zero metrics..." logs automatically. {agent-pull}4633[#4633] {agent-issue}4252[#4252]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -63,7 +63,7 @@ The 8.14.0 release added the following new and notable features.
 
 {fleet}::
 * Add `time_series_dimension: true` to dynamic field mappings defined in integrations with `dimension: true`. ({kibana-pull}180023[#180023])
-* Adds CPU metrics to request diagnostics. ({kibana-pull}179819[#179819])
+* Allow additional CPU metrics to be collected when requesting diagnostics from an agent. ({kibana-pull}179819[#179819])
 * Adds Settings Framework API and UI. ({kibana-pull}179795[#179795])
 * Adds an Elastic Defend advanced policy option for pruning capability arrays. ({kibana-pull}179766[#179766])
 * Adds {agent} activity flyout enhancements. ({kibana-pull}179161[#179161])


### PR DESCRIPTION
This adds the 8.14.0 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/183914)
* Fleet Server contents from [BC5 changelog](https://github.com/elastic/fleet-server/tree/06101c8732535c666358679ad12185d2bbb11392/changelog/fragments)
* Elastic Agent contents from [BC5 "core" changelog](https://github.com/elastic/elastic-agent/tree/53ce8888909e9abe2a00da45d7e275a10fabc8a6/changelog/fragments)

See [DOCS PREVIEW](https://ingest-docs_bk_1079.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.14.0.html)

 Closes: #1078