### PR TITLE
Add note about '/liveness' endpoint for standalone agent

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -92,6 +92,10 @@ The following table illustrates the {fleet} user actions available to different 
 |{y}
 |{n}
 
+|<<change-policy-enable-agent-monitoring,Enable agent monitoring>>
+|{y}
+|{n}
+
 |<<change-policy-output,Change the output of a policy>>
 |{y}
 |{n}
@@ -250,6 +254,26 @@ Click the name of the policy you want to edit or delete.
 Alternatively, click **Delete policy** to delete the policy.
 Existing data is not deleted.
 Any agents assigned to a policy must be unenrolled or assigned to a different policy before a policy can be deleted.
+
+
+[discrete]
+[[change-policy-enable-agent-monitoring,Enable agent monitoring]]
+== Enable agent monitoring
+
+Use this setting to collect monitoring logs and metrics from {agent}. All monitoring data will be written to the specified **Default namespace**.
+
+. In {fleet}, click **Agent policies**.
+Select the name of the policy you want to edit.
+
+. Click the **Settings** tab and scroll to **Enable agent monitorings**.
+
+. Select whether to collect agent logs, agent metrics, or both, from the {agents} that use the policy.
+
+When this setting is enabled:
+
+* An {agent} integration is created automatically.
+* A `/liveness` endpoint is enabled and available where the server is configured to be exposed. By default, the endpoint 
+returns a `200` OK status as long as {agent}'s internal main loop is responsive and can process configuration changes. It can be configured to also monitor the component states to return an error if anything is degraded or failed.
 
 [discrete]
 [[change-policy-output]]

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -38,11 +38,10 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
-Setting `agent.monitoring.enabled` to `true` also enables a `/liveness` endpoint to be 
-available where that server is configured to be exposed. By default, the endpoint 
+Setting `agent.monitoring.enabled` to `true` also exposes a `/liveness` endpoint. By default, the endpoint 
 returns a `200` OK status as long as {agent}'s internal main loop is responsive and can 
 process configuration changes. It can be configured to also monitor the component states 
-to return an error if anything is degraded or failed.
+and return an error if anything is degraded or has failed.
 
 The `agent.monitoring.pprof.enabled` option controls whether the {agent} and {beats} expose the
 `/debug/pprof/` endpoints with the monitoring endpoints. It is set to `false`

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -38,6 +38,12 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
+Setting `agent.monitoring.enabled` to `true` also enables a `/liveness` endpoint to be 
+available where that same server is configured to be exposed. By default, the endpoint 
+returns a `200 OK` status as long {agent}'s internal main loop is responsive and can 
+process configuration changes. It can be configured to also monitor the component states 
+to return an error if anything is degraded or failed.
+
 The `agent.monitoring.pprof.enabled` option controls whether the {agent} and {beats} expose the
 `/debug/pprof/` endpoints with the monitoring endpoints. It is set to `false`
 by default. Data produced by these endpoints can be useful for debugging but present a

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -39,8 +39,8 @@ collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
 Setting `agent.monitoring.enabled` to `true` also enables a `/liveness` endpoint to be 
-available where that same server is configured to be exposed. By default, the endpoint 
-returns a `200 OK` status as long {agent}'s internal main loop is responsive and can 
+available where that server is configured to be exposed. By default, the endpoint 
+returns a `200` OK status as long as {agent}'s internal main loop is responsive and can 
 process configuration changes. It can be configured to also monitor the component states 
 to return an error if anything is degraded or failed.
 


### PR DESCRIPTION
This updates the "[Configure monitoring for standalone Elastic Agents](https://www.elastic.co/guide/en/fleet/8.13/elastic-agent-monitoring-configuration.html)" docs page to include mention of the `/liveness` endpoint added for 8.15. Rel: https://github.com/elastic/elastic-agent/issues/107#issuecomment-2133910470

**ADD:** Please see my [comment below](https://github.com/elastic/ingest-docs/pull/1090#issuecomment-2136026119) for an additional change to the Fleet-managed agent docs.

---

![Screenshot 2024-05-28 at 11 21 02 AM](https://github.com/elastic/ingest-docs/assets/41695641/448726c1-1983-47a4-b986-31f4c8cfe608)


