### PR TITLE
Add docs for agent unenrollment timeout setting

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -527,7 +527,8 @@ Select the name of the policy you want to edit.
 
 . Save your changes.
 
-Once an unenrollment timeout is set, any inactive agents are unenrolled automatically after the specified period of time. The unenroll task runs every ten minutes, and it will unenroll a maximum of one thousand agents at a time.
+After you set an unenrollment timeout, any inactive agents are unenrolled automatically after the specified period of time. 
+The unenroll task runs every ten minutes, and it unenrolls a maximum of one thousand agents at a time.
 
 [discrete]
 [[agent-policy-scale]]

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -513,7 +513,7 @@ If neither pre-requisite is satisfied, `host.name` continues to report the hostn
 == Set an unenrollment timeout for inactive agents
 
 You can configure a length of time after which any inactive {agent}s are automatically unenrolled and their API keys invalidated.
-This setting is useful when you have agents running in an ephemeral environment, such as Docker or Kubernetes, and you want to prevent inactive agents from consuming unused API keys.
+This setting is useful when you have agents running in an ephemeral environment, such as Docker or {k8s}, and you want to prevent inactive agents from consuming unused API keys.
 
 
 To configure an unenrollment timeout for inactive agents:

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -131,6 +131,11 @@ The following table illustrates the {fleet} user actions available to different 
 |<<fleet-agent-hostname-format-settings>>
 |{y}
 |{n}
+
+|<<fleet-agent-unenrollment-timeout>>
+|{y}
+|{n}
+
 |===
 
 See also the <<agent-policy-scale,recommended scaling options>> for an {agent} policy.
@@ -501,6 +506,28 @@ For FQDN reporting to work as expected, the hostname of the current host must ei
 * Have one of its corresponding IP addresses respond successfully to a reverse DNS lookup.
 
 If neither pre-requisite is satisfied, `host.name` continues to report the hostname of the current host in a non-fully-qualified format.
+
+
+[discrete]
+[[fleet-agent-unenrollment-timeout]]
+== Set an unenrollment timeout for inactive agents
+
+You can configure a length of time after which any inactive {agent}s are automatically unenrolled and their API keys invalidated.
+This setting is useful when you have agents running in an ephemeral environment, such as Docker or Kubernetes, and you want to prevent inactive agents from consuming unused API keys.
+
+
+To configure an unenrollment timeout for inactive agents:
+
+. In {fleet}, click **Agent policies**.
+Select the name of the policy you want to edit.
+
+. Click the **Settings** tab and scroll to **Inactive agent unenrollment timeout**.
+
+. Specify an unenrollment timeout period in seconds.
+
+. Save your changes.
+
+Once an unenrollment timeout is set, any inactive agents are unenrolled automatically after the specified period of time. The unenroll task runs every ten minutes, and it will unenroll a maximum of one thousand agents at a time.
 
 [discrete]
 [[agent-policy-scale]]


### PR DESCRIPTION
This updates the [Elastic Agent policies page](http://localhost:8000/guide/agent-policy.html) with the new unenrollment timeout setting added via https://github.com/elastic/kibana/pull/189861

Target: 8.16
Closes: https://github.com/elastic/ingest-docs/issues/1225

Welcome back @criamico! Please let me know if I've missed anything.

Preview
---

![Screenshot 2024-08-15 at 3 15 53 PM](https://github.com/user-attachments/assets/8498f186-b820-4d1b-aaa4-cbd6500eb71c)
