### PR TITLE
Add known issue for 8.15 agent with Azure EventHub input

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -35,6 +35,26 @@ Review important information about the {fleet} and {agent} 8.15.0 release.
 {fleet-server}::
 * Update {fleet-server} Go version to 1.22.5. {fleet-server-pull}3681[#3681]
 
+
+[discrete]
+[[known-issues-8.15.0]]
+=== Known issues
+
+[[known-issue-issue-40608]]
+.Short description
+[%collapsible]
+====
+
+*Details*
+
+The Azure EventHub input fails to start on {agent} version 8.15 running on Windows. See {beats} issue link:https://github.com/elastic/beats/issues/40608[#40608] for details.
+
+*Impact* +
+
+If you're using {agent} on Windows with the Azure EventHub input we recommend not upgrading {agent} to version 8.15 and instead waiting for a later release.
+
+====
+
 [discrete]
 [[new-features-8.15.0]]
 === New features


### PR DESCRIPTION
As discussed in Slack, this adds a known issue for a Filebeat failing input on Windows for Azure EventHub.


![screen2](https://github.com/user-attachments/assets/08fe772a-d2ee-482d-a716-6630b0e3081f)
