### PR TITLE
Add new data stream type custom component template to Fleet docs

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -109,8 +109,9 @@ WARNING: Custom index mappings may conflict with the mappings defined by the int
 and may break the integration in {kib}. Do not change or customize any default mappings.
 
 When you install an integration, {fleet} creates two default `@custom` component templates:
-. A `@custom` component template allowing customization across all documents of a given data stream type, named following the pattern: `<data_stream_type>@custom`.
-. A `@custom` component template for each data stream, named following the pattern: `<name_of_data_stream>@custom`.
+
+* A `@custom` component template allowing customization across all documents of a given data stream type, named following the pattern: `<data_stream_type>@custom`.
+* A `@custom` component template for each data stream, named following the pattern: `<name_of_data_stream>@custom`.
 
 The `@custom` component template specific to a datastream has higher precedence over the data stream type `@custom` component template.
 

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -108,7 +108,11 @@ These templates are loaded when the integration is installed, and are used to co
 WARNING: Custom index mappings may conflict with the mappings defined by the integration
 and may break the integration in {kib}. Do not change or customize any default mappings.
 
-When you install an integration, {fleet} creates a default `@custom` component template for each data stream. The Custom component templates are named following the pattern: `<name_of_data_stream>@custom`.
+When you install an integration, {fleet} creates two default `@custom` component templates:
+. A `@custom` component template allowing customization across all documents of a given data stream type, named following the pattern: `<data_stream_type>@custom`.
+. A `@custom` component template for each data stream, named following the pattern: `<name_of_data_stream>@custom`.
+
+The `@custom` component template specific to a datastream has higher precedence over the data stream type `@custom` component template.
 
 You can edit a `@custom` component template to customize your {es} indices:
 


### PR DESCRIPTION
Relates https://github.com/elastic/kibana/issues/190730

This PR update the [Fleet data stream docs](https://www.elastic.co/guide/en/fleet/current/data-streams.html) to document the new data stream type custom component template feature.

Before:
<img width="894" alt="Screenshot 2024-09-19 at 17 23 45" src="https://github.com/user-attachments/assets/1bab1b2c-9cff-4040-aeee-8e1496892d7f">

After:
<img width="894" alt="Screenshot 2024-09-20 at 11 57 02" src="https://github.com/user-attachments/assets/9b501225-643d-4c3c-9098-ef6d513f1309">
