### PR TITLE
[DOCS] Update Fleet Server guide - Fleet Server keeps using the ES host provided at install/enroll time.

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -212,9 +212,9 @@ token for each {fleet-server}. For other ways to generate service tokens, refer 
 `--fleet-server-port` options in the `elastic-agent install` command. Refer to the 
 {fleet-guide}/elastic-agent-cmd-options.html#elastic-agent-install-command[install command documentation]
 for details.
-* Please note that {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install
-time. The {es} hosts configured in the associated policy will be ignored by the {fleet-server} integration. We
-strongly recommend using a load balancer to avoid coupling the {fleet-server} to the provided host.
+* Please note that {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install time. 
+The {es} hosts configured in the associated policy will be ignored by the {fleet-server} integration. 
+We strongly recommend using a load balancer to avoid coupling the {fleet-server} to the provided host.
 ====
 +
 At the *Install Fleet Server to a centralized host* step, 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -212,6 +212,9 @@ token for each {fleet-server}. For other ways to generate service tokens, refer 
 `--fleet-server-port` options in the `elastic-agent install` command. Refer to the 
 {fleet-guide}/elastic-agent-cmd-options.html#elastic-agent-install-command[install command documentation]
 for details.
+* Please note {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install
+time. The {es} hosts configured in the associated policy will be ignored by the {fleet-server} integration. We
+strongly recommend using a load balancer to avoid coupling the {fleet-server} to the provided host.
 ====
 +
 At the *Install Fleet Server to a centralized host* step, 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -212,7 +212,7 @@ token for each {fleet-server}. For other ways to generate service tokens, refer 
 `--fleet-server-port` options in the `elastic-agent install` command. Refer to the 
 {fleet-guide}/elastic-agent-cmd-options.html#elastic-agent-install-command[install command documentation]
 for details.
-* Please note {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install
+* Please note that {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install
 time. The {es} hosts configured in the associated policy will be ignored by the {fleet-server} integration. We
 strongly recommend using a load balancer to avoid coupling the {fleet-server} to the provided host.
 ====


### PR DESCRIPTION
Feedback from real users.

Due to the limitation https://github.com/elastic/elastic-agent/issues/2784 (https://support.elastic.co/knowledge/f69b6e46), Fleet Server still keeps using the Elasticsearch host provided at enroll time instead of using the one in the policy.

Elastic agent & Fleet are working on overcoming the limitation via https://github.com/elastic/fleet-server/issues/3464 but we should add a big warning message about this.

This message should be backported to all versions, at least until we'll introduce the enhancements to take into account the ES hosts coming from the policy.