### PR TITLE
Add restriction about traffic filters with remote ES output

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
@@ -7,6 +7,8 @@ Beginning in version 8.12.0, you can send {agent} data to a remote {es} cluster.
 
 A remote {es} cluster supports the same <<es-output-settings,output settings>> as your main {es} cluster.
 
+NOTE: Using a remote {es} output with a target cluster that has {cloud}/ec-traffic-filtering-deployment-configuration.html[traffic filters] enabled is not currently supported.
+
 To configure a remote {es} cluster for your {agent} data:
 
 . In {fleet}, open the **Settings** tab.


### PR DESCRIPTION
This adds the following restriction:

![Screenshot 2024-07-26 at 11 24 30 AM](https://github.com/user-attachments/assets/361e34b3-f737-4025-a60c-f136012c5212)

---

The link points to the main [traffic filtering](https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-deployment-configuration.html) page in the Cloud docs.

Closes: #1206