### PR TITLE
Remove sudo restriction from standalone examples

### DIFF
--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
@@ -143,7 +143,7 @@ image::images/guide-install-agent-on-host.png["Install {agent} on your host step
 +
 [NOTE] 
 ==== 
-{agent} commands need to be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. 
+It's recommended to run {agent} commands as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
 ====
 +
 If you're prompted with `Elastic Agent will be installed at {installation location} and will run as a service. Do you want to continue?` answer `Yes`.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-ess.asciidoc
@@ -143,7 +143,7 @@ image::images/guide-install-agent-on-host.png["Install {agent} on your host step
 +
 [NOTE] 
 ==== 
-It's recommended to run {agent} commands as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
+{agent} commands should be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. If you need to run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
 ====
 +
 If you're prompted with `Elastic Agent will be installed at {installation location} and will run as a service. Do you want to continue?` answer `Yes`.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -147,7 +147,7 @@ image::images/guide-install-agent-on-host.png["Install {agent} on your host step
 +
 [NOTE] 
 ==== 
-{agent} commands should be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about how to run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
+{agent} commands should be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. If you need to run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
 ====
 +
 If you're prompted with `Elastic Agent will be installed at {installation location} and will run as a service. Do you want to continue?` answer `Yes`.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -147,7 +147,7 @@ image::images/guide-install-agent-on-host.png["Install {agent} on your host step
 +
 [NOTE] 
 ==== 
-It's recommended to run {agent} commands as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
+{agent} commands should be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about how to run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
 ====
 +
 If you're prompted with `Elastic Agent will be installed at {installation location} and will run as a service. Do you want to continue?` answer `Yes`.

--- a/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/example-standalone-monitor-nginx-serverless.asciidoc
@@ -147,7 +147,7 @@ image::images/guide-install-agent-on-host.png["Install {agent} on your host step
 +
 [NOTE] 
 ==== 
-{agent} commands need to be run as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. 
+It's recommended to run {agent} commands as `root`. You can prefix each agent command with `sudo` or you can start a new shell as `root` by running `sudo su`. For details about run {agent} commands without `root` access, refer to <<elastic-agent-unprivileged>>.
 ====
 +
 If you're prompted with `Elastic Agent will be installed at {installation location} and will run as a service. Do you want to continue?` answer `Yes`.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -821,5 +821,5 @@ For example, when you run {agent} with the `--unprivileged` flag, running the `e
 Error: error loading agent config: error loading raw config: fail to read configuration /Library/Elastic/Agent/fleet.enc for the elastic-agent: fail to decode bytes: cipher: message authentication failed
 ----
 
-To resolve this, either run {agent} without the `--unprivileged` flag so that it has administrative access, or run the {agent} commands without the `sudo` prefix.
+To resolve this, either install {agent} without the `--unprivileged` flag so that it has administrative access, or run the {agent} commands without the `sudo` prefix.
 


### PR DESCRIPTION
Small change to remove a couple of notes saying that `sudo` is required for Elastic Agent commands.

Also, a small touch-up to a semi-related troubleshooting page.

Closes: #505 