### PR TITLE
Add Fleet & Agent 8.14.3 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.14.3>>
 * <<release-notes-8.14.2>>
 * <<release-notes-8.14.1>>
 * <<release-notes-8.14.0>>
@@ -22,6 +23,22 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.14.3 relnotes
+
+[[release-notes-8.14.3]]
+== {fleet} and {agent} 8.14.3
+
+Review important information about the {fleet} and {agent} 8.14.3 release.
+
+[discrete]
+[[bug-fixes-8.14.3]]
+=== Bug fixes
+
+//{agent}::
+
+// end 8.14.3 relnotes
+
 
 // begin 8.14.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.14.asciidoc
@@ -35,7 +35,11 @@ Review important information about the {fleet} and {agent} 8.14.3 release.
 [[bug-fixes-8.14.3]]
 === Bug fixes
 
-//{agent}::
+{agent}::
+* Update the `elastic-agent install -f` command to use paths associated with the installed agent binary instead of paths associated with the agent running the install command. {agent-pull}4965[#4965] {agent-issue}4506[#4506]
+* Allow the {agent} container to work with a read-only filesystem. {agent-pull}5010[#5010]
+* Upgrade NodeJS to LTS version 18.20.3. {agent-pull}4995[#4995]
+* Fix {agent} to account for the timeout period when waiting for {fleet-server} to start. {agent-pull}5034[#5034] {agent-issue}5033[#5033]
 
 // end 8.14.3 relnotes
 


### PR DESCRIPTION
This adds the 8.14.3 Fleet & Elastic Agent Release Notes:

* No new Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/187928)
* No new Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/c80a3b16de03350fec26d0ae326bf8ca250dc2ba/changelog/fragments)
* Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/2df2c10b10501e457b69ef94e0ada45304b2d1a9/changelog/fragments)

---

![Screenshot 2024-07-10 at 10 50 21 AM](https://github.com/elastic/ingest-docs/assets/41695641/8652d943-dbe8-45d3-b073-db12e97497cc)
