### PR TITLE
Update air-gapped install docs wrt ARM64

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -95,9 +95,12 @@ the {stack}. The {package-registry} API exposes a {kib} version constraint that
 allows for filtering packages that are compatible with a particular version.
 
 // lint ignore runtimes
-NOTE: These steps use the standard Docker CLI, but you can create a Kubernetes manifest
-based on this information.
+[NOTE]
+====
+* These steps use the standard Docker CLI, but you can create a Kubernetes manifest based on this information.
 These images can also be used with other container runtimes compatible with Docker images.
+* Currently, distribution Docker images are available only for AMD64 platforms. ARM64 images are not yet supported.
+====
 
 1. Pull the Docker image from the public Docker registry:
 +


### PR DESCRIPTION
Apparently ARM64 images aren't available for air-gapped installs. This adds a note to that effect on the [Air-gapped environments](https://www.elastic.co/guide/en/fleet/current/air-gapped.html#air-gapped-diy-epr) page.

@cmacknz  I'm just going by what was reported in Slack, but please let me know if that's not correct.

---

![Screenshot 2024-07-29 at 2 14 30 PM](https://github.com/user-attachments/assets/499da002-84b8-42d1-a9dd-228b1e6a627d)

