### PR TITLE
Add Fleet Server install steps on K8s and Docker

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -99,12 +99,13 @@ If you need to run {fleet-server} as well, adjust the `docker run` command above
 
 [source,yaml]
 ----
-      - FLEET_SERVER_ENABLE=true
-      - FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host>
-      - FLEET_SERVER_SERVICE_TOKEN=<service-token>
+  --env FLEET_SERVER_ENABLE=true \ <1>
+  --env FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host> \ <2>
+  --env FLEET_SERVER_SERVICE_TOKEN=<service-token> <3>
 ----
-
-Refer to <<agent-environment-variables>> for all available options.
+<1> Set to `1` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
+<2> The Elasticsearch host for Fleet Server to communicate with, for example `http://elasticsearch:9200`.
+<3> Service token to use for communication with {es} and {kib}.
 
 [TIP] 
 .Running {agent} on a read-only file system

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -95,6 +95,17 @@ docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent co
 
 include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/run-agent-image/widget.asciidoc[]
 
+If you need to run {fleet-server} as well, adjust the `docker run` command above by adding these environment variables:
+
+[source,yaml]
+----
+      - FLEET_SERVER_ENABLE=true
+      - FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host>
+      - FLEET_SERVER_SERVICE_TOKEN=<service-token>
+----
+
+Refer to <<agent-environment-variables>> for all available options.
+
 [TIP] 
 .Running {agent} on a read-only file system
 ==== 

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -103,7 +103,7 @@ If you need to run {fleet-server} as well, adjust the `docker run` command above
   --env FLEET_SERVER_ELASTICSEARCH_HOST=<elasticsearch-host> \ <2>
   --env FLEET_SERVER_SERVICE_TOKEN=<service-token> <3>
 ----
-<1> Set to `1` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
+<1> Set to `true` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
 <2> The Elasticsearch host for Fleet Server to communicate with, for example `http://elasticsearch:9200`.
 <3> Service token to use for communication with {es} and {kib}.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -78,7 +78,7 @@ If you need to run {fleet-server} as well, adjust the `docker run` command above
 - name: FLEET_SERVER_SERVICE_TOKEN
   value: "<service-token>" <3>
 ------------------------------------------------
-<1> Set to `1` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
+<1> Set to `true` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
 <2> The Elasticsearch host for Fleet Server to communicate with, for example `http://elasticsearch:9200`.
 <3> Service token to use for communication with {es} and {kib}.
 

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-managed-by-fleet.asciidoc
@@ -67,8 +67,22 @@ To specify different destination/credentials, change the following parameters in
 <5> The basic authentication username used to connect to {kib} and retrieve a `service_token` to enable {fleet}.
 <6> The basic authentication password used to connect to {kib} and retrieve a `service_token` to enable {fleet}.
 
-Refer to <<agent-environment-variables>> for all available options.
+If you need to run {fleet-server} as well, adjust the `docker run` command above by adding these environment variables:
 
+[source,yaml]
+------------------------------------------------
+- name: FLEET_SERVER_ENABLE
+  value: "true" <1>
+- name: FLEET_SERVER_ELASTICSEARCH_HOST
+  value: "<elasticsearch-host>" <2>
+- name: FLEET_SERVER_SERVICE_TOKEN
+  value: "<service-token>" <3>
+------------------------------------------------
+<1> Set to `1` to bootstrap {fleet-server} on this {agent}. This automatically forces {fleet} enrollment as well.
+<2> The Elasticsearch host for Fleet Server to communicate with, for example `http://elasticsearch:9200`.
+<3> Service token to use for communication with {es} and {kib}.
+
+Refer to <<agent-environment-variables>> for all available options.
 
 [discrete]
 == Step 4: Configure tolerations


### PR DESCRIPTION
This updates the docs with the extra steps required to install Elastic Agent as a Fleet Server in containerized environments.

**On Kubernetes**
 - On the page "Run Elastic Agent on Kubernetes managed by Fleet" this updates "[Step 3: Enroll Elastic Agent to the policy](https://www.elastic.co/guide/en/fleet/master/running-on-kubernetes-managed-by-fleet.html#_step_3_enroll_elastic_agent_to_the_policy)" to add the following:
    ![Screenshot 2024-09-18 at 12 38 25 PM](https://github.com/user-attachments/assets/e914860d-abc6-4398-96c0-4be50746ba71)


**In Docker**
 - On the page "Run Elastic Agent in a container" this updates "[Step 4: Run the Elastic Agent image](https://www.elastic.co/guide/en/fleet/master/elastic-agent-container.html#_step_4_run_the_elastic_agent_image)"  to add the following:
    ![Screenshot 2024-09-18 at 12 40 19 PM](https://github.com/user-attachments/assets/e1c1ba72-2319-4338-a855-65902dc72b87)


---

 Rel: https://github.com/elastic/ingest-docs/issues/1075







