### PR TITLE
Remove warning about Fleet Server using ES host at install/enroll time

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -212,9 +212,6 @@ token for each {fleet-server}. For other ways to generate service tokens, refer 
 `--fleet-server-port` options in the `elastic-agent install` command. Refer to the 
 {fleet-guide}/elastic-agent-cmd-options.html#elastic-agent-install-command[install command documentation]
 for details.
-* Please note that {fleet-server} will keep using the {es} host provided via `--fleet-server-host` at install time. 
-The {es} hosts configured in the associated policy will be ignored by the {fleet-server} integration. 
-We strongly recommend using a load balancer to avoid coupling the {fleet-server} to the provided host.
 ====
 +
 At the *Install Fleet Server to a centralized host* step, 


### PR DESCRIPTION
As suggested by Luca [here](https://github.com/elastic/ingest-docs/pull/1186#issuecomment-2265103140), since https://github.com/elastic/fleet-server/issues/3464 has merged, this removes the following warning from the [Fleet Server on-prem](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-on-prem.html) install docs:


![Screenshot 2024-08-02 at 9 46 08 AM](https://github.com/user-attachments/assets/5505f7de-3028-4200-9b0a-11f7b551e880)
