### PR TITLE
Remove mention of Agent -> Fleet default port

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -59,7 +59,7 @@ You may need to allow access to these ports. See the following table for default
 | Elastic Agent → {fleet-server} | 443
 | Elastic Agent → {es} | 443
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 443
+//| Elastic Agent → {fleet} | 443
 | {fleet-server} → {fleet} | 443
 | {fleet-server} → {es} | 443
 |===

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -77,7 +77,7 @@ You may need to allow access to these ports. See the following table for default
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 443
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 443
+//| Elastic Agent → {fleet} | 443
 | {fleet-server} → {fleet} | 443
 | {fleet-server} → {es} | 443
 |===

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -94,7 +94,7 @@ You may need to allow access to these ports. Refer to the following table for de
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 9200
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 5601
+//| Elastic Agent → {fleet} | 5601
 | {fleet-server} → {fleet} | 5601
 | {fleet-server} → {es} | 9200
 |===


### PR DESCRIPTION
This updates the documented default port assignments to remove mention of Agent -> Fleet communication, since Agent only communicates with Fleet via Fleet Server.

Rel: #1075

---

[Deploy on Elastic Cloud](http://localhost:8000/guide/add-fleet-server-cloud.html)
Elastic Agent → Fleet Server | 443
Elastic Agent → Elasticsearch | 443
Elastic Agent → Logstash | 5044
~~Elastic Agent → Fleet       443~~
Fleet Server → Fleet    443
Fleet Server → Elasticsearch    443


[Deploy Fleet Server on-premises and Elasticsearch on Cloud](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-mixed.html)
Elastic Agent → Fleet Server    8220
Elastic Agent → Elasticsearch   443
Elastic Agent → Logstash   5044
~~Elastic Agent → Fleet   443~~
Fleet Server → Fleet  443
Fleet Server → Elasticsearch  443


[Deploy on-premises and self-managed](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-on-prem.html)
Elastic Agent → Fleet Server   8220
Elastic Agent → Elasticsearch     9200
Elastic Agent → Logstash     5044
~~Elastic Agent → Fleet    5601~~
Fleet Server → Fleet   5601
Fleet Server → Elasticsearch   9200


