### PR TITLE
Add new agent disk size, plus some reorg of the requirements section

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -12,6 +12,7 @@ run the commands described here. After the {agent} service is installed and runn
 make sure you run these commands without prepending them with `./` to avoid
 invoking the wrong binary.
 * Running {agent} commands using the Windows PowerShell ISE is not supported.
+* See also the <<elastic-agent-installation-minimum-requirements,minimum requirements>> described on this page. 
 ====
 
 You have a few options for installing and managing an {agent}:
@@ -66,19 +67,36 @@ If you are using {agent} with link:{serverless-docs}[{serverless-full}], note th
 ====
 
 [discrete]
-== Minimum Requirements
+[[elastic-agent-installation-minimum-requirements]]
+== Minimum requirements  
+
+The following are the minimum system requirements for installing {agent}.
+// lint ignore mem
+[discrete]
+=== CPU and RSS memory size
 
 // lint ignore 2vcpu 1gb
 Minimum requirements have been determined by running the {agent} on a GCP `e2-micro` instance (2vCPU/1GB).
 The {agent} used the default policy, running the system integration and self-monitoring.
-During upgrades, double the disk space is required to store the new {agent} binary. After the upgrade completes, the original {agent} is removed from disk to free up the space.  
 
-// lint ignore mem
 |===
 | **CPU** | Under 2% total, including all monitoring processes
-| **Disk** | 1.7 GB
-| **RSS Mem Size** | 400 MB
+| **RSS memory size** | 400 MB
 |===
 Adding integrations will increase the memory used by the agent and its processes.
 
+[discrete]
+=== Size on disk
 
+The disk requirements for {agent} vary by operating system and {stack} version. With version 8.14 we have significantly reduced the size of the {agent} binary. Further reductions will be made in future releases.
+
+[options,header]
+|===
+|Operating system |8.13 |8.14
+
+| **Linux** | 1800 MB | 341 MB
+| **macOS** | 1100 MB | 328 MB
+| **Windows** | 891 MB | 195 MB
+|===
+
+During upgrades, double the disk space is required to store the new {agent} binary. After the upgrade completes, the original {agent} is removed from disk to free up the space.

--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -88,15 +88,15 @@ Adding integrations will increase the memory used by the agent and its processes
 [discrete]
 === Size on disk
 
-The disk requirements for {agent} vary by operating system and {stack} version. With version 8.14 we have significantly reduced the size of the {agent} binary. Further reductions will be made in future releases.
+The disk requirements for {agent} vary by operating system and {stack} version. With version 8.14 we have significantly reduced the size of the {agent} binary. Further reductions are planned to be made in future releases.
 
 [options,header]
 |===
 |Operating system |8.13 |8.14
 
-| **Linux** | 1800 MB | 341 MB
-| **macOS** | 1100 MB | 328 MB
-| **Windows** | 891 MB | 195 MB
+| **Linux** | 1800 MB | 1018 MB
+| **macOS** | 1100 MB | 619 MB
+| **Windows** | 891 MB | 504 MB
 |===
 
 During upgrades, double the disk space is required to store the new {agent} binary. After the upgrade completes, the original {agent} is removed from disk to free up the space.


### PR DESCRIPTION
This adds the new Elastic Agent binary sizes for 8.13 and 8.14, and reorganizes the "[Minimum requirements](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements)" section of the install docs slightly, as shown below.

Closes: #1088

---

![Screenshot 2024-05-28 at 10 45 21 AM](https://github.com/elastic/ingest-docs/assets/41695641/abbc0130-1213-43ab-bd2e-1d2832cc3d86)
