### PR TITLE
Fix duplicates and misordered parameters in commmand ref

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -150,10 +150,10 @@ elastic-agent enroll --url <string>
                      --enrollment-token <string>
                      [--ca-sha256 <string>]
                      [--certificate-authorities <string>]
-                     [--elastic-agent-cert <string>]
-                     [--elastic-agent-cert-key <string>]
                      [--daemon-timeout <duration>]
                      [--delay-enroll]
+                     [--elastic-agent-cert <string>]
+                     [--elastic-agent-cert-key <string>]
                      [--force]
                      [--header <strings>]
                      [--help]
@@ -177,10 +177,10 @@ elastic-agent enroll --fleet-server-es <string>
                      [--fleet-server-service-token-path <string>]
                      [--ca-sha256 <string>]
                      [--certificate-authorities <string>]
-                     [--elastic-agent-cert <string>]
-                     [--elastic-agent-cert-key <string>]
                      [--daemon-timeout <duration>]
                      [--delay-enroll]
+                     [--elastic-agent-cert <string>]
+                     [--elastic-agent-cert-key <string>]
                      [--fleet-server-cert <string>] <1>
                      [--fleet-server-cert-key <string>]
                      [--fleet-server-cert-key-passphrase <string>]
@@ -555,7 +555,6 @@ elastic-agent install --url <string>
                       [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
-                      [--delay-enroll]
                       [--force]
                       [--header <strings>]
                       [--help]
@@ -585,7 +584,6 @@ elastic-agent install --fleet-server-es <string>
                       [--delay-enroll]
                       [--elastic-agent-cert <string>]
                       [--elastic-agent-cert-key <string>]
-                      [--delay-enroll]
                       [--fleet-server-cert <string>] <1>
                       [--fleet-server-cert-key <string>]
                       [--fleet-server-cert-key-passphrase <string>]
@@ -642,19 +640,16 @@ Comma-separated list of root certificates used for server verification.
 `--daemon-timeout <duration>`::
 Timeout waiting for {agent} daemon.
 
-`--delay-enroll::
-Delays enrollment to occur on first start of the {agent} service.
+`--delay-enroll`::
+Delays enrollment to occur on first start of the {agent} service. This setting
+is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for
+example, when you're preparing an image that includes {agent}.
 
 `--elastic-agent-cert`::
 Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.
 
 `--elastic-agent-cert-key`::
 Private key to use as for the {agent}'s connections to {fleet-server}.
-
-`--delay-enroll`::
-Delays enrollment to occur on first start of the {agent} service. This setting
-is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for
-example, when you're preparing an image that includes {agent}.
 
 `--enrollment-token <string>`::
 Enrollment token to use to enroll {agent} into {fleet}. You can use


### PR DESCRIPTION
Fixes a few small duplicates and misorderings in the command docs. I've checked through the enroll and install syntax diagram and descriptions, and these seem to be the only issues.

There might be a merge conflict for recently added options...