### PR TITLE
Fix up enrollment token docs

### DIFF
--- a/docs/en/ingest-management/security/enrollment-tokens.asciidoc
+++ b/docs/en/ingest-management/security/enrollment-tokens.asciidoc
@@ -84,7 +84,7 @@ To re-enroll your {agent}s, use an active enrollment token.
 
 Note that when an enrollment token is revoked it is not immediately deleted.
 Deletion occurs automatically after the duration specified in the {es}
-{ref}/security-settings.html#api-key-service-settings-delete-retention-period[`xpack.security.authc.api_key.delete.retention_period`] setting has expired.
+{ref}/security-settings.html#api-key-service-settings-delete-retention-period[`xpack.security.authc.api_key.delete.retention_period`] setting has expired (see {ref}/security-api-invalidate-api-key.html[Invalidate API key API] for details).
 
 Until the enrollment token has been deleted:
 

--- a/docs/en/ingest-management/security/enrollment-tokens.asciidoc
+++ b/docs/en/ingest-management/security/enrollment-tokens.asciidoc
@@ -1,8 +1,9 @@
 [[fleet-enrollment-tokens]]
 = {fleet} enrollment tokens
 
-A {fleet} enrollment token is an {es} API key that you use to enroll one or more
-{agent}s in {fleet}. The enrollment token enrolls the {agent} in a specific
+A {fleet} enrollment token (also referred to as an `enrollment API key` )
+is an {es} API key that you use to enroll one or more {agent}s in {fleet}.
+The enrollment token enrolls the {agent} in a specific
 agent policy that defines the data to be collected by the agent. You can
 use the token as many times as required. It will remain valid until you revoke
 it.
@@ -38,6 +39,8 @@ To create an enrollment token:
 
 . Click  **Create enrollment token**. Name your token and select an agent policy.
 +
+Note that the token name you specify must be unique so as to avoid conflict with any existing API keys.
++
 [role="screenshot"]
 image::images/create-token.png[Enrollment tokens tab in {fleet}]
 
@@ -61,6 +64,9 @@ information, refer to <<fleet-api-docs>>.
 [[revoke-fleet-enrollment-tokens]]
 == Revoke enrollment tokens
 
+You can revoke an enrollment token that you no longer wish to use to enroll {agents} in an agent policy in {fleet}.
+Revoking an enrollment token essentially invalidates the API key used by agents to communicate with {fleet-server}.
+
 To revoke an enrollment token:
 
 . In {fleet}, click **Enrollment tokens**.
@@ -75,3 +81,14 @@ image::images/revoke-token.png[Enrollment tokens tab with Revoke token highlight
 {agent}s. However, the currently enrolled agents will continue to function.
 
 To re-enroll your {agent}s, use an active enrollment token.
+
+Note that when an enrollment token is revoked it is not immediately deleted.
+Deletion occurs automatically after the duration specified in the {es}
+{ref}/security-settings.html#api-key-service-settings-delete-retention-period[`xpack.security.authc.api_key.delete.retention_period`] setting has expired.
+Until the enrollment token has been deleted, the token name may not be re-used when you <<create-fleet-enrollment-tokens,create an enrollment token>>.
+
+As well, until an enrollment token has been deleted:
+
+* It continues to be visible in the {fleet} UI.
+* It continues to be returned by a `GET /api/fleet/enrollment_api_keys` API request. Revoked enrollment tokens are identified as `"active": false`.
+

--- a/docs/en/ingest-management/security/enrollment-tokens.asciidoc
+++ b/docs/en/ingest-management/security/enrollment-tokens.asciidoc
@@ -79,16 +79,16 @@ image::images/revoke-token.png[Enrollment tokens tab with Revoke token highlight
 
 . Click **Revoke enrollment token**. You can no longer use this token to enroll
 {agent}s. However, the currently enrolled agents will continue to function.
-
++
 To re-enroll your {agent}s, use an active enrollment token.
 
 Note that when an enrollment token is revoked it is not immediately deleted.
 Deletion occurs automatically after the duration specified in the {es}
 {ref}/security-settings.html#api-key-service-settings-delete-retention-period[`xpack.security.authc.api_key.delete.retention_period`] setting has expired.
-Until the enrollment token has been deleted, the token name may not be re-used when you <<create-fleet-enrollment-tokens,create an enrollment token>>.
 
-As well, until an enrollment token has been deleted:
+Until the enrollment token has been deleted:
 
-* It continues to be visible in the {fleet} UI.
-* It continues to be returned by a `GET /api/fleet/enrollment_api_keys` API request. Revoked enrollment tokens are identified as `"active": false`.
-
+* The token name may not be re-used when you <<create-fleet-enrollment-tokens,create an enrollment token>>.
+* The token continues to be visible in the {fleet} UI.
+* The token continues to be returned by a `GET /api/fleet/enrollment_api_keys` API request.
+Revoked enrollment tokens are identified as `"active": false`.

--- a/docs/en/ingest-management/security/enrollment-tokens.asciidoc
+++ b/docs/en/ingest-management/security/enrollment-tokens.asciidoc
@@ -1,7 +1,7 @@
 [[fleet-enrollment-tokens]]
 = {fleet} enrollment tokens
 
-A {fleet} enrollment token (also referred to as an `enrollment API key` )
+A {fleet} enrollment token (referred to as an `enrollment API key` in the {fleet} API documentation)
 is an {es} API key that you use to enroll one or more {agent}s in {fleet}.
 The enrollment token enrolls the {agent} in a specific
 agent policy that defines the data to be collected by the agent. You can


### PR DESCRIPTION
This adds some detail to clear up usage of Fleet enrollment tokens.

Thanks for the suggestions @jillguyonnet. Let me know if I've missed anything.

Closes: #1270 

---

> Why the token name must be unique.

I think it should be enough for users to know just that the names need to be unique. I added:

![Screenshot 2024-09-05 at 1 26 29 PM](https://github.com/user-attachments/assets/8a9f7eb2-a4c4-4fb2-9964-0d3d139fb5bc)

---

> Add an explanation around revoking tokens (marked as inactive, will be removed after expiration) with a link to the [retention period setting in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#api-key-service-settings-delete-retention-period).
> A mention that inactive tokens are still returned by the GET API and visible in the UI until they are cleaned up.

![Screenshot 2024-09-05 at 1 41 12 PM](https://github.com/user-attachments/assets/87fd15dc-4516-467a-8234-a75277172faf)


---

> "enrollment tokens" in the docs vs. "enrollment API keys" in the OpenAPI spec

![Screenshot 2024-09-05 at 1 31 33 PM](https://github.com/user-attachments/assets/76c74e16-e5e3-4d57-baa9-b8db374d0d9e)

---

> "[revoke token](https://www.elastic.co/guide/en/fleet/8.15/fleet-enrollment-tokens.html#revoke-fleet-enrollment-tokens)" vs. "[invalidate API key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html)"

![Screenshot 2024-09-05 at 1 33 34 PM](https://github.com/user-attachments/assets/111dd772-648c-4ef2-920a-dbf1d30da3d5)


