### PR TITLE
Fixing typo in Fleet port requirements

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -94,8 +94,6 @@ You may need to allow access to these ports. Refer to the following table for de
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 9200
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 5601
-| {fleet-server} → {fleet} | 5601
 | {fleet-server} → {es} | 9200
 |===
 


### PR DESCRIPTION
- Fleet port is wrong. 5601 is Kibana default port
- "Fleet" doesn't really make sense
- Neither Elastic Agent nor Fleet Server connect to Kibana port