### PR TITLE
Improve warning about using 'sudo' in agent unprivileged mode

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -31,8 +31,8 @@ elastic-agent install \
   --unprivileged
 ----
 
-IMPORTANT: On Linux systems, when you install {agent} using the `--unprivileged` flag, {agent} commands should not be run with `sudo`.
-Doing so may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
+IMPORTANT: On Linux systems, when you install {agent} using the `--unprivileged` flag, because the agent is in unprivileged mode, all {agent} commands that you run should not be prefixed with `sudo`.
+Including `sudo` in a command may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
 
 [discrete]
 [[unprivileged-command-behaviors]]


### PR DESCRIPTION
From the discussion in https://github.com/elastic/ingest-docs/issues/1197, the warning about `sudo`ing Elastic Agent commands when agent is running in `unprivileged` mode needs to be more clear.

Here's the updated version:

![Screenshot 2024-07-18 at 6 51 30 PM](https://github.com/user-attachments/assets/a899e317-e22c-42d4-871c-cde8538ef6f9)
