### PR TITLE
Add note about unprivileged mode on 'install' tabs

### DIFF
--- a/docs/en/ingest-management/tab-widgets/install.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/install.asciidoc
@@ -1,8 +1,9 @@
 // tag::deb[]
 
 // tag::install-tip[]
-TIP: You must run this command as the root user because some
-integrations require root privileges to collect sensitive data.
+TIP: It's recommended to run this command as the root user because some
+integrations require root privileges to collect sensitive data. To <<elastic-agent-unprivileged,run {agent} without full administrative privileges>>, use the `--unprivileged` flag.
+Note the limitations as described in the linked document. 
 
 // end::install-tip[]
 


### PR DESCRIPTION
This updates the [Install standalone Elastic Agents](https://www.elastic.co/guide/en/fleet/8.14/install-standalone-elastic-agent.html) docs page, so the install tabs for macOS, Linux, DEB and RPM would have the following note:

![Screenshot 2024-06-27 at 10 38 01 AM](https://github.com/elastic/ingest-docs/assets/41695641/fa4a0784-38e5-470a-aee7-bb0048466c5a)

@ycombinator I know that in [this comment](https://github.com/elastic/elastic-agent/issues/4125#issuecomment-2125798370) you mentioned only RPM and DEB, but I think this note should apply to all four operating systems, right, since they all show `sudo` in the install command? I tried the phrase the text so that it applies to all four.

Rel: #4125
