### PR TITLE
Add links at top of FAQ page

### DIFF
--- a/docs/en/ingest-management/troubleshooting/faq.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/faq.asciidoc
@@ -7,6 +7,21 @@ is very valuable to us.
 
 Also read <<fleet-troubleshooting>>.
 
+* <<enrolled-agent-not-showing-up>>
+* <<where-are-the-agent-logs>>
+* <<what-is-my-agent-config>>
+* <<where-is-the-data-agent-is-sending>>
+* <<i-deleted-my-agent>>
+* <<i-rebooted-my-host>>
+* <<does-agent-download-packages>>
+* <<does-agent-download-anything-from-internet>>
+* <<do-i-need-to-setup-elastic-agent>>
+* <<what-is-the-endpoint-package>>
+* <<how-are-security-to-agent-communications-secured>>
+* <<how-are-secrets-secured>>
+* <<which-es-kibana-ports-are-needed>>
+* <<how-do-i-reinstall-a-missing-dashboard-asset>>
+
 [discrete]
 [[enrolled-agent-not-showing-up]]
 == Why doesn't my enrolled agent show up in the {fleet} app?


### PR DESCRIPTION
A quick PR to add links to the top of the [FAQ page](https://www.elastic.co/guide/en/fleet/current/fleet-faq.html), for easier navigation.

Closes: #1118

![Screenshot 2024-06-06 at 7 56 50 PM](https://github.com/elastic/ingest-docs/assets/41695641/a435b9c9-2650-468f-8523-cf916a0e6dde)
