### PR TITLE
TEST ONLY: Source all known issues in a separate file

### DIFF
--- a/docs/en/ingest-management/release-notes/known-issues-8.x.asciidoc
+++ b/docs/en/ingest-management/release-notes/known-issues-8.x.asciidoc
@@ -1,0 +1,23 @@
+// All known issues for the 8.x release should be listed here in descending order from oldest to newest.
+// In addition to the docs build, the contents of this file are reproduced in the Upgrade Elastic Agent 
+// section of the Kibana UI.
+
+
+// tag::known-issue-8.14.0-001[]
+
+[[known-issue-8.14.0-0001]]
+.Beats MSI binaries do not support directories with a trailing slash
+[%collapsible]
+====
+
+*Details*
+
+Due to changes introduced to support customizing an MSI install folder (see link:https://github.com/elastic/elastic-stack-installers/pull/209[#209]), Beats MSI binaries, which currently are in beta, will not properly handle directories that end in a slash. This defect may affect many deployments using the {beats} MSI binaries.
+
+*Impact* +
+
+This issue has been link:https://github.com/elastic/elastic-stack-installers/pull/264[resolved] in version 8.14.0 and later releases. We recommend users of {beats} MSI to upgrade to 8.14 when that release becomes available.
+
+====
+
+// end::known-issue-8.14.0-001[]

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -29,6 +29,12 @@ Also see:
 Review important information about {fleet-server} and {agent} for the 8.14.0 release.
 
 [discrete]
+[[known-issues-8.14.0]]
+=== Known issues
+
+include::../release-notes/known-issues-8.x.asciidoc[tag=known-issue-8.14.0-001]
+
+[discrete]
 [[security-updates-8.14.0]]
 === Security updates
 


### PR DESCRIPTION
**Test only: Please do not merge**

This is a demo showing the format we could use to source all "known issues" for a major release in a single asciidoc file, separate from other release notes. This would allow the relevant known issues to be rendered in a flyout when a user upgrades Elastic Agent to given version.

The docs content of the Release Notes would be unchanged, but the `known-issues-8.x.asciidoc` file could be grepped by tag (e.g. `tag::known-issue-8.14.0-*`) or by ID (e.g. `known-issue-8.14.0-*`).

---

![Screenshot 2024-06-11 at 7 22 53 PM](https://github.com/elastic/ingest-docs/assets/41695641/8423ab20-7abb-4700-9f9f-83cd8d3a5725)

