### PR TITLE
Add Fleet & Agent 8.14.1 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -60,6 +60,10 @@ The 8.14.1 release added the following new and notable features.
 {fleet}::
 * Fix the `Restart upgrade` modal submit button disabled condition. {kibana-pull}184586[#184586]
 
+{agent}::
+* Make {agent} delayed enrollment try indefinitely until the agent is able to enroll successfully into {fleet}. {agent-pull}4727[#4727] {agent-issue}4716[#4716]
+* Fix delayed enrollment to work in unprivileged mode on Windows. {agent-pull}4779[#4779] {agent-issue}4678[#4678]
+
 // end 8.14.1 relnotes
 
 // begin 8.14.0 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -27,7 +27,7 @@ Also see:
 [[release-notes-8.14.1]]
 == {fleet} and {agent} 8.14.1
 
-Review important information about {fleet-server} and {agent} for the 8.14.0 release.
+Review important information about {fleet-server} and {agent} for the 8.14.1 release.
 
 [discrete]
 [[security-updates-8.14.1]]
@@ -45,7 +45,6 @@ The 8.14.1 release added the following new and notable features.
 {agent}::
 * For users of {agent} running as an OpenTelemetry Collector, the link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter[`elasticsearchexporter`] and the link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor[`filterprocessor`] are now available to configure in agent pipelines. {agent-pull}4707[#4707] {agent-pull}4708[#4708]
 
-
 [discrete]
 [[enhancements-8.14.1]]
 === Enhancements
@@ -53,6 +52,13 @@ The 8.14.1 release added the following new and notable features.
 {agent}::
 * The more reliable snapshot API is now used in place of the artifact API for snapshot downloads, for both {agent} upgrades to a snapshot and for artifact fetching used in testing. {agent-pull}4693[#4693] {agent-issue}4458[#4458]
 * The {agent} diagnostics bundle now contains an `agent-info.yaml` file, which provides information on the running agent, including its agent ID, whether or not it's a snapshot, any headers, and if it's running in `unprivileged` mode. {agent-pull}4725[#4725] {agent-issue}4439[#4439]
+
+[discrete]
+[[bug-fixes-8.14.1]]
+=== Bug fixes
+
+{fleet}::
+* Fix the `Restart upgrade` modal submit button disabled condition. {kibana-pull}184586[#184586]
 
 // end 8.14.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -58,7 +58,7 @@ The 8.14.1 release added the following new and notable features.
 === Bug fixes
 
 {fleet}::
-* Fix the `Restart upgrade` modal submit button disabled condition. {kibana-pull}184586[#184586]
+* The "restart upgrade" button for single agent upgrades is now enabled as expected when the upgrade has been pending for over 2 hours. {kibana-pull}184586[#184586]
 
 {agent}::
 * Make {agent} delayed enrollment try indefinitely until the agent is able to enroll successfully into {fleet}. {agent-pull}4727[#4727] {agent-issue}4716[#4716]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -14,12 +14,47 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.14.1>>
 * <<release-notes-8.14.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.14.1 relnotes
+
+[[release-notes-8.14.1]]
+== {fleet} and {agent} 8.14.1
+
+Review important information about {fleet-server} and {agent} for the 8.14.0 release.
+
+[discrete]
+[[security-updates-8.14.1]]
+=== Security updates
+
+{fleet-server}::
+* Update {fleet-server} Go version to 1.21.11. {fleet-server-pull}3607[#3607]
+
+[discrete]
+[[new-features-8.14.1]]
+=== New features
+
+The 8.14.1 release added the following new and notable features.
+
+{agent}::
+* For users of {agent} running as an OpenTelemetry Collector, the link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter[`elasticsearchexporter`] and the link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor[`filterprocessor`] are now available to configure in agent pipelines. {agent-pull}4707[#4707] {agent-pull}4708[#4708]
+
+
+[discrete]
+[[enhancements-8.14.1]]
+=== Enhancements
+
+{agent}::
+* The more reliable snapshot API is now used in place of the artifact API for snapshot downloads, for both {agent} upgrades to a snapshot and for artifact fetching used in testing. {agent-pull}4693[#4693] {agent-issue}4458[#4458]
+* The {agent} diagnostics bundle now contains an `agent-info.yaml` file, which provides information on the running agent, including its agent ID, whether or not it's a snapshot, any headers, and if it's running in `unprivileged` mode. {agent-pull}4725[#4725] {agent-issue}4439[#4439]
+
+// end 8.14.1 relnotes
 
 // begin 8.14.0 relnotes
 


### PR DESCRIPTION
This adds the 8.14.1 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/186029)
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/06101c8732535c666358679ad12185d2bbb11392/changelog/fragments)
* Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/53ce8888909e9abe2a00da45d7e275a10fabc8a6/changelog/fragments)

See [DOCS PREVIEW](https://ingest-docs_bk_1126.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.14.1.html)

Closes: #1125