### PR TITLE
Add Fleet & Agent 7.17.24 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.24>>
+
 * <<release-notes-7.17.23>>
 
 * <<release-notes-7.17.22>>
@@ -66,6 +68,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.24 relnotes
+
+[[release-notes-7.17.24]]
+== {fleet} and {agent} 7.17.24
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.24 relnotes
 
 // begin 7.17.23 relnotes
 


### PR DESCRIPTION
This adds the 7.17.24 Fleet & Agent Release Notes:

 - Fleet: TBD [Kibana RN PR](TBD)
 - Fleet Server: no new entries in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/7e17c51d72499b7eff1e1ab2e74d82ae5c04b1aa/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/bc2cbf4b71ba456adace751f9da04b065a4091a2/changelog/fragments)

---

![Screenshot 2024-09-05 at 12 27 41 PM](https://github.com/user-attachments/assets/1ce7ba95-07cc-412d-9070-469c1f933f02)
