### PR TITLE
Add docs for orphaned integrations

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -184,6 +184,11 @@ You can update the settings for an installed integration at any time:
 . In {kib}, go to the **Integrations** page.
 . On the **Integration policies** tab, for the integration that you like to update open the **Actions** menu and select **Edit integration**.
 . On the **Edit <integration>** page you can update any configuration settings and also update the list of {agent} polices to which the integration is added.
++
+If you clear the **Agent policies** field, the integration will be removed from any {agent} policies to which it had been added.
++
+To identify any integrations that have been "orphaned", that is, not associated with any {agent} policies, check the **Agent polices** column on the **Integration policies** tab.
+Any integrations that are installed but not associated with an {agent} policy are as labeled as `No agent policies`.
 
 [discrete]
 [[apply-a-policy]]

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -28,6 +28,11 @@ You can update the settings for an installed integration at any time:
 . In {kib}, go to the **Integrations** page.
 . On the **Integration policies** tab, for the integration that you like to update open the **Actions** menu and select **Edit integration**.
 . On the **Edit <integration>** page you can update any configuration settings and also update the list of {agent} polices to which the integration is added.
++
+If you clear the **Agent policies** field, the integration will be removed from any {agent} policies to which it had been added.
++
+To identify any integrations that have been "orphaned", that is, not associated with any {agent} policies, check the **Agent polices** column on the **Integration policies** tab.
+Any integrations that are installed but not associated with an {agent} policy are as labeled as `No agent policies`.
 
 If you haven't deployed any {agent}s yet or set up agent policies, start with
 one of our quick start guides:


### PR DESCRIPTION
This adds a few sentences to mention orphaned integrations, i.e., those that have been removed from and are no longer associated with any Elastic Agent policies.

@jen-huang Please let me know if I've missed anything.

Closes: #1261 
Rel: https://github.com/elastic/ingest-docs/issues/1220

This content appears in two spots:

 - [Add an integration to an Elastic Agent policy](https://www.elastic.co/guide/en/fleet/master/add-integration-to-policy.html) (in the "Manage integrations" section of the docs)
 - [Add an integration to a policy](https://www.elastic.co/guide/en/fleet/master/agent-policy.html#add-integration) (in the Agent Policies section of the docs)

---

![Screenshot 2024-09-05 at 3 37 01 PM](https://github.com/user-attachments/assets/abceb884-8bd9-4a0e-b00f-84f399d18f81)
