### PR TITLE
[DOCS] Warn about sensible information in Elastic Agent diagnostic

### DIFF
--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -415,6 +415,8 @@ Run the following command to generate a zip archive containing diagnostics infor
 elastic-agent diagnostics
 ----
 
+If you want to omit the raw events from the diagnostic, add the flag `--exclude-events`.
+
 **Get the diagnostics bundle through {fleet}**
 
 {fleet} provides the ability to remotely generate and gather an {agent}'s diagnostics bundle.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -405,6 +405,7 @@ Please review the contents of the archive before sharing to ensure that there ar
 IMPORTANT: The zip archive containing diagnostics information will contain the raw events of documents sent to the output. By default, it will log only the failing events as `warn`.
 When enabling `debug` logging level, it will log all the events. 
 Please review the contents of the archive before sharing to ensure that there is no sensible information in them.
+
 **Get the diagnostics bundle using the CLI**
 
 Run the following command to generate a zip archive containing diagnostics information that the Elastic team can use for debugging cases.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -402,6 +402,10 @@ Note that the diagnostics bundle is intended for debugging purposes only, its st
 IMPORTANT: {agent} attempts to automatically redact credentials and API keys when creating diagnostics. 
 Please review the contents of the archive before sharing to ensure that there are no credentials in plain text.
 
+IMPORTANT: When enabling `debug` logging level, the zip archive containing diagnostics information will also contain
+the raw events of documents sent to the output. Please review the contents of the archive before sharing to ensure
+that there is no sensible information in them.
+
 **Get the diagnostics bundle using the CLI**
 
 Run the following command to generate a zip archive containing diagnostics information that the Elastic team can use for debugging cases.

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -402,9 +402,10 @@ Note that the diagnostics bundle is intended for debugging purposes only, its st
 IMPORTANT: {agent} attempts to automatically redact credentials and API keys when creating diagnostics. 
 Please review the contents of the archive before sharing to ensure that there are no credentials in plain text.
 
-IMPORTANT: The zip archive containing diagnostics information will contain the raw events of documents sent to the output. By default, it will log only the failing events as `warn`.
-When enabling `debug` logging level, it will log all the events. 
-Please review the contents of the archive before sharing to ensure that there is no sensible information in them.
+IMPORTANT: The ZIP archive containing diagnostics information will include the raw events of documents sent to the {agent} output.
+By default, it will log only the failing events as `warn`.
+When the `debug` logging level is enabled, all events are logged.
+Please review the contents of the archive before sharing to ensure that no sensitive information is included.
 
 **Get the diagnostics bundle using the CLI**
 

--- a/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting/troubleshooting.asciidoc
@@ -402,10 +402,9 @@ Note that the diagnostics bundle is intended for debugging purposes only, its st
 IMPORTANT: {agent} attempts to automatically redact credentials and API keys when creating diagnostics. 
 Please review the contents of the archive before sharing to ensure that there are no credentials in plain text.
 
-IMPORTANT: When enabling `debug` logging level, the zip archive containing diagnostics information will also contain
-the raw events of documents sent to the output. Please review the contents of the archive before sharing to ensure
-that there is no sensible information in them.
-
+IMPORTANT: The zip archive containing diagnostics information will contain the raw events of documents sent to the output. By default, it will log only the failing events as `warn`.
+When enabling `debug` logging level, it will log all the events. 
+Please review the contents of the archive before sharing to ensure that there is no sensible information in them.
 **Get the diagnostics bundle using the CLI**
 
 Run the following command to generate a zip archive containing diagnostics information that the Elastic team can use for debugging cases.


### PR DESCRIPTION
Following https://github.com/elastic/beats/pull/38767, let's warn of raw data being collected by the Elastic Agent diagnostic bundle.