### PR TITLE
Remove technical preview markers for 'unprivileged' mode

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -521,8 +521,6 @@ elastic-agent inspect components log-default
 [[elastic-agent-privileged-command]]
 == elastic-agent privileged
 
-preview::[]
-
 Run {agent} with full superuser privileges.
 This is the usual, default running mode for {agent}.
 The `privileged` command allows you to switch back to running an agent with full administrative privileges when you have been running it in `unprivileged` mode. 
@@ -1150,8 +1148,6 @@ elastic-agent uninstall
 [discrete]
 [[elastic-agent-unprivileged-command]]
 == elastic-agent unprivileged
-
-preview::[]
 
 Run {agent} without full superuser privileges.
 This is useful in organizations that limit `root` access on Linux or macOS systems, or `admin` access on Windows systems.

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-unprivileged-mode.asciidoc
@@ -1,8 +1,6 @@
 [[elastic-agent-unprivileged]]
 = Run {agent} without administrative privileges
 
-preview::[]
-
 Beginning with {stack} version 8.15, {agent} is no longer required to be run by a user with superuser privileges. You can now run agents in an `unprivileged` mode that does not require `root` access on Linux or macOS, or `admin` access on Windows. Being able to run agents without full administrative privileges is often a requirement in organizations where this kind of access is often very limited.
 
 In general, agents running without full administrative privileges will perform and behave exactly as those run by a superuser. There are certain integrations and datastreams that are not available, however. If an integration requires root access, this is <<unprivileged-integrations,indicated on the integration main page>>.


### PR DESCRIPTION
This removes the Technical Preview admonitions from [Run Elastic Agent without administrative privileges](https://www.elastic.co/guide/en/fleet/current/elastic-agent-unprivileged.html) and from the associated commands on the Command Reference page.

