### PR TITLE
[DOCS] Clarify cadence of updates to EPR image

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -78,7 +78,8 @@ There are different distributions available:
 * lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
 * production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). 
 Please note that this image is updated every time a new version of a package gets published.
-* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). Please note that this image is updated every time a new version of a package gets published.
+* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). 
+Please note that this image is updated every time a new version of a package gets published.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -76,7 +76,8 @@ There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with {stack} {version}.
 * lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
-* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). Please note that this image is updated every time a new version of a package gets published.
+* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). 
+Please note that this image is updated every time a new version of a package gets published.
 * lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). Please note that this image is updated every time a new version of a package gets published.
 
 ifeval::["{release-state}"=="unreleased"]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -76,8 +76,8 @@ There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with {stack} {version}.
 * lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
-* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). Please note this image is updated every time a new version of a package gets published.
-* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). Please note this image is updated every time a new version of a package gets published.
+* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). Please note that this image is updated every time a new version of a package gets published.
+* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). Please note that this image is updated every time a new version of a package gets published.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -76,8 +76,8 @@ There are different distributions available:
 
 * {version} (recommended): +docker.elastic.co/package-registry/distribution:{version}+ - Selection of packages from the production repository released with {stack} {version}.
 * lite-{version}: +docker.elastic.co/package-registry/distribution:lite-{version}+ - Subset of the most commonly used packages from the production repository released with {stack} {version}. This image is a good candidate to start using {fleet} in air-gapped environments.
-* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co).
-* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co).
+* production: `docker.elastic.co/package-registry/distribution:production` - Packages available in the production registry (https://epr.elastic.co). Please note this image is updated every time a new version of a package gets published.
+* lite: `docker.elastic.co/package-registry/distribution:lite` - Subset of the most commonly used packages available in the production registry (https://epr.elastic.co). Please note this image is updated every time a new version of a package gets published.
 
 ifeval::["{release-state}"=="unreleased"]
 [WARNING]


### PR DESCRIPTION
As stated by @mrodm, we update the docker images every time a new version of a package gets published.

It's important to highlight this detail for users in air-gapped envs.

This should be backported to any version.