### PR TITLE
[Fleet/EA] Logstash & Kafka Outputs refresh

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
@@ -44,7 +44,7 @@ outputs:
       verification_mode: full
 ----
 
-== Kafka output and using Logstash to index data to Elasticsearch
+== Kafka output and using {ls} to index data to {es}
 
 If you are considering using {ls} to ship the data from `kafka` to {es}, please
 be aware Elastic is not currently testing this kind of setup.

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
@@ -52,7 +52,7 @@ be aware Elastic is not currently testing this kind of setup.
 The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
 We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
 
-Refer to {ls} output for {agent} for more details.
+Refer to <<logstash-output,{ls} output for {agent}>> documentation for more details.
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-kafka.asciidoc
@@ -44,6 +44,29 @@ outputs:
       verification_mode: full
 ----
 
+== Kafka output and using Logstash to index data to Elasticsearch
+
+If you are considering using {ls} to ship the data from `kafka` to {es}, please
+be aware Elastic is not currently testing this kind of setup.
+
+The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
+We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
+
+Refer to {ls} output for {agent} for more details.
+
+[source,yaml]
+----
+inputs {
+  kafka {
+    ...
+    ecs_compatibility => "disabled"
+    codec => json { ecs_compatibility => "disabled" }
+    ...
+  }
+}
+...
+----
+
 == Kafka output configuration settings
 
 The `kafka` output supports the following settings, grouped by category.

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -35,8 +35,7 @@ processes received events, and then sends the events to {es}.
 The following example configures a {ls} pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.
 
-The {ls} pipeline definition below is an example. Please refer to the `Additional Logstash
-configuration required` steps when creating the {ls} output in the Fleet outputs page.
+The {ls} pipeline definition below is an example.
 
 [source,yaml]
 ----
@@ -65,7 +64,7 @@ output {
 }
 ----
 <1> The {es} server and the port (`9200`) where {es} is running.
-<2> The API Key obtained from the {ls} output creation steps in Fleet.
+<2> The API Key used by {ls} to ship data to the destination data streams.
 
 For more information about configuring {ls}, refer to
 {logstash-ref}/configuration.html[Configuring {ls}] and

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -32,7 +32,7 @@ To receive the events in {ls}, you also need to create a {ls} configuration pipe
 The {ls} configuration pipeline listens for incoming {agent} connections,
 processes received events, and then sends the events to {es}.
 
-The following example configures a {ls} pipeline that listens on port `5044` for
+The following {ls} pipeline definition example configures a pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.
 
 

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -33,7 +33,10 @@ The {ls} configuration pipeline listens for incoming {agent} connections,
 processes received events, and then sends the events to {es}.
 
 The following example configures a {ls} pipeline that listens on port `5044` for
-incoming {agent} connections and routes received events to {es}:
+incoming {agent} connections and routes received events to {es}.
+
+The {ls} pipeline definition below is an example. Please refer to the `Additional Logstash
+configuration required` steps when creating the {ls} output in the Fleet outputs page.
 
 [source,yaml]
 ----
@@ -41,19 +44,28 @@ input {
   elastic_agent {
     port => 5044
     enrich => none # don't modify the events' schema at all
-    # or minimal change, add only ssl and source metadata
-    # enrich => [ssl_peer_metadata, source_metadata]
+    ssl => true
+    ssl_certificate_authorities => ["<ca_path>"]
+    ssl_certificate => "<server_cert_path>"
+    ssl_key => "<server_cert_key_in_pkcs8>"
+    ssl_verify_mode => "force_peer"
   }
 }
 
 output {
   elasticsearch {
     hosts => ["http://localhost:9200"] <1>
+    # cloud_id => "..." 
     data_stream => "true"
+    api_key => "<api_key>" <2>
+    data_stream => true
+    ssl => true
+    # cacert => "<elasticsearch_ca_path>"
   }
 }
 ----
 <1> The {es} server and the port (`9200`) where {es} is running.
+<2> The API Key obtained from the {ls} output creation steps in Fleet.
 
 For more information about configuring {ls}, refer to
 {logstash-ref}/configuration.html[Configuring {ls}] and

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -35,7 +35,6 @@ processes received events, and then sends the events to {es}.
 The following example configures a {ls} pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.
 
-The {ls} pipeline definition below is an example.
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -13,7 +13,7 @@ be aware Elastic is not currently testing this kind of setup.
 The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
 We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
 
-Refer to {ls} output for {agent} for more details.
+Refer to the <<ls-output-settings,{ls} output for {agent}>> documentation for more details.
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -5,6 +5,29 @@
 
 Specify these settings to send data over a secure connection to Kafka. In the {fleet} <<output-settings,Output settings>>, make sure that the Kafka output type is selected. 
 
+== Kafka output and using Logstash to index data to Elasticsearch
+
+If you are considering using {ls} to ship the data from `kafka` to {es}, please
+be aware Elastic is not currently testing this kind of setup.
+
+The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
+We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
+
+Refer to {ls} output for {agent} for more details.
+
+[source,yaml]
+----
+inputs {
+  kafka {
+    ...
+    ecs_compatibility => "disabled"
+    codec => json { ecs_compatibility => "disabled" }
+    ...
+  }
+}
+...
+----
+
 [discrete]
 == General settings
 

--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -5,7 +5,7 @@
 
 Specify these settings to send data over a secure connection to Kafka. In the {fleet} <<output-settings,Output settings>>, make sure that the Kafka output type is selected. 
 
-== Kafka output and using Logstash to index data to Elasticsearch
+== Kafka output and using {ls} to index data to {es}
 
 If you are considering using {ls} to ship the data from `kafka` to {es}, please
 be aware Elastic is not currently testing this kind of setup.

--- a/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-logstash.asciidoc
@@ -13,6 +13,44 @@ Before using the {ls} output, you need to make sure that for any integrations th
 
 To learn how to generate certificates, refer to <<secure-logstash-connections>>.
 
+To receive the events in {ls}, you also need to create a {ls} configuration pipeline.
+The {ls} configuration pipeline listens for incoming {agent} connections,
+processes received events, and then sends the events to {es}.
+
+The following example configures a {ls} pipeline that listens on port `5044` for
+incoming {agent} connections and routes received events to {es}.
+
+The {ls} pipeline definition below is an example. Please refer to the `Additional Logstash
+configuration required` steps when creating the {ls} output in the Fleet outputs page.
+
+[source,yaml]
+----
+input {
+  elastic_agent {
+    port => 5044
+    enrich => none # don't modify the events' schema at all
+    ssl => true
+    ssl_certificate_authorities => ["<ca_path>"]
+    ssl_certificate => "<server_cert_path>"
+    ssl_key => "<server_cert_key_in_pkcs8>"
+    ssl_verify_mode => "force_peer"
+  }
+}
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"] <1>
+    # cloud_id => "..." 
+    data_stream => "true"
+    api_key => "<api_key>" <2>
+    data_stream => true
+    ssl => true
+    # cacert => "<elasticsearch_ca_path>"
+  }
+}
+----
+<1> The {es} server and the port (`9200`) where {es} is running.
+<2> The API Key obtained from the {ls} output creation steps in Fleet.
+
 [cols="2*<a"]
 |===
 |


### PR DESCRIPTION
- Update Logstash output (both Fleet managed EA & standalone EA)
  - To share a more realistic configuration to the "reality" 
  - Callout to the Fleet Output wizard in Fleet UI
- Update the Kafka output (both Fleet managed EA & standalone EA)
  - To highlight we do not test this flow at the moment
  - To suggest to disable `ecs_compatibility` both in input and codec when using the Kafka input in Logstash to dequeue items coming from EA and shipping them to Elasticsearch

Maintainers/reviewers:
- Improve wording (@davidkyle)
- Double check with PMs (@nimarezainia + @flexitrev) 
- FYI @jlind23 as discussed internally