### PR TITLE
Add Fleet scaling recommendation: ES API key cache size

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -236,7 +236,7 @@ A single instance of {fleet} supports a maximum of 500 {agent} policies. If more
 
 **{agents}**
 
-When you use {fleet} to manage a large volume (10k or more) of {agents}, the check-in from each of the multiple agents triggers an {es} authentication request. To help reduce the possibility of cache eviction and to speed up propagation of {agent} policy changes and actions, we recommend setting the {ref}/security-settings.html#api-key-service-settings[API key cache size] in your {es} configuration to `max number of agents * 2`.
+When you use {fleet} to manage a large volume (10k or more) of {agents}, the check-in from each of the multiple agents triggers an {es} authentication request. To help reduce the possibility of cache eviction and to speed up propagation of {agent} policy changes and actions, we recommend setting the {ref}/security-settings.html#api-key-service-settings[API key cache size] in your {es} configuration to 2x the maximum number of agents.
 
 For example, with 25,000 running {agents} you could set the cache value to `50000`:
 

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -6,6 +6,8 @@ requirements needed to scale your deployment of {agent}s. To scale
 {fleet-server}, you need to modify settings in your deployment and the
 {fleet-server} agent policy.
 
+TIP: Refer to the <<agent-policy-scaling-recommendations>> section for specific recommendations about using {fleet-server} at scale.
+
 First modify your {fleet} deployment settings in {ecloud}:
 
 . Log in to {ecloud} and go to your deployment.
@@ -226,7 +228,19 @@ of these operations.
 
 [discrete]
 [[agent-policy-scaling-recommendations]]
-== Policy scaling recommendations
+== Scaling recommendations
+
+**{agent} policies**
 
 A single instance of {fleet} supports a maximum of 500 {agent} policies. If more policies are configured, UI performance might be impacted.
 
+**{agents}**
+
+When you use {fleet} to manage a large volume (10k or more) of {agents}, the check-in from each of the multiple agents triggers an {es} authentication request. To help reduce the possibility of cache eviction and to speed up propagation of {agent} policy changes and actions, we recommend setting the {ref}/security-settings.html#api-key-service-settings[API key cache size] in your {es} configuration to `max number of agents * 2`.
+
+For example, with 25,000 running {agents} you could set the cache value to `50,000`:
+
+[source,yaml]
+----
+xpack.security.authc.api_key.cache.max_keys: 50000
+----

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -238,7 +238,7 @@ A single instance of {fleet} supports a maximum of 500 {agent} policies. If more
 
 When you use {fleet} to manage a large volume (10k or more) of {agents}, the check-in from each of the multiple agents triggers an {es} authentication request. To help reduce the possibility of cache eviction and to speed up propagation of {agent} policy changes and actions, we recommend setting the {ref}/security-settings.html#api-key-service-settings[API key cache size] in your {es} configuration to `max number of agents * 2`.
 
-For example, with 25,000 running {agents} you could set the cache value to `50,000`:
+For example, with 25,000 running {agents} you could set the cache value to `50000`:
 
 [source,yaml]
 ----


### PR DESCRIPTION
This updates the Fleet Server scalability page with a scaling tip running a large volume of agents.

Closes: #1156 

---

![Screenshot 2024-07-09 at 12 46 15 PM](https://github.com/elastic/ingest-docs/assets/41695641/bfd3ef83-a1fa-44a0-a14a-f1034443094f)

---

I also put a link at the top of the page to make sure people can find the scaling recommendations section.

![Screenshot 2024-07-09 at 12 48 43 PM](https://github.com/elastic/ingest-docs/assets/41695641/3b7c2118-dfcf-479d-b5a3-9c4d012efca5)

