### PR TITLE
Remove 'technical preview' warning from FQDN docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-standalone-features.asciidoc
@@ -26,8 +26,6 @@ You can specify the following settings in the Feature Flag section of the
 Fully qualified domain name (FQDN)::
 When enabled, information provided about the current host through the <<host-provider,host.name>> key, in events produced by {agent}, is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. With `fqdn` enabled, the fully qualified hostname allows each host to be more easily identified when viewed in {kib}.
 +
-preview::[]
-+
 NOTE: FQDN reporting is not currently supported in APM.
 +
 For FQDN reporting to work as expected, the hostname of the current host must either:

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -145,8 +145,6 @@ These settings control the format of information provided about the current host
 
 | When this setting is selected, information about the current host is in FQDN format (`somehost.example.com` rather than `somehost`). This helps you to distinguish between hosts on different domains that have similar names. The fully qualified hostname allows each host to be more easily identified when viewed in {kib}, for example.
 
-preview::[]
-
 NOTE: FQDN reporting is not currently supported in APM.
 
 For FQDN reporting to work as expected, the hostname of the current host must either:


### PR DESCRIPTION
This removes the "Technical Preview" warning that appears in a couple of spots in the docs for the FQDN feature.

Target: 8.15
Rel: https://github.com/elastic/ingest-dev/issues/3368#issuecomment-2145248184

![Screenshot 2024-06-03 at 10 12 15 AM](https://github.com/elastic/ingest-docs/assets/41695641/e5ad2e61-2589-48df-b5ef-9e423e7d99fe)


