### PR TITLE
Clarification of MSI Upgrading Behavior

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
@@ -47,7 +47,7 @@ Installing using an MSI package has the following behaviors:
 [discrete]
 == Upgrading
 
-Upgrades are not supported and are prevented by the MSI itself. Instead, all of your {agent} upgrades can be managed in {fleet}.
+The {agent} version can be upgraded via {fleet}, but the registered MSI version will display the initially installed version. Attempts to upgrade outside of {fleet} via the MSI will require an uninstall and reinstall procedure to upgrade. 
 
 [discrete]
 == Installing in a custom location


### PR DESCRIPTION
Rephrased to clarify that upgrades via fleet are supported, but the impact is that the MSI version remains registered at the initially installed package version. Added suggestion for MSI installs (package management) that in order to upgrade an uninstall/reinstall is required. 