### PR TITLE
Add technical preview tag for agent unprivileged mode

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -1,6 +1,8 @@
 [[elastic-agent-unprivileged]]
 = Run {agent} without administrative privileges
 
+preview::[]
+
 Beginning with {stack} version 8.15, {agent} is no longer required to be run by a user with superuser privileges. You can now run agents in an `unprivileged` mode that does not require `root` access on Linux or macOS, or `admin` access on Windows. Being able to run agents without full administrative privileges is often a requirement in organizations where this kind of access is often very limited.
 
 In general, agents running without full administrative privileges will perform and behave exactly as those run by a superuser. There are certain integrations and datastreams that are not available, however. If an integration requires root access, this is <<unprivileged-integrations,indicated on the integration main page>>.


### PR DESCRIPTION
This adds a "technical preview" marker to the docs about [running Elastic Agent in unprivileged mode](http://localhost:8000/guide/elastic-agent-unprivileged.html).


![Screenshot 2024-08-09 at 9 53 51 AM](https://github.com/user-attachments/assets/3d034d19-1790-4422-900d-977ca2ce554a)
