### PR TITLE
Fix standalone agent K8s manifest link to include patch level

### DIFF
--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -1,7 +1,7 @@
 [[running-on-kubernetes-standalone]]
 = Run {agent} Standalone on Kubernetes
 
-:manifest: https://raw.githubusercontent.com/elastic/elastic-agent/{bare_version}/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+:manifest: https://raw.githubusercontent.com/elastic/elastic-agent/v{bare_version}/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
 :show-condition: enabled
 
 == What you need

--- a/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/running-on-kubernetes-standalone.asciidoc
@@ -1,7 +1,7 @@
 [[running-on-kubernetes-standalone]]
 = Run {agent} Standalone on Kubernetes
 
-:manifest: https://raw.githubusercontent.com/elastic/elastic-agent/{branch}/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+:manifest: https://raw.githubusercontent.com/elastic/elastic-agent/{bare_version}/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
 :show-condition: enabled
 
 == What you need


### PR DESCRIPTION
It was reported in Slack that on the [Kubernetes install instructions for standalone agent](_step_1_download_the_elastic_agent_manifest_3), customers are being directed to `8.15.2` manifest files before they're fully available.

Essentially this link:

`curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/8.15/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml`

Should be:

`curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/8.15.1deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml`

I've fixed this by changing the `{manifest}` variable to include `{bare-version}` (which is currently set to `8.15.1`) rather than `{branch}` (which is currently set to `8.15`).

The screen capture below shows the manifest link as `8.16.0` because this change is going into the `main` branch. In the public docs, this would be the current patch version, so as I write this that version is currently set to `8.15.1`.

---

![Screenshot 2024-09-25 at 11 00 16 AM](https://github.com/user-attachments/assets/15380332-afec-44fd-9f35-9af4dba9e17f)

