### PR TITLE
Fix liveness endpoint docs

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -269,11 +269,7 @@ Select the name of the policy you want to edit.
 
 . Select whether to collect agent logs, agent metrics, or both, from the {agents} that use the policy.
 
-When this setting is enabled:
-
-* An {agent} integration is created automatically.
-* A `/liveness` endpoint is enabled and available where the server is configured to be exposed. By default, the endpoint 
-returns a `200` OK status as long as {agent}'s internal main loop is responsive and can process configuration changes. It can be configured to also monitor the component states to return an error if anything is degraded or failed.
+When this setting is enabled an {agent} integration is created automatically.
 
 [discrete]
 [[change-policy-output]]

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -38,7 +38,7 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
-You can also add the setting `agent.monitoring.enabled.http: true` to expose a `/liveness` endpoint.
+You can also add the setting `agent.monitoring.http.enabled: true` to expose a `/liveness` endpoint.
 By default, the endpoint returns a `200` OK status as long as {agent}'s internal main loop is responsive and can process configuration changes.
 It can be configured to also monitor the component states and return an error if anything is degraded or has failed.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/elastic-agent-monitoring.asciidoc
@@ -38,10 +38,9 @@ To enable monitoring, set `agent.monitoring.enabled` to `true`. Also set the
 collected. If neither setting is specified, monitoring is turned off. Set
 `use_output` to specify the output to which monitoring events are sent.
 
-Setting `agent.monitoring.enabled` to `true` also exposes a `/liveness` endpoint. By default, the endpoint 
-returns a `200` OK status as long as {agent}'s internal main loop is responsive and can 
-process configuration changes. It can be configured to also monitor the component states 
-and return an error if anything is degraded or has failed.
+You can also add the setting `agent.monitoring.enabled.http: true` to expose a `/liveness` endpoint.
+By default, the endpoint returns a `200` OK status as long as {agent}'s internal main loop is responsive and can process configuration changes.
+It can be configured to also monitor the component states and return an error if anything is degraded or has failed.
 
 The `agent.monitoring.pprof.enabled` option controls whether the {agent} and {beats} expose the
 `/debug/pprof/` endpoints with the monitoring endpoints. It is set to `false`


### PR DESCRIPTION
This is a follow-on to https://github.com/elastic/ingest-docs/pull/1090 to fix the Fleet & Agent docs with respect to the new `/liveness` endpoint:
 - Corrects the setting name to be `agent.monitoring.enabled.http` (see [comment](https://github.com/elastic/ingest-docs/pull/1090#discussion_r1626559373))
 - Removes mention of the setting from the Fleet docs "[Enable agent monitoring](https://www.elastic.co/guide/en/fleet/master/agent-policy.html#change-policy-enable-agent-monitoring)" section, since I don't think the setting is available through the UI (Julia, please correct me if that's wrong).