### PR TITLE
Add docs for agent 'otel' mode

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -902,7 +902,6 @@ Run {agent} as an <<otel-agent,OpenTelemetry Collector>>.
 ----
 elastic-agent otel [flags]
 elastic-agent otel [command]
-kilfoyle marked this conversation as resolved.
 ----
 
 NOTE: You can also run the `./otelcol` command, which calls `./elastic-agent otel` and passes any arguments to it.

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -28,6 +28,7 @@ invoking the wrong binary.
 * <<elastic-agent-help-command,help>>
 * <<elastic-agent-inspect-command,inspect>>
 * <<elastic-agent-install-command,install>>
+* <<elastic-agent-otel-command,otel>> [technical preview]
 * <<elastic-agent-privileged-command,privileged>>
 * <<elastic-agent-restart-command,restart>>
 * <<elastic-agent-run-command,run>>
@@ -878,6 +879,67 @@ the previous example:
 elastic-agent install --url=https://fleet-server:8220 \
   --enrollment-token=NEFmVllaa0JLRXhKebVKVTR5TTI6N2JaVlJpSGpScmV0ZUVnZVlRUExFQQ== \
   --certificate-authorities=/path/to/ca.crt
+----
+
+++++
+<hr>
+++++
+
+[discrete]
+[[elastic-agent-otel-command]]
+== elastic-agent otel
+
+preview::[]
+
+Run {agent} as an <<otel-agent,OpenTelemetry Collector>>. 
+
+[discrete]
+=== Synopsis
+
+[source,shell]
+----
+elastic-agent otel [flags]
+elastic-agent otel [command]
+kilfoyle marked this conversation as resolved.
+----
+
+NOTE: You can also run the `./otelcol` command, which calls `./elastic-agent otel` and passes any arguments to it.
+
+[discrete]
+=== Available commands
+
+`validate`::
+Validates the OpenTelemetry collector configuration without running the collector.
+
+[discrete]
+=== Flags
+
+`--config=file:/path/to/first --config=file:path/to/second`::
+Locations to the config file(s). Note that only a single location can be set per flag entry, for example `--config=file:/path/to/first --config=file:path/to/second`.
+
+`--feature-gates flag`::
+Comma-delimited list of feature gate identifiers. Prefix with `-` to disable the feature. Prefixing with `+` or no prefix will enable the feature.
+
+`-h, --help`::
+Get help for the `otel` sub-command. Use `elastic-agent otel [command] --help` for more information about a command.
+
+`--set string`::
+Set an arbitrary component config property. The component has to be defined in the configuration file and the flag has a higher precedence. Array configuration properties are overridden and maps are joined. For example, `--set=processors::batch::timeout=2s`.
+
+[discrete]
+=== Examples
+
+Run {agent} as on OTel Collector using the supplied `otel.yml` configuration file.
+[source,shell]
+----
+./elastic-agent otel --config otel.yml
+----
+
+Change the default verbosity setting in the {agent} OTel configuration from `detailed` to `normal`.
+
+[source,shell]
+----
+./elastic-agent otel --config otel.yml --set "exporters::debug::verbosity=normal"
 ----
 
 ++++

--- a/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
@@ -7,4 +7,4 @@ The link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector] is a 
 
 When you run {agent} in `otel` mode it supports the standard OTel Collector configuration format that defines a set of receivers, processors, exporters, and connectors. Logs, metrics, and traces can be ingested using OpenTelemetry data formats.
 
-For a full overview and steps to configure {agent} in `otel` mode, including a guided onboarding, refer to the link:https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions for OpenTelemetry] repository in GitHub. You can also check the <<elastic-agent-otel-command,`elastic-agent otel`>> in the {fleet} and {agent} Command reference.
+For a full overview and steps to configure {agent} in `otel` mode, including a guided onboarding, refer to the link:https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions for OpenTelemetry] repository in GitHub. You can also check the <<elastic-agent-otel-command,`elastic-agent otel` command>> in the {fleet} and {agent} Command reference.

--- a/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
@@ -1,0 +1,10 @@
+[[otel-agent]]
+= Run {agent} as an OTel Collector
+
+preview::[]
+
+The link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector] is a vendor-neutral way to receive, process, and export telemetry data. {agent} includes an embedded OTel Collector, enabling you to instrument your applications and infrastructure once, and send data to multiple vendors and backends. 
+
+When you run {agent} in `otel` mode it supports the standard OTel Collector configuration format that defines a set of receivers, processors, exporters, and connectors. Logs, metrics, and traces can be ingested using OpenTelemetry data formats.
+
+For a full overview and steps to configure {agent} in `otel` mode, including a guided onboarding, refer to the link:https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions for OpenTelemetry] repository in GitHub. You can also check the <<elastic-agent-otel-command,`elastic-agent otel`>> in the {fleet} and {agent} Command reference.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -63,6 +63,8 @@ include::elastic-agent/ingest-pipeline-kubernetes.asciidoc[leveloffset=+3]
 
 include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]
 
+include::elastic-agent/otel-agent.asciidoc[leveloffset=+2]
+
 include::elastic-agent/elastic-agent-unprivileged-mode.asciidoc[leveloffset=+2]
 
 include::elastic-agent/install-agent-msi.asciidoc[leveloffset=+2]


### PR DESCRIPTION
This is a redo of https://github.com/elastic/ingest-docs/pull/1095 reducing the docs that we include in the Fleet & Elastic Agent Guide. Full docs for running Elastic Agent as an OTel collector can be found in the [elastic/opentelemetry repo](https://github.com/elastic/opentelemetry/tree/main).

This updates the F&A Guide with:
 - A brief intro: [Run Elastic Agent as an OTel Collector](https://ingest-docs_bk_1250.docs-preview.app.elstc.co/guide/en/fleet/master/otel-agent.html)
 - The [`elastic-agent otel` command](https://ingest-docs_bk_1250.docs-preview.app.elstc.co/guide/en/fleet/master/elastic-agent-cmd-options.html#elastic-agent-otel-command)

FYI @ycombinator & @strawgate 