### PR TITLE
Add note about elliptic-curve restriction

### DIFF
--- a/docs/en/ingest-management/security/certificates.asciidoc
+++ b/docs/en/ingest-management/security/certificates.asciidoc
@@ -37,6 +37,8 @@ openssl pkcs12 -in path.p12 -out private.key -nocerts -nodes
 Key passwords are not currently supported.
 ====
 
+IMPORTANT: When you run {agent} with the {elastic-defend} integration, the link:https://en.wikipedia.org/wiki/X.509[TLS certificates] used to connect to {fleet-server} and {es} need to be generated using link:https://en.wikipedia.org/wiki/RSA_(cryptosystem)[RSA]. For a full list of available algorithms to use when configuring TLS or mTLS, see <<elastic-agent-ssl-configuration,Configure SSL/TLS for standalone {agents}>>. These settings are available for both standalone and {fleet}-managed {agent}.
+
 [discrete]
 [[generate-fleet-server-certs]]
 == Generate a custom certificate and private key for {fleet-server}

--- a/docs/en/ingest-management/security/mutual-tls.asciidoc
+++ b/docs/en/ingest-management/security/mutual-tls.asciidoc
@@ -48,6 +48,8 @@ When mTLS is required, the secure setup between {agent}, {fleet}, and {fleet-ser
 .. If the {agent} policy contains mTLS configuration settings, those settings will take precedence over those used during enrollment: This includes both the mTLS settings used for connectivity between {agent} and {fleet-server} (and the {fleet} application in {kib}, for {fleet}-managed {agent}), and the settings used between {agent} and it's specified output.
 .. If the {agent} policy does not contain any TLS, mTLS, or proxy configuration settings, these settings will remain as they were specified when {agent} enrolled. Note that the initial TLS, mTLS, or proxy configuration settings can not be removed through the {agent} policy; they can only be updated.
 
+IMPORTANT: When you run {agent} with the {elastic-defend} integration, configuring an mTLS connection between {agent} and {fleet-server} does not support using an link:https://en.wikipedia.org/wiki/Elliptic-curve_cryptography[elliptic-curve (ECC) key].
+
 [discrete]
 [[mutual-tls-on-premise]]
 == On-premise deployments

--- a/docs/en/ingest-management/security/mutual-tls.asciidoc
+++ b/docs/en/ingest-management/security/mutual-tls.asciidoc
@@ -48,7 +48,7 @@ When mTLS is required, the secure setup between {agent}, {fleet}, and {fleet-ser
 .. If the {agent} policy contains mTLS configuration settings, those settings will take precedence over those used during enrollment: This includes both the mTLS settings used for connectivity between {agent} and {fleet-server} (and the {fleet} application in {kib}, for {fleet}-managed {agent}), and the settings used between {agent} and it's specified output.
 .. If the {agent} policy does not contain any TLS, mTLS, or proxy configuration settings, these settings will remain as they were specified when {agent} enrolled. Note that the initial TLS, mTLS, or proxy configuration settings can not be removed through the {agent} policy; they can only be updated.
 
-IMPORTANT: When you run {agent} with the {elastic-defend} integration, configuring an mTLS connection between {agent} and {fleet-server} does not support using an link:https://en.wikipedia.org/wiki/Elliptic-curve_cryptography[elliptic-curve (ECC) key].
+IMPORTANT: When you run {agent} with the {elastic-defend} integration, the link:https://en.wikipedia.org/wiki/X.509[TLS certificates] used to connect to {fleet-server} and {es} need to be generated using link:https://en.wikipedia.org/wiki/RSA_(cryptosystem)[RSA]. For a full list of available algorithms to use when configuring TLS or mTLS, see <<elastic-agent-ssl-configuration,Configure SSL/TLS for standalone {agents}>>. These settings are available for both standalone and {fleet}-managed {agent}.
 
 [discrete]
 [[mutual-tls-on-premise]]


### PR DESCRIPTION
This adds a note at the bottom of the Overview section on the [Elastic Agent deployment models with mutual TLS](https://www.elastic.co/guide/en/fleet/current/mutual-tls.html) page and the Prerequisites section of the [Configure SSL/TLS for self-managed Fleet Servers](https://www.elastic.co/guide/en/fleet/current/secure-connections.html#prereqs) page.

![Screenshot 2024-09-27 at 11 12 56 AM](https://github.com/user-attachments/assets/42f358c8-97ef-4f7d-ba22-a002b7da5707)



@AndersonQ, please fix this up however it should be worded because I have no idea what I'm talking about here. :-)