### PR TITLE
Add 'Docker and Kubernetes' to Deployment Models page

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
@@ -18,8 +18,11 @@ If you're running {es} and {kib} hosted on {cloud}/ec-getting-started.html[{ess}
 {ess} with {fleet-server} on-premise::
 When you use a hosted {ess} deployment you may still choose to run {fleet-server} on-premise. For details about this deployment model and set up instructions, refer to <<add-fleet-server-mixed,Deploy {fleet-server} on-premises and {es} on Cloud>>.
 
+Docker and Kubernetes::
+You can deploy {fleet}-managed {agent} in Docker or on Kubernetes. Refer to <<elastic-agent-container,Run {agent} in a container>> or  <<running-on-kubernetes-managed-by-fleet,Run {agent} on Kubernetes managed by {fleet}>> for all of the configuration instructions. Details for configuring {fleet-server} are included with the {agent} install steps.
+
 {eck}::
-You can deploy {fleet}-managed {agent} in a Kubernetes environment that provides configuration and management capabilities for the full {stack}. For details, refer to {eck-ref}/k8s-elastic-agent-fleet.html[Run {fleet}-managed {agent} on ECK].
+You can deploy {fleet}-managed {agent} in an {ecloud} Kubernetes environment that provides configuration and management capabilities for the full {stack}. For details, refer to {eck-ref}/k8s-elastic-agent-fleet.html[Run {fleet}-managed {agent} on ECK].
 
 Self-managed::
 For self-managed deployments, you must install and host {fleet-server} yourself. For details about this deployment model and set up instructions, refer to <<add-fleet-server-on-prem,Deploy on-premises and self-managed>>.


### PR DESCRIPTION
This adds a "Docker and Kubernetes" section to the [Deployment models](https://www.elastic.co/guide/en/fleet/current/fleet-deployment-models.html) page, which provides links to the various ways of configuring Elastic Agents to work with Elasticsearch, via Fleet Server.

The links point to:
 - [Run Elastic Agent in a container](https://www.elastic.co/guide/en/fleet/master/elastic-agent-container.html#_step_4_run_the_elastic_agent_image)
 - [Run Elastic Agent on Kubernetes managed by Fleet](https://www.elastic.co/guide/en/fleet/master/running-on-kubernetes-managed-by-fleet.html#_step_3_enroll_elastic_agent_to_the_policy)

Both pages have been updated to include Fleet Server setup steps, via https://github.com/elastic/ingest-docs/pull/1184


---
**DOCS UPDATE**


 
![Screenshot 2024-09-19 at 10 52 43 AM](https://github.com/user-attachments/assets/a35f76c2-72b7-40b0-a90b-81f6a8fa06d8)
