### PR TITLE
Update 8.12 Release Notes for Remote ES / Elastic Defend bug

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -223,7 +223,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.12.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.15.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -223,7 +223,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.15.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.12.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.12.asciidoc
@@ -576,6 +576,22 @@ DELETE _security/role/fleet_superuser
 After running these API requests, wait at least 10 minutes, and then the agents should be upgradeable again.
 ====
 
+[[known-issue-3939]]
+.Remote {es} output does not support {elastic-defend} response actions
+[%collapsible]
+====
+
+*Details*
+
+Support for a <<remote-elasticsearch-output,remote {es} output>> was introduced in this release to enable {agents} to send integration or monitoring data to a remote {es} cluster. A bug has been found that causes {elastic-defend} response actions to stop working when a remote {es} output is configured for an agent.
+
+*Impact* +
+
+This bug is currently being investigated and is expected to be resolved in an upcoming release.
+
+====
+
+
 [discrete]
 [[new-features-8.12.0]]
 === New features


### PR DESCRIPTION
This adds a known issue to the 8.12 Release Notes for the Remote ES / Elastic Defend bug.

Closes: https://github.com/elastic/ingest-docs/issues/1291

Thanks for providing the details @juliaElastic!


---

![Screenshot 2024-09-05 at 12 11 43 PM](https://github.com/user-attachments/assets/93959a7c-f4da-42bb-af87-4674ec9217f6)
