### PR TITLE
Add `allow_older_versions` setting

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -309,9 +309,9 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
 [id="{type}-allow_older_versions-setting"]
 `allow_older_versions`
 
-| Allow {agent} to connect and send output to an {es} instance that is at a version lower than the agent.
+| Allow {agent} to connect and send output to an {es} instance that is at a version earlier than the agent version.
  
-Note that this setting does not affect {agent}'s ability to connect to {fleet-server}. {fleet-server} will not accept a connection from an agent at a higher major or minor version. It will accept a connection from an agent at a higher patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or higher is not able to connect.
+Note that this setting does not affect {agent}'s ability to connect to {fleet-server}. {fleet-server} will not accept a connection from an agent at a later major or minor version. It will accept a connection from an agent at a later patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or later is not able to connect.
 
 *Default:* `true`
 // end::allow_older_versions-setting[]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -311,7 +311,9 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
 
 | Allow {agent} to connect and send output to an {es} instance that is at a version earlier than the agent version.
  
-Note that this setting does not affect {agent}'s ability to connect to {fleet-server}. {fleet-server} will not accept a connection from an agent at a later major or minor version. It will accept a connection from an agent at a later patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or later is not able to connect.
+Note that this setting does not affect {agent}'s ability to connect to {fleet-server}.
+{fleet-server} will not accept a connection from an agent at a later major or minor version.
+It will accept a connection from an agent at a later patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or later is not able to connect.
 
 *Default:* `true`
 // end::allow_older_versions-setting[]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -51,6 +51,8 @@ category. Many of these settings have sensible defaults that allow you to run
 
 * <<output-elasticsearch-authentication-settings>>
 
+* <<output-elasticsearch-compatibility-setting>>
+
 * <<output-elasticsearch-data-parsing-settings>>
 
 * <<output-elasticsearch-http-settings>>
@@ -294,6 +296,27 @@ options. Based on this configuration, the name would be:
 `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`
 
 include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-settings]
+
+[[output-elasticsearch-compatibility-setting]]
+=== Compatibility setting
+
+[cols="2*<a"]
+|===
+| Setting | Description
+
+// tag::allow_older_versions-setting[]
+|
+[id="{type}-allow_older_versions-setting"]
+`allow_older_versions`
+
+| Allow {agent} to connect and send output to an {es} instance that is at a version lower than the agent.
+
+*Default:* `true`
+// end::allow_older_versions-setting[]
+
+// =============================================================================
+
+|===
 
 [[output-elasticsearch-data-parsing-settings]]
 === Data parsing, filtering, and manipulation settings

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -313,7 +313,8 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
  
 Note that this setting does not affect {agent}'s ability to connect to {fleet-server}.
 {fleet-server} will not accept a connection from an agent at a later major or minor version.
-It will accept a connection from an agent at a later patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or later is not able to connect.
+It will accept a connection from an agent at a later patch version.
+For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or later is not able to connect.
 
 *Default:* `true`
 // end::allow_older_versions-setting[]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -309,7 +309,7 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
 [id="{type}-allow_older_versions-setting"]
 `allow_older_versions`
 
-| Allow {agent} to connect and send output to an {es} instance that is at a version earlier than the agent version.
+| Allow {agent} to connect and send output to an {es} instance that is running an earlier version than the agent version.
  
 Note that this setting does not affect {agent}'s ability to connect to {fleet-server}.
 {fleet-server} will not accept a connection from an agent at a later major or minor version.

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -310,6 +310,8 @@ include::../authentication/kerberos-shared-settings.asciidoc[tag=kerberos-all-se
 `allow_older_versions`
 
 | Allow {agent} to connect and send output to an {es} instance that is at a version lower than the agent.
+ 
+Note that this setting does not affect {agent}'s ability to connect to {fleet-server}. {fleet-server} will not accept a connection from an agent at a higher major or minor version. It will accept a connection from an agent at a higher patch version. For example, an {agent} at version 8.14.3 can connect to a {fleet-server} on version 8.14.0, but an agent at version 8.15.0 or higher is not able to connect.
 
 *Default:* `true`
 // end::allow_older_versions-setting[]

--- a/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-elasticsearch.asciidoc
@@ -123,6 +123,10 @@ When you create an {agent} policy using this output, the output will use the bal
 |===
 | Setting | Description
 
+include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=allow_older_versions-setting]
+
+// =============================================================================
+
 include::../elastic-agent/configuration/outputs/output-elasticsearch.asciidoc[tag=backoff.init-setting]
 
 // =============================================================================


### PR DESCRIPTION
This updates the Fleet & Agent docs with the `allow_older_version` setting that was added via https://github.com/elastic/beats/pull/36884

Closes: https://github.com/elastic/ingest-docs/issues/1135
Related Beats docs PR: https://github.com/elastic/beats/pull/40338

---

Fleet settings -> Elasticsearch output settings -> [Advanced YAML configuration](https://www.elastic.co/guide/en/fleet/current/es-output-settings.html#es-output-settings-yaml-config)

Configure standalone Elastic Agent -> Outputs -> [Elasticsearch](https://www.elastic.co/guide/en/fleet/current/elasticsearch-output.html)