### PR TITLE
Fix Serverless variable in API key steps

### DIFF
--- a/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/grant-access-to-elasticsearch.asciidoc
@@ -111,7 +111,7 @@ For more information about creating API keys in {kib}, see
 == Create a standalone agent role
 
 Although it's recommended that you use an API key instead of a username and
-password to access {es} (and an API key is required in a {serverless} environment), you can create a role with the required privileges,
+password to access {es} (and an API key is required in a {serverless-short} environment), you can create a role with the required privileges,
 assign it to a user, and specify the user's credentials in the
 `elastic-agent.yml` file.
 


### PR DESCRIPTION
Fixes my embarrassing typo:

![Screenshot 2024-06-28 at 1 56 38 PM](https://github.com/elastic/ingest-docs/assets/41695641/1a8c1346-27c3-4a3a-93a4-da4ee7dbb6c4)
