### PR TITLE
Fixes for 'unprivileged' agent docs

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -564,6 +564,7 @@ elastic-agent install --url <string>
                       [--help]
                       [--insecure ]
                       [--non-interactive]
+                      [--privileged]
                       [--proxy-disabled]
                       [--proxy-header <strings>]
                       [--proxy-url <string>]
@@ -607,6 +608,7 @@ elastic-agent install --fleet-server-es <string>
                       [--header <strings>]
                       [--help]
                       [--non-interactive]
+                      [--privileged]
                       [--proxy-disabled]
                       [--proxy-header <strings>]
                       [--proxy-url <string>]
@@ -760,6 +762,12 @@ We strongly recommend that you use a secure connection.
 Install {agent} in a non-interactive mode. This flag is helpful when
 using automation software or scripted deployments. If {agent} is
 already installed on the host, the installation will terminate.
+
+`--privileged`::
+Run {agent} with full superuser privileges.
+This is the usual, default running mode for {agent}.
+The `--privileged` option allows you to switch back to running an agent with full administrative privileges when you have been running it in `unprivileged`. 
+See the `--unprivileged` option and {fleet-guide}/elastic-agent-unprivileged.html[Run {agent} without administrative privileges] for more detail.
 
 `--proxy-disabled`::
 Disable proxy support including environment variables.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -31,8 +31,8 @@ elastic-agent install \
   --unprivileged
 ----
 
-IMPORTANT: On Linux systems, when you install {agent} using the `--unprivileged` flag, {agent} commands should not be run with `sudo`.
-Doing so may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
+IMPORTANT: On Linux systems, when you install {agent} using the `--unprivileged` flag, because the agent is in unprivileged mode, all {agent} commands that you run should not be prefixed with `sudo`.
+Including `sudo` in a command may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
 
 [discrete]
 [[unprivileged-command-behaviors]]
@@ -169,7 +169,23 @@ image::images/root-integration-and-unprivileged-agents.png[Agent policy tab show
 [[unprivileged-change-mode]]
 == Changing an {agent}'s privilege mode
 
-If an agent doesn't have the right level of privilege to read a data source, you can adjust the agent's privileges by adding `elastic-agent-user` to the user group that has privileges to read the data source.
+For any installed {agent} you can change the mode that it's running in by running the `privileged` or `unprivileged` subcommand.
+
+Change mode from privileged to unprivileged:
+
+[source,shell]
+----
+sudo elastic-agent unprivileged
+----
+
+Change mode from unprivileged to privileged:
+
+[source,shell]
+----
+sudo elastic-agent privileged
+----
+
+When an agent is running in `unprivileged` mode, if it doesn't have the right level of privilege to read a data source, you can also adjust the agent's privileges by adding `elastic-agent-user` to the user group that has privileges to read the data source.
 
 As background, when you run {agent} in `unprivileged` mode, one user and one group are created on the host. The same names are used for all operating systems:
 
@@ -181,4 +197,3 @@ For example:
 . When you install {agent} with the `--unprivileged` setting, the `elastic-agent-user` user and the `elastic-agent` group are created automatically.
 . If you then want your user `myuser` to be able to run an {agent} command such as `elastic-agent status`, add the `myuser` user to the `elastic-agent` group.
 . Then, once added to the group, the `elastic-agent status` command will work. Prior to that, the user `myuser` running the command will result in a permission error that indicates a problem communicating with the control socket.
-


### PR DESCRIPTION
This updates the [Run Elastic Agent without administrative privileges](https://www.elastic.co/guide/en/fleet/8.15/elastic-agent-unprivileged.html#unprivileged-view-mode) page based on suggestions in https://github.com/elastic/ingest-docs/issues/1197

---

1. Updates the warning about running commands in unprivileged mode to be more clear:

    ![Screenshot 2024-07-19 at 11 00 39 AM](https://github.com/user-attachments/assets/07e5763a-5d72-4d3f-a522-9d01a564865f)

---

2. Mention the `privileged` and `unprivileged` commands for changing an agent's running mode:

    ![Screenshot 2024-07-19 at 11 01 26 AM](https://github.com/user-attachments/assets/ed7b1c68-c652-4dc1-b653-1799961721a9)

---

3. Add the `--privileged` parameter to the Command reference. 
**Note:** I'm not sure that this is exactly right. Here, I've documented `--unprivileged` and `--privileged` as parameters of the `elastic agent install` command, but from https://github.com/elastic/elastic-agent/pull/4621 it seems that `privileged` and `unprivileged` are commands themselves rather than parameters. Can anyone confirm this?

     ![Screenshot 2024-07-19 at 11 06 33 AM](https://github.com/user-attachments/assets/836723fc-f211-4280-b17a-06588901c217)

---

Closes: #1199