### PR TITLE
Add ECS known issue for ecs@mappings and fieldless searches

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -42,7 +42,7 @@ There are no bug fixes for {fleet} or {agent} in this release.
 ====
 *Details*
 
-Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer includes ECS fields in the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 If you run a query without specifying a field, the query will not return results for ECS fields.
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -79,7 +79,7 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 ====
 *Details*
 
-Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer includes ECS fields in the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 If you run a query without specifying a field, the query will not return results for ECS fields.
 
@@ -138,7 +138,7 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 ====
 *Details*
 
-Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer includes ECS fields in the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 If you run a query without specifying a field, the query will not return results for ECS fields.
 
@@ -192,7 +192,7 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 ====
 *Details*
 
-Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer includes ECS fields in the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 If you run a query without specifying a field, the query will not return results for ECS fields.
 
@@ -315,7 +315,7 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 ====
 *Details*
 
-Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer includes ECS fields in the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 If you run a query without specifying a field, the query will not return results for ECS fields.
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -90,18 +90,18 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
-[[known-issue-242-8.13.0]]
+[[known-issue-242-8.13.2]]
 .ECS fields are not included to the `index.query.default_field` in {agent} integrations
 [%collapsible]
 ====
 
 *Details*
 
-Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
 If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 
@@ -144,18 +144,18 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
-[[known-issue-242-8.13.0]]
+[[known-issue-242-8.13.1]]
 .ECS fields are not included to the `index.query.default_field` in {agent} integrations
 [%collapsible]
 ====
 
 *Details*
 
-Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
 If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 
@@ -274,11 +274,11 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 *Details*
 
-Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
 If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -90,6 +90,23 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
+[[known-issue-242-8.13.0]]
+.ECS fields are not included to the `index.query.default_field` in {agent} integrations
+[%collapsible]
+====
+
+*Details*
+
+Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+
+*Impact* +
+
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+
+If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
+
+====
+
 [discrete]
 [[bug-fixes-8.13.2]]
 === Bug fixes
@@ -124,6 +141,23 @@ Due to changes introduced to support customizing an MSI install folder (see link
 *Impact* +
 
 This issue has been link:https://github.com/elastic/elastic-stack-installers/pull/264[resolved] in version 8.14.0 and later releases. We recommend users of {beats} MSI to upgrade to 8.14 when that release becomes available.
+
+====
+
+[[known-issue-242-8.13.0]]
+.ECS fields are not included to the `index.query.default_field` in {agent} integrations
+[%collapsible]
+====
+
+*Details*
+
+Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+
+*Impact* +
+
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+
+If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 
 ====
 
@@ -230,6 +264,23 @@ Due to changes introduced to support customizing an MSI install folder (see link
 *Impact* +
 
 This issue has been link:https://github.com/elastic/elastic-stack-installers/pull/264[resolved] in version 8.14.0 and later releases. We recommend users of {beats} MSI to upgrade to 8.14 when that release becomes available.
+
+====
+
+[[known-issue-242-8.13.0]]
+.ECS fields are not included to the `index.query.default_field` in {agent} integrations
+[%collapsible]
+====
+
+*Details*
+
+Due to changes introduced to support ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. This may affect integrations that rely fieldless queries (when no field is specified for a query).
+
+*Impact* +
+
+In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} to upgrade to 8.14 when that release becomes available.
+
+If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.13.asciidoc
@@ -32,6 +32,27 @@ Also see:
 
 There are no bug fixes for {fleet} or {agent} in this release.
 
+[discrete]
+[[known-issues-8.13.4]]
+=== Known issues
+
+[[known-issue-174855-8.13.4]]
+.ECS fields are not included to the `index.query.default_field` in {agent} integrations
+[%collapsible]
+====
+*Details*
+
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+
+If you run a query without specifying a field, the query will not return results for ECS fields.
+
+*Impact* +
+
+In version 8.14.0 and later, {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
+
+If you are running 8.13.x and unable to upgrade to 8.14.0, you can follow the workarounds described in the link:https://support.elastic.co/knowledge/bbdbeb57.
+====
+
 // end 8.13.4 relnotes
 
 // begin 8.13.3 relnotes
@@ -47,6 +68,27 @@ Review important information about {fleet-server} and {agent} for the 8.13.3 rel
 
 {agent}::
 * Update Go version to 1.21.9. {agent-pull}4508[#4508]
+
+[discrete]
+[[known-issues-8.13.3]]
+=== Known issues
+
+[[known-issue-174855-8.13.3]]
+.ECS fields are not included to the `index.query.default_field` in {agent} integrations
+[%collapsible]
+====
+*Details*
+
+Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
+
+If you run a query without specifying a field, the query will not return results for ECS fields.
+
+*Impact* +
+
+In version 8.14.0 and later, {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
+
+If you are running 8.13.x and unable to upgrade to 8.14.0, you can follow the workarounds described in the link:https://support.elastic.co/knowledge/bbdbeb57.
+====
 
 [discrete]
 [[bug-fixes-8.13.3]]
@@ -90,21 +132,21 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
-[[known-issue-242-8.13.2]]
+[[known-issue-174855-8.13.2]]
 .ECS fields are not included to the `index.query.default_field` in {agent} integrations
 [%collapsible]
 ====
-
 *Details*
 
 Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
+If you run a query without specifying a field, the query will not return results for ECS fields.
+
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
-If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
-
+If you are running 8.13.x and unable to upgrade to 8.14.0, you can follow the workarounds described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 ====
 
 [discrete]
@@ -144,21 +186,21 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
-[[known-issue-242-8.13.1]]
+[[known-issue-174855-8.13.1]]
 .ECS fields are not included to the `index.query.default_field` in {agent} integrations
 [%collapsible]
 ====
-
 *Details*
 
 Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
+If you run a query without specifying a field, the query will not return results for ECS fields.
+
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
-If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
-
+If you are running 8.13.x and unable to upgrade to 8.14.0, you can follow the workarounds described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 ====
 
 [discrete]
@@ -267,21 +309,21 @@ This issue has been link:https://github.com/elastic/elastic-stack-installers/pul
 
 ====
 
-[[known-issue-242-8.13.0]]
+[[known-issue-174855-8.13.0]]
 .ECS fields are not included to the `index.query.default_field` in {agent} integrations
 [%collapsible]
 ====
-
 *Details*
 
 Due to changes introduced to support the ecs@mappings component template (see link:https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855]), {fleet} no longer include ECS fields to the integrations' `index.query.default_field`. Not including ECS fields in the `index.query.default_field` setting may affect integrations that rely on fieldless queries (when no field is specified for a query).
 
+If you run a query without specifying a field, the query will not return results for ECS fields.
+
 *Impact* +
 
-In version 8.14.0 and later, the {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
+In version 8.14.0 and later, {fleet} sets `index.query.default_field` to `*`, so agentless queries will work as expected. We recommend users of {fleet} upgrade to 8.14 when that release becomes available.
 
-If you are unable to upgrade to 8.14.0, you can follow the workaround described in the link:https://support.elastic.co/knowledge/bbdbeb57.
-
+If you are running 8.13.x and unable to upgrade to 8.14.0, you can follow the workarounds described in the link:https://support.elastic.co/knowledge/bbdbeb57.
 ====
 
 [discrete]


### PR DESCRIPTION
Update the 8.13 release notes to add a known issue.

Due to changes introduced to support the ecs@mappings component template (see https://github.com/elastic/kibana/pull/174855[elastic/kibana/pull/174855), Fleet no longer includes ECS fields to the integrations' `index.query.default_field`. 

This may affect integrations that rely on fieldless queries (when no field is specified for a query).

This PR updates the 8.13 release notes to 

- acknowledge the problem
- inform users that 8.14 is not affected
- suggest a workaround to 8.13 users

Relates https://github.com/elastic/integrations/issues/10848