### PR TITLE
Add read-only filesystem option for Elastic Agent on Docker

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -108,7 +108,7 @@ For example:
 
 [source,terminal,subs="attributes"]
 ----
-docker run --rm --mount source=$(pwd)/state,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
+docker run --rm --mount source=$(pwd)/state,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:{version} <1>
 ----
 
 Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -95,6 +95,25 @@ docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent co
 
 include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/run-agent-image/widget.asciidoc[]
 
+[TIP] 
+.Running {agent} on a read-only file system
+==== 
+If you'd like to run {agent} in a Docker container on a read-only file 
+system, you can do so by specifying the `--read-only` option.
+{agent} requires a stateful directory to store application data, so
+with the `--read-only` option you also need to use the `--mount` option to
+specify a path to where that data can be stored.
+
+For example:
+
+[source,terminal,subs="attributes"]
+----
+docker run --rm --mount type=tmpfs,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
+----
+
+Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.
+====
+
 [discrete]
 == Step 5: View your data in {kib}
 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -108,7 +108,7 @@ For example:
 
 [source,terminal,subs="attributes"]
 ----
-docker run --rm --mount type=tmpfs,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
+docker run --rm --mount destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
 ----
 
 Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -108,7 +108,7 @@ For example:
 
 [source,terminal,subs="attributes"]
 ----
-docker run --rm --mount destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
+docker run --rm --mount source=$(pwd)/state,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:8.15.0 <1>
 ----
 
 Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -112,6 +112,8 @@ docker run --rm --mount destination=/state -e {STATE_PATH}=/state --read-only do
 ----
 
 Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.
+
+You can also add `type=tmpfs` to the mount parameter (`--mount type=tmpfs,destination=/state...`) to specify a temporary file storage location. This should be done with caution as it can cause data duplication, particularly for logs, when the container is restarted, as no state data is persisted.
 ====
 
 [discrete]

--- a/docs/en/ingest-management/elastic-agent/run-container-common/deploy-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-container-common/deploy-elastic-agent.asciidoc
@@ -17,5 +17,9 @@ elastic-agent-fj2z9             1/1     Running   0          81m
 elastic-agent-hs4pb             1/1     Running   0          81m
 ------------------------------------------------
 
-
-
+[TIP] 
+.Running {agent} on a read-only file system
+==== 
+If you'd like to run {agent} on Kubernetes on a read-only file 
+system, you can do so by specifying the `readOnlyRootFilesystem` option.
+====


### PR DESCRIPTION
This updates the [Running Elastic Agent in a container](https://www.elastic.co/guide/en/fleet/current/elastic-agent-container.html#_step_4_run_the_elastic_agent_image) instructions with the options required for running the container on a read-only file system.

Target: 8.15
Closes:: https://github.com/elastic/ingest-docs/issues/1152

I assumed that "STATE_PATH is a variable that should be replaced with the full path to the stateful directory to mount, but please correct me if that's wrong.

---

![Screenshot 2024-07-09 at 11 25 43 AM](https://github.com/elastic/ingest-docs/assets/41695641/f20f08f0-df4a-451a-aa5a-19b0d690dca6)



