### PR TITLE
Update docs for reusable integrations policies

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -166,7 +166,7 @@ To add a new integration to one or more {agent} policies:
 
 . In {fleet}, click **Agent policies**.
 Click the name of a policy you want to add an integration to.
-. Click **Add <Integration>**.
+. Click **Add <integration>**.
 . The Integrations page shows {agent} integrations along with other types, such as {beats}. Scroll down and select **Elastic Agent only** to view only integrations that work with {agent}.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
 . In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -169,7 +169,7 @@ Click the name of a policy you want to add an integration to.
 . Click **Add <integration>**.
 . The Integrations page shows {agent} integrations along with other types, such as {beats}. Scroll down and select **Elastic Agent only** to view only integrations that work with {agent}.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
-. In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.
+. In Step 1 on the **Add <integration>** page, you can select the configuration settings specific to the integration.
 . In Step 2 on the page, you have two options:
 .. If you'd like to create a new policy for your {agent}s, on the **New hosts** tab specify a name for the new agent policy and choose whether or not to collect system logs and metrics.
 Collecting logs and metrics will add the System integration to the new agent policy.

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -147,12 +147,9 @@ See also the <<agent-policy-scale,recommended scaling options>> for an {agent} p
 To manage your {agent}s and the data they collect, create a new policy:
 
 In {fleet}, open the **Agent policies** tab and click **Create agent policy**.
+
 . Name your policy. All other fields are optional and can be modified later.
 By default, each policy enables the _system_ integration, which collects system information and metrics.
-+
-[role="screenshot"]
-image::images/create-agent-policy.png[{fleet} in {kib}]
-+
 . Create the agent policy:
 * To use the UI, click **Create agent policy**.
 * To use the {fleet} API, click **Preview API request** and run the
@@ -168,9 +165,9 @@ An {agent} policy consists of one or more integrations that are applied to the a
 To add a new integration to one or more {agent} policies:
 
 . In {fleet}, click **Agent policies**.
-Click the name of the policy you want to add an integration to.
-
+Click the name of a policy you want to add an integration to.
 . Click **Add <Integration>**.
+. The Integrations page shows {agent} integrations along with other types, such as {beats}. Scroll down and select **Elastic Agent only** to view only integrations that work with {agent}.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
 . In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.
 . In Step 2 on the page, you have two options:
@@ -179,8 +176,14 @@ Collecting logs and metrics will add the System integration to the new agent pol
 .. If you already have an {agent} policy created, on the **Existing hosts** tab use the drop-down menu to specify one or more agent policies that you'd like to add the integration to.
 . Click **Save and continue** to confirm your settings.
 
-This action installs the integration (if it's not already installed) and adds it to the {agent} policies that you specified. 
+This action installs the integration and adds it to the {agent} policies that you specified. 
 {fleet} distributes the new integration policy to all {agent}s that are enrolled in the agent policies.
+
+You can update the settings for an installed integration at any time:
+
+. In {kib}, go to the **Integrations** page.
+. On the **Integration policies** tab, for the integration that you like to update open the **Actions** menu and select **Edit integration**.
+. On the **Edit <integration>** page you can update any configuration settings and also update the list of {agent} polices to which the integration is added.
 
 [discrete]
 [[apply-a-policy]]

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -164,36 +164,23 @@ Also see <<create-a-policy-no-ui>>.
 [[add-integration]]
 == Add an integration to a policy
 
-Policies consist of one or more integrations.
-To add a new integration to a policy:
+An {agent} policy consists of one or more integrations that are applied to the agents enrolled in that policy.
+To add a new integration to one or more {agent} policies:
 
 . In {fleet}, click **Agent policies**.
 Click the name of the policy you want to add an integration to.
 
-. Click **Add integration**.
+. Click **Add <Integration>**.
+. You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
+. In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.
+. In Step 2 on the page, you have two options:
+.. If you'd like to create a new policy for your {agent}s, on the **New hosts** tab specify a name for the new agent policy and choose whether or not to collect system logs and metrics.
+Collecting logs and metrics will add the System integration to the new agent policy.
+.. If you already have an {agent} policy created, on the **Existing hosts** tab use the drop-down menu to specify one or more agent policies that you'd like to add the integration to.
+. Click **Save and continue** to confirm your settings.
 
-. Search for and select an integration. You can select a category to narrow your search.
-
-. Click **Add <Integration>**.
-
-. Name the integration and add any required configuration variables.
-+
-NOTE: Integration policy names must be globally unique across all agent
-policies.
-
-. Save the integration policy as part of the larger {agent} policy:
-+
---
-* To use the UI, click **Save and continue**.
-* To use the {fleet} API, click **Preview API request** and run the
-request.
---
-
-{fleet} distributes this new policy to all {agent}s that are enrolled in the
-{agent} policy.
-
-After the policy has finished applying, the selected integration will be running on the host
-and communicating with the {agent}.
+This action installs the integration (if it's not already installed) and adds it to the {agent} policies that you specified. 
+{fleet} distributes the new integration policy to all {agent}s that are enrolled in the agent policies.
 
 [discrete]
 [[apply-a-policy]]

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -1,23 +1,15 @@
 [[add-integration-to-policy]]
-= Add an {agent} integration to one or more {agent} policies
+= Add an integration to an {agent} policy
 
 ++++
-<titleabbrev>Add an integration to one or more policies</titleabbrev>
+<titleabbrev>Add an integration to an {agent} policy</titleabbrev>
 ++++
 
-An {agent} policy consists of one or more integrations that are applied to the agents enrolled in that policy.
+An <<agent-policy,{agent} policy>> consists of one or more integrations that are applied to the agents enrolled in that policy.
 To add a new integration to one or more {agent} policies:
 
 . In {kib}, go to the **Integrations** page.
-+
-Notice that the Integrations page shows {agent} integrations along with other
-types, such as {beats}.
-// lint ignore elastic-agent
-. Scroll down and select **Elastic Agent only** so the view shows
-integrations that work with {agent}.
-+
-[role="screenshot"]
-image::images/unified-view-selector.png[Screen capture showing options for filtering the view]
+. The Integrations page shows {agent} integrations along with other types, such as {beats}. Scroll down and select **Elastic Agent only** to view only integrations that work with {agent}.
 . Search for and select an integration. You can select a category to narrow your search.
 . Click **Add <Integration>**.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -1,12 +1,12 @@
 [[add-integration-to-policy]]
-= Add an {agent} integration to a policy
+= Add an {agent} integration to one or more {agent} policies
 
 ++++
-<titleabbrev>Add an integration to a policy</titleabbrev>
+<titleabbrev>Add an integration to one or more policies</titleabbrev>
 ++++
 
-Policies consist of one or more integrations. To add a new integration to a
-policy:
+An {agent} policy consists of one or more integrations that are applied to the agents enrolled in that policy.
+To add a new integration to one or more {agent} policies:
 
 . In {kib}, go to the **Integrations** page.
 +
@@ -20,26 +20,22 @@ integrations that work with {agent}.
 image::images/unified-view-selector.png[Screen capture showing options for filtering the view]
 . Search for and select an integration. You can select a category to narrow your search.
 . Click **Add <Integration>**.
-. Name the integration and add any required configuration variables.
-+
-NOTE: Integration policy names must be globally unique across all agent
-policies.
+. You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
+. In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.
+. In Step 2 on the page, you have two options:
+.. If you'd like to create a new policy for your {agent}s, on the **New hosts** tab specify a name for the new agent policy and choose whether or not to collect system logs and metrics.
+Collecting logs and metrics will add the System integration to the new agent policy.
+.. If you already have an {agent} policy created, on the **Existing hosts** tab use the drop-down menu to specify one or more agent policies that you'd like to add the integration to.
+. Click **Save and continue** to confirm your settings.
 
-. Choose the agent policy you want to add the integration to. You can choose an
-existing agent policy or create a new one.
+This action installs the integration (if it's not already installed) and adds it to the {agent} policies that you specified. 
+{fleet} distributes the new integration policy to all {agent}s that are enrolled in the agent policies.
 
-. Save the integration policy:
-+
---
-* To use the UI, click **Save integration**.
-* To use the {fleet} API, click **Preview API request** and run the
-request.
---
+You can update the settings for an installed integration at any time:
 
-This action installs the integration (if it's not already installed) and saves
-the integration policy as a part of the larger {agent} policy. {fleet}
-distributes this new policy to all {agent}s that are enrolled in the agent
-policy.
+. In {kib}, go to the **Integrations** page.
+. On the **Integration policies** tab, for the integration that you like to update open the **Actions** menu and select **Edit integration**.
+. On the **Edit <integration>** page you can update any configuration settings and also update the list of {agent} polices to which the integration is added.
 
 If you haven't deployed any {agent}s yet or set up agent policies, start with
 one of our quick start guides:

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -11,7 +11,7 @@ To add a new integration to one or more {agent} policies:
 . In {kib}, go to the **Integrations** page.
 . The Integrations page shows {agent} integrations along with other types, such as {beats}. Scroll down and select **Elastic Agent only** to view only integrations that work with {agent}.
 . Search for and select an integration. You can select a category to narrow your search.
-. Click **Add <Integration>**.
+. Click **Add <integration>**.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
 . In Step 1 on the **Add <integration>** page, you can select the configuration settings specific to the integration.
 . In Step 2 on the page, you have two options:

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -13,7 +13,7 @@ To add a new integration to one or more {agent} policies:
 . Search for and select an integration. You can select a category to narrow your search.
 . Click **Add <Integration>**.
 . You can opt to install an {agent} if you haven't already, or choose **Add integration only** to proceed.
-. In Step 1 on the **Add <Integration>** page, you can select the configuration settings specific to the integration.
+. In Step 1 on the **Add <integration>** page, you can select the configuration settings specific to the integration.
 . In Step 2 on the page, you have two options:
 .. If you'd like to create a new policy for your {agent}s, on the **New hosts** tab specify a name for the new agent policy and choose whether or not to collect system logs and metrics.
 Collecting logs and metrics will add the System integration to the new agent policy.


### PR DESCRIPTION
This updates the instructions for adding an integration to a policy. Those instructions appear in two places, in the "manage integrations" context and as part of the Fleet docs for managing Elastic Agent and agent policies. The content in both places is pretty much identical. I also did a little bit of reorganizing.

Target: 8.16
Closes: #1220 

---
![screen](https://github.com/user-attachments/assets/78160506-2409-4b7e-8ab6-effc334bd527)

