### PR TITLE
Add Fleet & Agent 7.17.23 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.23>>
+
 * <<release-notes-7.17.22>>
 
 * <<release-notes-7.17.21>>
@@ -64,6 +66,22 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.23 relnotes
+
+[[release-notes-7.17.23]]
+== {fleet} and {agent} 7.17.23
+
+Review important information about the {fleet} and {agent} 7.17.23 release.
+
+[discrete]
+[[security-updates-7.17.23]]
+=== Security updates
+
+{fleet-server}::
+* Update {fleet-server} Go version to 1.21.11. {fleet-server-pull}3607[#3607]
+
+// end 7.17.23 relnotes
 
 // begin 7.17.22 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -5,8 +5,8 @@
 :beats-pull: https://github.com/elastic/beats/pull/
 :agent-issue: https://github.com/elastic/elastic-agent/issues/
 :agent-pull: https://github.com/elastic/elastic-agent/pull/
-:fleet-server-issue: https://github.com/elastic/beats/issues/fleet-server/
-:fleet-server-pull: https://github.com/elastic/beats/pull/fleet-server/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
 
 
 [[release-notes]]
@@ -104,7 +104,7 @@ Review important information about the {fleet} and {agent} 7.17.22 release.
 [[release-notes-7.17.21]]
 == {fleet} and {agent} 7.17.21
 
-The <<known-issue-3435,known issue>> introduced in version 7.17.20, that was causing {fleet-server} to fail to bootstrap with self-signed certificates, is resolved in this release. {fleet-server-pull}13473[#3473]  
+The <<known-issue-3435,known issue>> introduced in version 7.17.20, that was causing {fleet-server} to fail to bootstrap with self-signed certificates, is resolved in this release. {fleet-server-pull}3473[#3473]  
 
 // end 7.17.21 relnotes
 


### PR DESCRIPTION
This adds the 7.17.23 Fleet & Agent Release Notes:

 - Fleet: No entries in [Kibana RN PR](https://github.com/elastic/kibana/pull/189448)
 - Fleet Server: one entry in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/c8e0858bb3effb4bf78c29aba657cb98b0c2f3e3/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/bd0ffc1af3bb6c6b0b61e4324f8d9e905b60b45a/changelog/fragments) nor in [agent package BC1 changelog](https://github.com/elastic/elastic-agent/tree/132893e0e79f7378a0dd63a8266a3d01c82303f4/changelog/fragments)

This also fixes the variable used to link to Fleet Server issues and PRs.

---

![Screenshot 2024-07-26 at 12 09 35 PM](https://github.com/user-attachments/assets/bd5081b7-340c-4e1d-a793-e67b6d2c13a1)

