### PR TITLE
Data Streams: Add ecs@mappings disclaimer for index templates cloned on ES < 8.13

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -298,6 +298,8 @@ This tutorial explains how to apply a custom {ilm-init} policy to an integration
 **Goal:** Customize the {ilm-init} policy for the `system.network` data stream in the `production` namespace.
 Specifically, apply the built-in `90-days-default` {ilm-init} policy so that data is deleted after 90 days.
 
+NOTE: If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index template in the clone to use the `ecs@mappings` component template on {es} version 8.13 or later. See "Update index template cloned before {es} 8.13" section for the step-by-step instructions.
+
 [discrete]
 [[data-streams-ilm-one]]
 == Step 1: View data streams
@@ -419,6 +421,20 @@ or force a rollover using the {ref}/indices-rollover-index.html[{es} rollover AP
 ----
 POST /metrics-system.network-production/_rollover/
 ----
+
+[discrete]
+[[data-streams-pipeline-update-cloned-template-before-8.13]]
+== Update index template cloned before {es} 8.13
+
+If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index cloned index template adding the `ecs@mappings` component template on {es} version 8.13 or later.
+
+. Navigate to **{stack-manage-app}** > **Index Management** > **Index Templates**.
+. Find the index template you cloned. The index template will have the `<type>` and `<dataset>` in its name.
+. Select **Manage** > **Edit**.
+. Select **(2) Component templates**
+. In the **Search component templates** field, search for `ecs@mappings`.
+. Click on the **+ (plus)** icon to add the `ecs@mappings` component template.
+. Move the `ecs@mappings` component template right below the `@package` component template.
 
 [[data-streams-pipeline-tutorial]]
 == Tutorial: Transform data with custom ingest pipelines

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -298,7 +298,8 @@ This tutorial explains how to apply a custom {ilm-init} policy to an integration
 **Goal:** Customize the {ilm-init} policy for the `system.network` data stream in the `production` namespace.
 Specifically, apply the built-in `90-days-default` {ilm-init} policy so that data is deleted after 90 days.
 
-NOTE: If you cloned an index template to customize the data retention policy on an {es} version before 8.13, you must update the cloned index template to add the `ecs@mappings` component template. Updating the index template is a required step for cloned index templates. See the "Update index template cloned before {es} 8.13" section for step-by-step instructions.
+NOTE: If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index template in the clone to use the `ecs@mappings` component template on {es} version 8.13 or later. See <<data-streams-pipeline-update-cloned-template-before-8.13,Update index template cloned before {es} 8.13>> for the step-by-step instructions.
+
 
 [discrete]
 [[data-streams-ilm-one]]
@@ -426,9 +427,9 @@ POST /metrics-system.network-production/_rollover/
 [[data-streams-pipeline-update-cloned-template-before-8.13]]
 == Update index template cloned before {es} 8.13
 
-If you cloned an index template to customize the data retention policy on an {es} version before 8.13, you must update the cloned index template to add the `ecs@mappings` component template. 
+If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index cloned index template to add the `ecs@mappings` component template on {es} version 8.13 or later.
 
-Here is how you can add the `ecs@mappings` component template to the cloned index template:
+To update the cloned index template:
 
 . Navigate to **{stack-manage-app}** > **Index Management** > **Index Templates**.
 . Find the index template you cloned. The index template will have the `<type>` and `<dataset>` in its name.

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -298,7 +298,7 @@ This tutorial explains how to apply a custom {ilm-init} policy to an integration
 **Goal:** Customize the {ilm-init} policy for the `system.network` data stream in the `production` namespace.
 Specifically, apply the built-in `90-days-default` {ilm-init} policy so that data is deleted after 90 days.
 
-NOTE: If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index template in the clone to use the `ecs@mappings` component template on {es} version 8.13 or later. See "Update index template cloned before {es} 8.13" section for the step-by-step instructions.
+NOTE: If you cloned an index template to customize the data retention policy on an {es} version before 8.13, you must update the cloned index template to add the `ecs@mappings` component template. Updating the index template is a required step for cloned index templates. See the "Update index template cloned before {es} 8.13" section for step-by-step instructions.
 
 [discrete]
 [[data-streams-ilm-one]]
@@ -426,9 +426,9 @@ POST /metrics-system.network-production/_rollover/
 [[data-streams-pipeline-update-cloned-template-before-8.13]]
 == Update index template cloned before {es} 8.13
 
-If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index cloned index template adding the `ecs@mappings` component template on {es} version 8.13 or later.
+If you cloned an index template to customize the data retention policy on an {es} version before 8.13, you must update the cloned index template to add the `ecs@mappings` component template. 
 
-Here how you can update the cloned index template:
+Here is how you can add the `ecs@mappings` component template to the cloned index template:
 
 . Navigate to **{stack-manage-app}** > **Index Management** > **Index Templates**.
 . Find the index template you cloned. The index template will have the `<type>` and `<dataset>` in its name.

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -428,6 +428,8 @@ POST /metrics-system.network-production/_rollover/
 
 If you cloned an index template to customize the data retention policy on an {es} version prior to 8.13, you must update the index cloned index template adding the `ecs@mappings` component template on {es} version 8.13 or later.
 
+Here how you can update the cloned index template:
+
 . Navigate to **{stack-manage-app}** > **Index Management** > **Index Templates**.
 . Find the index template you cloned. The index template will have the `<type>` and `<dataset>` in its name.
 . Select **Manage** > **Edit**.
@@ -435,6 +437,9 @@ If you cloned an index template to customize the data retention policy on an {es
 . In the **Search component templates** field, search for `ecs@mappings`.
 . Click on the **+ (plus)** icon to add the `ecs@mappings` component template.
 . Move the `ecs@mappings` component template right below the `@package` component template.
+. Save the index template.
+
+Roll over the data stream to apply the changes.
 
 [[data-streams-pipeline-tutorial]]
 == Tutorial: Transform data with custom ingest pipelines


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Starting from version 8.13, Elasticsearch [includes](https://github.com/elastic/kibana/pull/174855) the `ecs@mappings` component templates in all the index templates used in Elastic Agent integrations. 

As integrations adopt the `ecs@mappings` component template, index templates cloned following the "Tutorial: Customize data retention policies" may start having problems with mappings.

End users must update their cloned index templates by adding the `ecs@mappings` component template.

### Change description
<!-- What does your code do? -->

This PR added a note and instructions to the tutorial users about updating the cloned index template they created following this tutorial.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

- relates: https://github.com/elastic/kibana/pull/174855


### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
