### PR TITLE
Remove 'fleet-server-insecure-http' setting from docs

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -198,7 +198,6 @@ elastic-agent enroll --fleet-server-es <string>
                      [--fleet-server-es-cert-key <string>]
                      [--fleet-server-es-insecure]
                      [--fleet-server-host <string>]
-                     [--fleet-server-insecure-http]
                      [--fleet-server-policy <string>]
                      [--fleet-server-port <uint16>]
                      [--fleet-server-timeout <duration>]
@@ -298,12 +297,6 @@ When this flag is used the certificate verification is disabled.
 
 `--fleet-server-host <string>`::
 {fleet-server} HTTP binding host (overrides the policy).
-
-`--fleet-server-insecure-http`::
-Expose {fleet-server} over HTTP. This option is not recommended because it's
-insecure. It's useful during development and testing, but should not be used in
-production. When using this option, you should bind {fleet-server} to the
-local host (this is the default).
 
 `--fleet-server-policy <string>`::
 Used when starting a self-managed {fleet-server} to allow a specific policy to be used.
@@ -627,7 +620,6 @@ elastic-agent install --fleet-server-es <string>
                       [--fleet-server-es-cert-key <string>]
                       [--fleet-server-es-insecure]
                       [--fleet-server-host <string>]
-                      [--fleet-server-insecure-http]
                       [--fleet-server-policy <string>]
                       [--fleet-server-port <uint16>]
                       [--fleet-server-timeout <duration>]
@@ -735,12 +727,6 @@ When this flag is used the certificate verification is disabled.
 
 `--fleet-server-host <string>`::
 {fleet-server} HTTP binding host (overrides the policy).
-
-`--fleet-server-insecure-http`::
-Expose {fleet-server} over HTTP. This option is not recommended because it's
-insecure. It's useful during development and testing, but should not be used in
-production. When using this option, you should bind {fleet-server} to the
-local host (this is the default).
 
 `--fleet-server-policy <string>`::
 Used when starting a self-managed {fleet-server} to allow a specific policy to be used.

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -116,8 +116,6 @@ include::shared-env.asciidoc[tag=fleet-server-cert-key]
 
 include::shared-env.asciidoc[tag=fleet-server-cert-key-passphrase]
 
-include::shared-env.asciidoc[tag=fleet-server-insecure-http]
-
 include::shared-env.asciidoc[tag=fleet-server-es-ca-trusted-fingerprint]
 
 |===

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -273,20 +273,6 @@ Overrides the port defined in the policy.
 
 // =============================================================================
 
-// tag::fleet-server-insecure-http[]
-|
-[id="env-{type}-fleet-server-insecure-http"]
-`FLEET_SERVER_INSECURE_HTTP`
-
-| (bool) When `true`, exposes {fleet-server} over HTTP (insecure).
-Setting this to `true` is not recommended.
-
-*Default:* `false`
-
-// end::fleet-server-insecure-http[]
-
-// =============================================================================
-
 // tag::fleet-server-es-ca-trusted-fingerprint[]
 |
 [id="env-{type}-fleet-server-es-ca-trusted-fingerprint"]


### PR DESCRIPTION
Apparently the setting `fleet-server-insecure-http` was removed by https://github.com/elastic/kibana/pull/129371
This updates the docs to remove mention of the removed setting.

Closes: https://github.com/elastic/ingest-docs/issues/1273