### PR TITLE
Add note to 'unprivleged' agent docs about elastic-agent-user

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -28,14 +28,14 @@ invoking the wrong binary.
 * <<elastic-agent-help-command,help>>
 * <<elastic-agent-inspect-command,inspect>>
 * <<elastic-agent-install-command,install>>
-* <<elastic-agent-privileged-command,privileged>>
+* <<elastic-agent-privileged-command,privileged>> [technical preview]
 * <<elastic-agent-restart-command,restart>>
 * <<elastic-agent-run-command,run>>
 * <<elastic-agent-status-command,status>>
 * <<elastic-agent-uninstall-command,uninstall>>
 * <<elastic-agent-upgrade-command,upgrade>>
 * <<elastic-agent-logs-command,logs>>
-* <<elastic-agent-unprivileged-command,unprivileged>>
+* <<elastic-agent-unprivileged-command,unprivileged>> [technical preview]
 * <<elastic-agent-version-command,version>>
 //* <<elastic-agent-watch-command,watch>>
 
@@ -526,6 +526,8 @@ elastic-agent inspect components log-default
 [discrete]
 [[elastic-agent-privileged-command]]
 == elastic-agent privileged
+
+preview::[]
 
 Run {agent} with full superuser privileges.
 This is the usual, default running mode for {agent}.
@@ -1101,6 +1103,8 @@ elastic-agent uninstall
 [discrete]
 [[elastic-agent-unprivileged-command]]
 == elastic-agent unprivileged
+
+preview::[]
 
 Run {agent} without full superuser privileges.
 This is useful in organizations that limit `root` access on Linux or macOS systems, or `admin` access on Windows systems.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -33,9 +33,16 @@ elastic-agent install \
   --unprivileged
 ----
 
-IMPORTANT: On Linux systems, once {agent} has been installed with the `--unprivileged` flag, all {agent} commands that you run should not be prefixed with `sudo`.
+[IMPORTANT] 
+====
+Note the following current restrictions for running {agent} in `unprivileged` mode:
+
+* On Linux systems, once {agent} has been installed with the `--unprivileged` flag, all {agent} commands that you run should not be prefixed with `sudo`.
 Including `sudo` in a command may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
-The `sudo` option is still required for the `elastic-agent install` command.
+* The `sudo` option is still required for the `elastic-agent install` command.
+* Currently, when you run some {agent} commands as non-root, for example, `elastic-agent inspect`, you may need to prefix the command with `sudo -u elastic-agent-user elastic-agent`.
+For example, `sudo -u elastic-agent-user elastic-agent inspect`.
+====
 
 [discrete]
 [[unprivileged-command-behaviors]]

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -37,11 +37,20 @@ elastic-agent install \
 ====
 Note the following current restrictions for running {agent} in `unprivileged` mode:
 
-* On Linux systems, once {agent} has been installed with the `--unprivileged` flag, all {agent} commands that you run should not be prefixed with `sudo`.
-Including `sudo` in a command may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
-* The `sudo` option is still required for the `elastic-agent install` command.
-* Currently, when you run some {agent} commands as non-root, for example, `elastic-agent inspect`, you may need to prefix the command with `sudo -u elastic-agent-user elastic-agent`.
-For example, `sudo -u elastic-agent-user elastic-agent inspect`.
+* On Linux systems, after {agent} has been installed with the `--unprivileged` flag, all {agent} commands can be run without being the root user.
+** The `sudo` option is still required for the `elastic-agent install` command.
+Only `root` can install new services.
+The installed service will not run as the root user.
+* Using `sudo` without specifying an alternate non-root user with `sudo -u` in a command may result in <<agent-sudo-error,an error>> due to the agent not having the required privileges.
+* Using `sudo -u elastic-agent-user` will run commands as the user running the {agent} service and will always work.
+* For files that allow users in the `elastic-agent` group access, using an alternate user that has been added to that group will also work.
+There are still some commands that are only accessible to the `elastic-agent-user` that runs the service.
+** For example, `elastic-agent inspect` requires you to prefix the command with `sudo -u elastic-agent-user`.
++
+[source,shell]
+----
+sudo -u elastic-agent-user elastic-agent inspect
+----
 ====
 
 [discrete]


### PR DESCRIPTION
From a discussion in Slack, some commands when run in unprivleged mode require a `sudo -u elastic-agent-user` prefix. 

See [Knowledge Base article](https://support.elastic.dev/knowledge/view/1d161cf8) for reference.

![screen](https://github.com/user-attachments/assets/00aa9b57-b44c-420c-a3ae-a323f112eb32)


---

ADD: This also updates the command reference to mark the `elastic-agent privileged` and `elastic-agent unprivileged` as in technical preview mode, since I forgot to do that in https://github.com/elastic/ingest-docs/pull/1244