### PR TITLE
Add supported TLS version info to air-gapped docs

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -171,6 +171,8 @@ docker run -it -p 443:443 \
   docker.elastic.co/package-registry/distribution:{version}
 ----
 
+The {package-registry} supports TLS versions from 1.0 to 1.3, and defaults to version 1.0.
+
 [discrete]
 === Using custom CA certificates
 

--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -171,7 +171,7 @@ docker run -it -p 443:443 \
   docker.elastic.co/package-registry/distribution:{version}
 ----
 
-The {package-registry} supports TLS versions from 1.0 to 1.3, and defaults to version 1.0.
+The {package-registry} supports TLS versions from 1.0 to 1.3. The minimum version accepted can be configured with `EPR_TLS_MIN_VERSION`, it defaults to 1.0. If you want to restrict the supported versions from 1.2 to 1.3, you can use `EPR_TLS_MIN_VERSION=1.2`.
 
 [discrete]
 === Using custom CA certificates


### PR DESCRIPTION
We should mention the supported TLS versions in the Fleet air-gapped docs, as Jaime suggests [here](https://github.com/elastic/ingest-docs/issues/1279#issuecomment-2326569596).

Closes: #1279 

---

![Screenshot 2024-09-03 at 10 41 37 AM](https://github.com/user-attachments/assets/e99d037d-1d5b-4a87-a61d-b70f43462962)
