### PR TITLE
Docs workflow test: Add 'queue.mem.datatype' setting

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-shared-settings.asciidoc
@@ -79,6 +79,18 @@ escaping.
 
 // =============================================================================
 
+// tag::queue.mem.datatype-setting[]
+|
+[id="{type}-queue.mem.datatype-setting"]
+`queue.mem.datatype`
+
+| (string) I am a pretend setting to illustrate workflow for a typical docs update.
+
+*Default:* `true!`
+// end::queue.mem.datatype-setting[]
+
+// =============================================================================
+
 // tag::worker-setting[]
 |
 [id="{type}-worker-setting"]

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -529,6 +529,10 @@ include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[
 
 // =============================================================================
 
+include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[tag=queue.mem.datatype-setting]
+
+// =============================================================================
+
 |===
 
 :type!:


### PR DESCRIPTION
This adds the pretend new Kafka output setting `queue.mem.datatype` to the Fleet and Agent Guide.
