### PR TITLE
[8.15] Update beats-agent-comparison.asciidoc (#1316)

### DIFF
--- a/docs/en/ingest-management/beats-agent-comparison.asciidoc
+++ b/docs/en/ingest-management/beats-agent-comparison.asciidoc
@@ -271,9 +271,9 @@ The following table shows a comparison of capabilities supported by {beats} and 
 
 |Run without root on host
 |{y}
-|{n}
-|{n}
-|{fleet}-managed {agent}s require root permission, in particular for {elastic-defend}. Standalone {agent}s also require root permissions. {beats} requires root permission only if it's configured to capture data that requires that level of permission.
+|{y}
+|{y}
+|{fleet}-managed {agent}s, Standalone {agent}s, and {beats} require root permission only if they're configured to capture data that requires that level of permission.
 
 |Multiple outputs
 |{y}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Update beats-agent-comparison.asciidoc (#1316)](https://github.com/elastic/ingest-docs/pull/1316)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)