### PR TITLE
Add best practices for using integration assets

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -201,6 +201,8 @@ include::integrations/upgrade-integration.asciidoc[leveloffset=+2]
 
 include::integrations/managed-integrations-content.asciidoc[leveloffset=+2]
 
+include::integrations/integrations-assets-best-practices.asciidoc[leveloffset=+2]
+
 include::data-streams.asciidoc[leveloffset=+2]
 
 include::processors/processors.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
+++ b/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
@@ -3,7 +3,13 @@
 
 When you use integrations with {fleet} and {agent} there are some restrictions to be aware of.
 
+* <<assets-restrictions-standalone>>
+* <<assets-restrictions-without-agent>>
+* <<assets-restrictions-custom-integrations>>
+* <<assets-restrictions-copying>>
+
 [discrete]
+[[assets-restrictions-standalone]]
 == Using integration assets with standalone {agent}
 
 When you use standalone {agent} with integrations, the integration assets added to the {agent} policy must be installed on the destination {es} cluster.
@@ -13,27 +19,30 @@ When you use standalone {agent} with integrations, the integration assets added 
 * If {kib} is not available (for instance if you have a remote cluster without a {kib} instance), then the integration assets need to be installed manually.
 
 [discrete]
+[[assets-restrictions-without-agent]]
 == Using integration assets without {agent}
 
 Using {agent} and {fleet} integration assets without {agent} is not supported.
 
-For example, if you install the {integrations-docs}/redis-intro[Redis integration] to collect logs and metrics, the integration is supported only for use with {agent}. Using {ls} or {filebeat} to collect the Redis logs from a third party source (such as Kafka or AWS S3) is not supported. As well, a configuration like this could break when the integration is upgraded.
+For example, if you install the {integrations-docs}/redis-intro[Redis integration] to collect logs and metrics, the integration is supported only for use with {agent}. Using {ls} or {filebeat} to collect the Redis logs from a third party source (such as Kafka or AWS S3) is not supported. As well, a configuration like this could break when the integration is upgraded, which can happen automatically.
 
 [discrete]
+[[assets-restrictions-custom-integrations]]
 == Using {fleet} and {agent} integration assets in custom integrations
 
 While it's possible to include {fleet} and {agent} integration assets in a custom integration, this is not recommended nor supported. Assets from another integration should not be referenced directly from a custom integration.
 
-As an example scenario, one may want to ingest Redis logs from Kafka. This can be done using the {integrations-docs}/redis-intro[Redis integration], but only certainly files and paths are allowed. A possible workaround would be to use the {integrations-docs}/kafka_log[Custom Kafka Logs integration] with a custom ingest pipeline, referencing the ingest pipeline of the Redis integration to ingest logs into the index templates of the Custom Kafka Logs integration data streams. 
+As an example scenario, one may want to ingest Redis logs from Kafka. This can be done using the {integrations-docs}/redis-intro[Redis integration], but only certain files and paths are allowed. It's technically possible to use the {integrations-docs}/kafka_log[Custom Kafka Logs integration] with a custom ingest pipeline, referencing the ingest pipeline of the Redis integration to ingest logs into the index templates of the Custom Kafka Logs integration data streams. 
 
-Reference assets of an integration from another custom integration is not recommended nor supported. A configuration as described above is very likely to break when the integration is next upgraded.
+However, referencing assets of an integration from another custom integration is not recommended nor supported. A configuration as described above can break when the integration is upgraded, as can happen automatically.
 
 [discrete]
+[[assets-restrictions-copying]]
 == Copying {fleet} and {agent} integration assets
 
 As an alternative to referencing assets from another integration from within a custom integration, assets such as index templates and ingest pipelines can be copied so that they become standalone.
 
 This way, because the assets are not managed by another integration, there is less risk of a configuration breaking or of an integration asset being deleted when the other integration is upgraded.
 
-Note that creating standalone integration assets based off of {fleet} and {agent} integrations is considered a custom configuration that is not tested nor supported.
+Note, however, that creating standalone integration assets based off of {fleet} and {agent} integrations is considered a custom configuration that is not tested nor supported. Whenever possible it's recommended to use standard integrations.
 

--- a/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
+++ b/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
@@ -22,9 +22,9 @@ When you use standalone {agent} with integrations, the integration assets added 
 [[assets-restrictions-without-agent]]
 == Using integration assets without {agent}
 
-Using {agent} and {fleet} integration assets without {agent} is not supported.
+{fleet} integration assets are meant to work only with {agent}.
 
-For example, if you install the {integrations-docs}/redis-intro[Redis integration] to collect logs and metrics, the integration is supported only for use with {agent}. Using {ls} or {filebeat} to collect the Redis logs from a third party source (such as Kafka or AWS S3) is not supported. As well, a configuration like this could break when the integration is upgraded, which can happen automatically.
+The {fleet} integration assets are not supposed to work when sending arbitrary logs or metrics collected with other products such as {filebeat}, {metricbeat} or {ls}.
 
 [discrete]
 [[assets-restrictions-custom-integrations]]

--- a/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
+++ b/docs/en/ingest-management/integrations/integrations-assets-best-practices.asciidoc
@@ -1,0 +1,39 @@
+[[integrations-assets-best-practices]]
+= Best practices for integrations assets
+
+When you use integrations with {fleet} and {agent} there are some restrictions to be aware of.
+
+[discrete]
+== Using integration assets with standalone {agent}
+
+When you use standalone {agent} with integrations, the integration assets added to the {agent} policy must be installed on the destination {es} cluster.
+
+* If {kib} is available, the integration assets can be <<install-uninstall-integration-assets,installed through {fleet}>>.
+
+* If {kib} is not available (for instance if you have a remote cluster without a {kib} instance), then the integration assets need to be installed manually.
+
+[discrete]
+== Using integration assets without {agent}
+
+Using {agent} and {fleet} integration assets without {agent} is not supported.
+
+For example, if you install the {integrations-docs}/redis-intro[Redis integration] to collect logs and metrics, the integration is supported only for use with {agent}. Using {ls} or {filebeat} to collect the Redis logs from a third party source (such as Kafka or AWS S3) is not supported. As well, a configuration like this could break when the integration is upgraded.
+
+[discrete]
+== Using {fleet} and {agent} integration assets in custom integrations
+
+While it's possible to include {fleet} and {agent} integration assets in a custom integration, this is not recommended nor supported. Assets from another integration should not be referenced directly from a custom integration.
+
+As an example scenario, one may want to ingest Redis logs from Kafka. This can be done using the {integrations-docs}/redis-intro[Redis integration], but only certainly files and paths are allowed. A possible workaround would be to use the {integrations-docs}/kafka_log[Custom Kafka Logs integration] with a custom ingest pipeline, referencing the ingest pipeline of the Redis integration to ingest logs into the index templates of the Custom Kafka Logs integration data streams. 
+
+Reference assets of an integration from another custom integration is not recommended nor supported. A configuration as described above is very likely to break when the integration is next upgraded.
+
+[discrete]
+== Copying {fleet} and {agent} integration assets
+
+As an alternative to referencing assets from another integration from within a custom integration, assets such as index templates and ingest pipelines can be copied so that they become standalone.
+
+This way, because the assets are not managed by another integration, there is less risk of a configuration breaking or of an integration asset being deleted when the other integration is upgraded.
+
+Note that creating standalone integration assets based off of {fleet} and {agent} integrations is considered a custom configuration that is not tested nor supported.
+


### PR DESCRIPTION
This adds a "Best practices for integrations assets" page as proposed in https://github.com/elastic/ingest-docs/issues/248

Please see [PREVIEW PAGE](https://ingest-docs_bk_1155.docs-preview.app.elstc.co/guide/en/fleet/master/integrations-assets-best-practices.html)


