### PR TITLE
Add Fleet & Agent 7.17.22 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.22>>
+
 * <<release-notes-7.17.21>>
 
 * <<release-notes-7.17.20>>
@@ -62,6 +64,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.22 relnotes
+
+[[release-notes-7.17.22]]
+== {fleet} and {agent} 7.17.22
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.22 relnotes
 
 // begin 7.17.21 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -70,7 +70,14 @@ Also see:
 [[release-notes-7.17.22]]
 == {fleet} and {agent} 7.17.22
 
-There are no bug fixes for {fleet} or {agent} in this release.
+Review important information about the {fleet} and {agent} 7.17.22 release.
+
+[discrete]
+[[security-updates-7.17.22]]
+=== Security updates
+
+{fleet-server}::
+* Update {fleet-server} Go version to 1.21.10. {fleet-server-pull}3533[#3533]
 
 // end 7.17.22 relnotes
 


### PR DESCRIPTION
This adds the 7.17.22 Fleet & Agent Release Notes:

 - Fleet: no entries in [Kibana RN PR](https://github.com/elastic/kibana/pull/184470)
 - Fleet Server: one entry in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/e6f9cb548146e2a3e946036a443078bcc943f7e9/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/b40ddd8a2769c6433dadb574f5c9e03788fb7a02/changelog/fragments)

---

![Screenshot 2024-05-29 at 4 12 47 PM](https://github.com/elastic/ingest-docs/assets/41695641/4b93705c-4e39-4616-ba75-85cb9ff69cc3)

