### PR TITLE
Add Fleet & Agent 8.15.1 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -38,7 +38,7 @@ Review important information about the {fleet} and {agent} 8.15.1 release.
 {agent}::
 * Fix the Debian packaging to properly copy the `state.enc` and `state.yml` files to the new version of the {agent}. {agent-pull}5260[#5260] {agent-issue}5101[#5101]
 * Switch from wall clock to montonic clocks for component check-in calculation. {agent-pull}5284[#5284] {agent-issue}5277[#5277]
-* For a failed installation return a `nil` error instead of `syscall.Errno(0)` which indicates a successful operation on Windows. {agent-pull}5317[#5317] {agent-issue}4496[#4496]
+* For a failed installation, return a `nil` error instead of `syscall.Errno(0)` which indicates a successful operation on Windows. {agent-pull}5317[#5317] {agent-issue}4496[#4496]
 
 // end 8.15.1 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -32,7 +32,8 @@ Review important information about the {fleet} and {agent} 8.15.1 release.
 [[bug-fixes-8.15.1]]
 === Bug fixes
 
-// {fleet}::
+{fleet}::
+* Remove duplicative retries from client-side requests to APIs that depend on EPR ({kibana-pull}190722[#190722]).
 
 {agent}::
 * Fix the Debian packaging to properly copy the `state.enc` and `state.yml` files to the new version of the {agent}. {agent-pull}5260[#5260] {agent-issue}5101[#5101]

--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -21,6 +21,26 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.15.1 relnotes
+
+[[release-notes-8.15.1]]
+== {fleet} and {agent} 8.15.1
+
+Review important information about the {fleet} and {agent} 8.15.1 release.
+
+[discrete]
+[[bug-fixes-8.15.1]]
+=== Bug fixes
+
+// {fleet}::
+
+{agent}::
+* Fix the Debian packaging to properly copy the `state.enc` and `state.yml` files to the new version of the {agent}. {agent-pull}5260[#5260] {agent-issue}5101[#5101]
+* Switch from wall clock to montonic clocks for component check-in calculation. {agent-pull}5284[#5284] {agent-issue}5277[#5277]
+* For a failed installation return a `nil` error instead of `syscall.Errno(0)` which indicates a successful operation on Windows. {agent-pull}5317[#5317] {agent-issue}4496[#4496]
+
+// end 8.15.1 relnotes
+
 // begin 8.15.0 relnotes
 
 [[release-notes-8.15.0]]


### PR DESCRIPTION
This adds the 8.15.1 Fleet & Elastic Agent Release Notes:

* Fleet contents from [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/191871)
* Fleet Server: no new entries in [BC1 changelog](https://github.com/elastic/fleet-server/tree/d39870621bf812bfba536a9038958fca6ba7235e/changelog/fragments)
* Elastic Agent contents from [BC1 "core" changelog](https://github.com/elastic/elastic-agent/tree/edeb02e448d2f26070a023e63df429d30bbb91a6/changelog/fragments)

Closes: https://github.com/elastic/ingest-docs/issues/1277

---

![screen](https://github.com/user-attachments/assets/3332bfb3-e16b-4ee7-9a97-d13e9b6d5282)

