### PR TITLE
[Fleet & Agent docs] Change 'beats' namespace to 'elastic-agent'

### DIFF
--- a/docs/en/ingest-management/elastic-agent/advanced-kubernetes-managed-by-fleet.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/advanced-kubernetes-managed-by-fleet.asciidoc
@@ -73,12 +73,12 @@ Inside the downloaded manifest, update the Daemonset resource:
 ------------------------------------------------
 containers:
   - name: elastic-agent
-    image: docker.elastic.co/beats/elastic-agent: <ImageVersion>     
+    image: docker.elastic.co/elastic-agent/elastic-agent: <ImageVersion>     
     args: ["-c", "/etc/elastic-agent/agent.yml", "-e"]
 ------------------------------------------------
 
 Notes:: 
-The <ImageVersion> is just a placeholder for the elastic-agent image version that you will download in your manifest: eg. `image: docker.elastic.co/beats/elastic-agent: 8.11.0`
+The <ImageVersion> is just a placeholder for the elastic-agent image version that you will download in your manifest: eg. `image: docker.elastic.co/elastic-agent/elastic-agent: 8.11.0`
 Important thing is to update your manifest with args details 
 
 [source,yaml]

--- a/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/autodiscovery/kubernetes-hints-autodiscover.asciidoc
@@ -182,7 +182,7 @@ An init container is required to download the hints templates.
 ----
 initContainers:
 - name: k8s-templates-downloader
-  image: docker.elastic.co/beats/elastic-agent:{branch}
+  image: docker.elastic.co/elastic-agent/elastic-agent:{branch}
   command: ['bash']
   args:
     - -c

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -31,14 +31,14 @@ Run the `docker pull` command against the Elastic Docker registry:
 
 [source,terminal,subs="attributes"]
 ----
-docker pull docker.elastic.co/beats/elastic-agent:{version}
+docker pull docker.elastic.co/elastic-agent/elastic-agent:{version}
 ----
 
 If you want to run Synthetics tests, run the `docker pull` command to fetch the *elastic-agent-complete* image:
 
 [source,terminal,subs="attributes"]
 ----
-docker pull docker.elastic.co/beats/elastic-agent-complete:{version}
+docker pull docker.elastic.co/elastic-agent/elastic-agent-complete:{version}
 ----
 
 [discrete]
@@ -54,7 +54,7 @@ Run the following commands to verify the *elastic-agent* container image signatu
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/cosign.pub <1>
-cosign verify --key cosign.pub docker.elastic.co/beats/elastic-agent:{version} <2>
+cosign verify --key cosign.pub docker.elastic.co/elastic-agent/elastic-agent:{version} <2>
 --------------------------------------------
 <1> Download the Elastic public key to verify container signature
 <2> Verify the container against the Elastic public key
@@ -64,14 +64,14 @@ If you're using the *elastic-agent-complete* image, run the commands as follows:
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/cosign.pub <1>
-cosign verify --key cosign.pub docker.elastic.co/beats/elastic-agent-complete:{version} <2>
+cosign verify --key cosign.pub docker.elastic.co/elastic-agent/elastic-agent-complete:{version} <2>
 --------------------------------------------
 
 The command prints the check results and the signature payload in JSON format, for example:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-Verification for docker.elastic.co/beats/elastic-agent-complete:{version} --
+Verification for docker.elastic.co/elastic-agent/elastic-agent-complete:{version} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
@@ -87,7 +87,7 @@ To see the full list, run:
 
 [source,terminal,subs="attributes"]
 ----
-docker run --rm docker.elastic.co/beats/elastic-agent:{version} elastic-agent container -h
+docker run --rm docker.elastic.co/elastic-agent/elastic-agent:{version} elastic-agent container -h
 ----
 
 [discrete]
@@ -108,7 +108,7 @@ For example:
 
 [source,terminal,subs="attributes"]
 ----
-docker run --rm --mount source=$(pwd)/state,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/beats/elastic-agent:{version} <1>
+docker run --rm --mount source=$(pwd)/state,destination=/state -e {STATE_PATH}=/state --read-only docker.elastic.co/elastic-agent/elastic-agent:{version} <1>
 ----
 
 Where {STATE_PATH} is the path to a stateful directory to mount where {agent} application data can be stored.
@@ -133,7 +133,7 @@ The example below shows how to enroll an {agent}:
 version: "3"
 services:
   elastic-agent:
-    image: docker.elastic.co/beats/elastic-agent:{version} <1>
+    image: docker.elastic.co/elastic-agent/elastic-agent:{version} <1>
     container_name: elastic-agent
     restart: always
     user: root # note, synthetic browser monitors require this set to `elastic-agent`

--- a/docs/en/ingest-management/fleet/filter-agent-list-by-tags.asciidoc
+++ b/docs/en/ingest-management/fleet/filter-agent-list-by-tags.asciidoc
@@ -99,7 +99,7 @@ docker run \
   --env FLEET_URL=<Fleet Server host URL> \
   --env FLEET_ENROLLMENT_TOKEN=<enrollment token> \
   --env ELASTIC_AGENT_TAGS=docker,dev
-  --rm docker.elastic.co/beats/elastic-agent:{version}
+  --rm docker.elastic.co/elastic-agent/elastic-agent:{version}
 ----
 
 For more information about running on containers, refer to the guides under

--- a/docs/en/ingest-management/fleet/fleet-server-secrets.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-secrets.asciidoc
@@ -210,7 +210,7 @@ docker run \
 	-v /path/to/creds:/creds:ro \
         -e FLEET_SERVER_CERT_KEY_PASSPHRASE=/creds/passphrase \
         -e FLEET_SERVER_SERVICE_TOKEN_PATH=/creds/service-token \
-        --rm docker.elastic.co/beats/elastic-agent
+        --rm docker.elastic.co/elastic-agent/elastic-agent
 ----
 
 === Secrets in Kubernetes
@@ -244,7 +244,7 @@ spec:
       secretName: fleet-server-service-token
   containers:
   - name: fleet-server
-    image: docker.elastic.co/beats/elastic-agent
+    image: docker.elastic.co/elastic-agent/elastic-agent
     volumeMounts:
     - name: key-passphrase
       mountPath: /var/secrets/passphrase

--- a/docs/en/ingest-management/tab-widgets/run-agent-image/content.asciidoc
+++ b/docs/en/ingest-management/tab-widgets/run-agent-image/content.asciidoc
@@ -6,7 +6,7 @@ docker run \
   --env FLEET_ENROLL=1 \ <1>
   --env FLEET_URL=<fleet-server-host-url> \ <2>
   --env FLEET_ENROLLMENT_TOKEN=<enrollment-token> \ <3>
-  --rm docker.elastic.co/beats/elastic-agent:{version} <4>
+  --rm docker.elastic.co/elastic-agent/elastic-agent:{version} <4>
 ----
 
 <1> Set to 1 to enroll the {agent} into {fleet-server}.
@@ -29,7 +29,7 @@ docker run \
   --env FLEET_SERVER_SERVICE_TOKEN=<service-token> \ <3>
   --env FLEET_SERVER_POLICY_ID=<fleet-server-policy> \ <4>
   -p 8220:8220 \ <5>
-  --rm docker.elastic.co/beats/elastic-agent:{version} <6>
+  --rm docker.elastic.co/elastic-agent/elastic-agent:{version} <6>
 ----
 
 <1> Set to 1 to bootstrap Fleet Server on this Elastic Agent.


### PR DESCRIPTION
Elastic Agent Docker images are currently available under both a `beats` and `elastic-agent` namespace. For 9.0 only the latter will be available, so in preparation for that this will update the current (8.15).

Closes: https://github.com/elastic/ingest-docs/issues/1314