### PR TITLE
Update port assignments from 'Fleet' to 'Kibana (Fleet)'

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -59,8 +59,8 @@ You may need to allow access to these ports. See the following table for default
 | Elastic Agent → {fleet-server} | 443
 | Elastic Agent → {es} | 443
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 443
-| {fleet-server} → {fleet} | 443
+| Elastic Agent → {kib} ({fleet}) | 443
+| {fleet-server} → {kib} ({fleet}) | 443
 | {fleet-server} → {es} | 443
 |===
 

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -77,8 +77,8 @@ You may need to allow access to these ports. See the following table for default
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 443
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 443
-| {fleet-server} → {fleet} | 443
+| Elastic Agent → {kib} ({fleet}) | 443
+| {fleet-server} → {kib} ({fleet}) | 443
 | {fleet-server} → {es} | 443
 |===
 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -94,8 +94,8 @@ You may need to allow access to these ports. Refer to the following table for de
 | Elastic Agent → {fleet-server} | 8220
 | Elastic Agent → {es} | 9200
 | Elastic Agent → Logstash | 5044
-| Elastic Agent → {fleet} | 5601
-| {fleet-server} → {fleet} | 5601
+| Elastic Agent → {kib} ({fleet}) | 5601
+| {fleet-server} → {kib} ({fleet}) | 5601
 | {fleet-server} → {es} | 9200
 |===
 


### PR DESCRIPTION
From a Slack thread with @jeanfabrice, this updates the default port settings on the three pages below to refer to "Kibana (Fleet)" rather than "Fleet":

 - [Deploy on Elastic Cloud](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-cloud.html)
 - [Deploy on premises and self-managed](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-on-prem.html)
 - [Deploy Fleet Server on premises and Elasticsearch on Cloud](https://www.elastic.co/guide/en/fleet/current/add-fleet-server-mixed.html)

For example:

![Screenshot 2024-08-30 at 11 49 54 AM](https://github.com/user-attachments/assets/522497ce-8847-4dc8-be02-8a23cdb44693)

