### PR TITLE
Add section about Env Provider availability for Fleet-managed agent

### DIFF
--- a/docs/en/ingest-management/agent-policies-environment-variables.asciidoc
+++ b/docs/en/ingest-management/agent-policies-environment-variables.asciidoc
@@ -1,0 +1,6 @@
+[[fleet-agent-environment-variables]]
+= Set environment variables in an {agent} policy
+
+As an advanced use case, you may wish to configure environment variables in your {agent} policy. This is useful, for example, if there are configuration details about the system on which {agent} is running that you may not know in advance. As a solution, you may want to configure environment variables to be interpreted by {agent} at runtime, using information from the running environment.
+
+For {fleet}-managed {agents}, you can configure environment variables using the <<env-provider,Env Provider>>. Refer to <<dynamic-input-configuration,Variables and conditions in input configurations>> in the standalone {agent} documentation for more detail.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -137,6 +137,8 @@ include::create-agent-policies-no-UI.asciidoc[leveloffset=+3]
 
 include::override-policy-settings.asciidoc[leveloffset=+3]
 
+include::agent-policies-environment-variables.asciidoc[leveloffset=+3]
+
 include::security/fleet-roles-and-privileges.asciidoc[leveloffset=+2]
 
 include::security/enrollment-tokens.asciidoc[leveloffset=+2]


### PR DESCRIPTION
[Based on a Slack discussion] The Env Provider is available for use in Fleet-managed Elastic Agent (i.e., not only for standalone Elastic Agent), so this updates the Fleet-managed agent docs with a short section about that.

Closes: #1283

---

![Screenshot 2024-09-04 at 10 30 37 AM](https://github.com/user-attachments/assets/cbb184a2-9dbd-41d4-88b5-c6b62f2141c0)
