### PR TITLE
Add Fleet & Agent 8.14.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -31,7 +31,7 @@ Also see:
 Review important information about the {fleet} and {agent} 8.14.2 release.
 
 [discrete]
-[[notable-changes-8.13.0]]
+[[notable-changes-8.14.2]]
 === Notable changes
 
 The following are notable, non-breaking updates to be aware of:
@@ -39,16 +39,37 @@ The following are notable, non-breaking updates to be aware of:
 {fleet}::
 * The `health_check` API endpoint has been updated to accept host IDs. An `id` string should be used in place of the `host` field, which is now deprecated. ({kibana-pull}185014[#185014])
 
-//[discrete]
-//[[bug-fixes-8.14.2]]
-//=== Bug fixes
+[discrete]
+[[new-features-8.14.2]]
+=== New features
 
+The 8.14.2 release added the following new and notable features.
 
+{agent}::
+* The following processors are now available to users running {agent} in `otel` mode:
+** link:https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor[Resource Detection Processor] {agent-pull}4811[#4811]
+** link:https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.102.0/processor/k8sattributesprocessor[Kubernetes Attributes Processor] {agent-pull}4893[#4893]
+** link:https://github.com/elastic/opentelemetry-collector-components/tree/processor/elasticinframetricsprocessor/v0.1.0/processor/elasticinframetricsprocessor[Elastic Infra Metrics Processor] {agent-pull}4968[#4968]
+* An `otelcol` shortcut has been added for the `elasticc-agent otel` command. {agent-pull}4816[#4816] {agent-issue}4661[#4661]
+* An `agent.monitoring.metrics_period` setting has been added, enabling you to control the sampling period of {agent} monitoring metrics according to your needs. {agent-pull}4961[#4961]
 
+[discrete]
+[[enhancements-8.14.2]]
+=== Enhancements
 
+{agent}::
+* Add link:https://kubernetes.io/docs/reference/kubectl/generated/kubectl_kustomize/[kustomize] templates using default manifests for Kubernetes onboarding. {agent-pull}4754[#4754] {agent-issue}4657[#4657]
+* Capture early errors on Windows in the Application eventlog. {agent-pull}4846[#4846] {agent-issue}4627[#4627]
+
+[discrete]
+[[bug-fixes-8.14.2]]
+=== Bug fixes
+
+{agent}::
+* Fix an issue where the `log_writer.go` can panic in the case it logs an empty line. {agent-pull}4910[#4910] {agent-issue}4907[#4907]
+* Increase the removal timeout period to 60 seconds when uninstalling {agent}. {agent-pull}4921[#4921] {agent-issue}4164[#4164]
 
 // end 8.14.2 relnotes
-
 
 // begin 8.14.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.14.2>>
 * <<release-notes-8.14.1>>
 * <<release-notes-8.14.0>>
 
@@ -22,12 +23,39 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.14.2 relnotes
+
+[[release-notes-8.14.2]]
+== {fleet} and {agent} 8.14.2
+
+Review important information about the {fleet} and {agent} 8.14.2 release.
+
+[discrete]
+[[notable-changes-8.13.0]]
+=== Notable changes
+
+The following are notable, non-breaking updates to be aware of:
+
+{fleet}::
+* The `health_check` API endpoint has been updated to accept host IDs. An `id` string should be used in place of the `host` field, which is now deprecated. ({kibana-pull}185014[#185014])
+
+//[discrete]
+//[[bug-fixes-8.14.2]]
+//=== Bug fixes
+
+
+
+
+
+// end 8.14.2 relnotes
+
+
 // begin 8.14.1 relnotes
 
 [[release-notes-8.14.1]]
 == {fleet} and {agent} 8.14.1
 
-Review important information about {fleet-server} and {agent} for the 8.14.1 release.
+Review important information about the {fleet} and {agent} 8.14.1 release.
 
 [discrete]
 [[security-updates-8.14.1]]
@@ -71,7 +99,7 @@ The 8.14.1 release added the following new and notable features.
 [[release-notes-8.14.0]]
 == {fleet} and {agent} 8.14.0
 
-Review important information about {fleet-server} and {agent} for the 8.14.0 release.
+Review important information about the {fleet} and {agent} 8.14.0 release.
 
 [discrete]
 [[security-updates-8.14.0]]


### PR DESCRIPTION
This adds the 8.14.2 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/186920)
* No new Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/849246d2433d3fa9ae980e1252f8b7e65d271292/changelog/fragments)
* Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/fce8a9c6015e0021d235fbc6ce405e43707dfc7c/changelog/fragments)

See [DOCS PREVIEW](https://ingest-docs_bk_1141.docs-preview.app.elstc.co/guide/en/fleet/master/release-notes-8.14.2.html)

Closes: #1140