### PR TITLE
Fix 'API key' link to point to Fleet & Agent instructions

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-apache.asciidoc
@@ -68,7 +68,7 @@ inputs: <7>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<4> An <<create-api-key-standalone-agent,API key>> used to authenticate with the {es} cluster.
 <5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
 <6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
 <7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
@@ -120,7 +120,7 @@ inputs: <7>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<4> An <<create-api-key-standalone-agent,API key>> used to authenticate with the {es} cluster.
 <5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
 <6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
 <7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.

--- a/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-nginx.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/examples/config-file-example-nginx.asciidoc
@@ -73,7 +73,7 @@ inputs: <7>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the {es} cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<4> An <<create-api-key-standalone-agent,API key>> used to authenticate with the {es} cluster.
 <5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
 <6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
 <7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.
@@ -127,7 +127,7 @@ inputs: <7>
 <1> For available output settings, refer to <<elastic-agent-output-configuration,Configure outputs for standalone {agents}>>.
 <2> For settings specific to the {es} output, refer to <<elasticsearch-output,Configure the {es} output>>.
 <3> The URL of the Elasticsearch cluster where output should be sent, including the port number. For example `https://12345ab6789cd12345ab6789cd.us-central1.gcp.cloud.es.io:443`.
-<4> An {kibana-ref}/api-keys.html[API key] used to authenticate with the {es} cluster.
+<4> An <<create-api-key-standalone-agent,API key>> used to authenticate with the {es} cluster.
 <5> For available download settings, refer to <<elastic-agent-standalone-download,Configure download settings for standalone Elastic Agent upgrades>>.
 <6> For available monitoring settings, refer to <<elastic-agent-monitoring-configuration,Configure monitoring for standalone {agents}>>.
 <7> For available input settings, refer to <<elastic-agent-input-configuration,Configure inputs for standalone {agents}>>.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
@@ -67,7 +67,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 
 [discrete]
 [[nginx-guide-create-api-key-ess]]
-=== Step 3: Create an {ecloud} API key
+=== Step 3: Create an {es} API key
 
 . From the {kib} menu and go to *Stack Management* -> *API keys*.
 

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -71,7 +71,7 @@ image::images/guide-sign-up-trial.png["Start your free Elastic Cloud trial",widt
 
 [discrete]
 [[nginx-guide-create-api-key-serverless]]
-=== Step 3: Create an {ecloud} API key
+=== Step 3: Create an {es} API key
 
 . When your {serverless-short} project is ready, open the {kib} menu and go to **Project settings** -> **Management -> API keys**.
 

--- a/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
@@ -36,11 +36,11 @@ If you are using link:{serverless-docs}[{serverless-full}], API key authenticati
 
 To create an API key for {agent}:
 
-. In an {ecloud} or premises environment, in {kib} navigate to *{stack-manage-app} > API keys* and click *Create API key*.
+. In an {ecloud} or on premises environment, in {kib} navigate to *{stack-manage-app} > API keys* and click *Create API key*.
 +
 In a {serverless-short} environment, in {kib} navigate to *Project settings* > *Management* > *API keys* and click *Create API key*.
 
-. Enter a name for your API key and select *Restrict privileges* (in a {serverless-short} environment, *Control security privileges*).
+. Enter a name for your API key and select *Control security privileges*.
 
 . In the role descriptors box, copy and paste the following JSON. This example creates an API key with privileges for ingesting logs, metrics, traces, and synthetics:
 +


### PR DESCRIPTION
The "API key" link that appears on a few pages in the Fleet & Agent docs would be more helpful if it pointed to [these instructions](https://www.elastic.co/guide/en/fleet/current/grant-access-to-elasticsearch.html#create-api-key-standalone-agent) in the guide.

ADD: I noticed a couple of small things that need updating on the page about API keys, so they're fixed as well.