### PR TITLE
Use external link in files used in multiple books

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -781,9 +781,9 @@ NOTE: Currently, there is no way to remove or edit existing tags. To change the
 tags, you must unenroll the {agent}, then re-enroll it using new tags.
 
 `--unprivileged`::
-Run {agent} without full superuser privileges. 
+Run {agent} without full superuser privileges.
 This option is useful in organizations that limit `root` access on Linux or macOS systems, or `admin` access on Windows systems.
-For details and limitations for running {agent} in this mode, refer to <<elastic-agent-unprivileged>>.
+For details and limitations for running {agent} in this mode, refer to {fleet-guide}/elastic-agent-unprivileged.html[Run {agent} without administrative privileges].
 
 `--url <string>`::
 {fleet-server} URL to use to enroll the {agent} into {fleet}.

--- a/docs/en/ingest-management/tab-widgets/download.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/download.asciidoc
@@ -11,7 +11,7 @@ ifeval::["{release-state}"!="unreleased"]
 ====
 * To simplify upgrading to future versions of {agent}, we recommended
 that you use the tarball distribution instead of the RPM distribution.
-* You can install {agent} in an `unprivileged` mode that does not require `root` privileges. Refer to <<elastic-agent-unprivileged>> for details.
+* You can install {agent} in an `unprivileged` mode that does not require `root` privileges. Refer to {fleet-guide}/elastic-agent-unprivileged.html[Run {agent} without administrative privileges] for details.
 ====
 
 ["source","sh",subs="attributes"]
@@ -36,7 +36,7 @@ ifeval::["{release-state}"!="unreleased"]
 ====
 * To simplify upgrading to future versions of {agent}, we recommended
 that you use the tarball distribution instead of the RPM distribution.
-* You can install {agent} in an `unprivileged` mode that does not require `root` privileges. Refer to <<elastic-agent-unprivileged>> for details.
+* You can install {agent} in an `unprivileged` mode that does not require `root` privileges. Refer to {fleet-guide}/elastic-agent-unprivileged.html[Run {agent} without administrative privileges] for details.
 ====
 
 ["source","sh",subs="attributes"]
@@ -95,7 +95,7 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","powershell",subs="attributes"]
 ----
 # PowerShell 5.0+
-wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-windows-x86_64.zip -OutFile elastic-agent-{version}-windows-x86_64.zip 
+wget https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{version}-windows-x86_64.zip -OutFile elastic-agent-{version}-windows-x86_64.zip
 Expand-Archive .\elastic-agent-{version}-windows-x86_64.zip
 ----
 Or manually:


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/3029

Updates the links in files that are included in the Observability guide. The use of internal links are breaking the build in https://github.com/elastic/docs/pull/3029. 

cc @KOTungseth @lcawl 