### PR TITLE
Change docker link from 'beats' to 'elastic-agent' namespace

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -1,7 +1,7 @@
 [[elastic-agent-container]]
 = Run {agent} in a container
 
-You can run {agent} inside a container -- either with {fleet-server} or standalone. Docker images for all versions of {agent} are available from the https://www.docker.elastic.co/r/beats/elastic-agent[Elastic Docker registry]. If you are running in Kubernetes, refer to {eck-ref}/k8s-elastic-agent.html[run {agent} on ECK].
+You can run {agent} inside a container -- either with {fleet-server} or standalone. Docker images for all versions of {agent} are available from the https://www.docker.elastic.co/r/elastic-agent/elastic-agent[Elastic Docker registry]. If you are running in Kubernetes, refer to {eck-ref}/k8s-elastic-agent.html[run {agent} on ECK].
 
 Considerations:
 

--- a/docs/en/ingest-management/elastic-agent/run-container-common/download-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/run-container-common/download-elastic-agent.asciidoc
@@ -1,4 +1,4 @@
-NOTE: You can find {agent} Docker images https://www.docker.elastic.co/r/beats/elastic-agent[here].
+NOTE: You can find {agent} Docker images https://www.docker.elastic.co/r/elastic-agent/elastic-agent[here].
 
 Download the manifest file:
 


### PR DESCRIPTION
This fixes two links to use the newly created `elastic-agent` namespace rather than `beats`. 

Rel: https://github.com/elastic/ingest-docs/pull/1315#issuecomment-2349244946