### PR TITLE
Change 'enable' to 'set up' for agent alerting

### DIFF
--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -247,7 +247,7 @@ To do so, follow the steps in <<remote-elasticsearch-output>>. After the new out
 
 [discrete]
 [[fleet-alerting]]
-= Enable alerts and ML jobs based on {fleet} and {agent} status
+= Set up alerts and ML jobs based on {fleet} and {agent} status
 
 You can access the health status of {fleet}-managed {agents} and other {fleet} settings through internal {fleet} indices. This enables you to leverage various applications within the {stack} that can be triggered by the provided information. For instance, you can now create alerts and machine learning (ML) jobs based on these specific fields. Refer to the {kibana-ref}/alerting-getting-started.html[Alerting documentation] or see the <<fleet-alerting-example,example>> on this page to learn how to define rules that can trigger actions when certain conditions are met.
 
@@ -287,7 +287,7 @@ This index publishes a separate document for each version number and a count of 
 
 [discrete]
 [[fleet-alerting-example]]
-== Example: Enable an alert for offline {agent}s
+== Example: Set up an alert for offline {agent}s
 
 You can set up an alert to notify you when one or more {agent}s goes offline:
 


### PR DESCRIPTION
Just fixing up the terminology a bit for  this section about [alerts](https://www.elastic.co/guide/en/fleet/master/monitor-elastic-agent.html#fleet-alerting). The term "enable" seems a bit inappropriate in the context of an alert, since it implies that the alert already exists.