### PR TITLE
Add restriction about containerized agent on Windows

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -3,6 +3,8 @@
 
 You can run {agent} inside a container -- either with {fleet-server} or standalone. Docker images for all versions of {agent} are available from the https://www.docker.elastic.co/r/elastic-agent/elastic-agent[Elastic Docker registry]. If you are running in Kubernetes, refer to {eck-ref}/k8s-elastic-agent.html[run {agent} on ECK].
 
+Note that running {elastic-agent} in a container is supported only in Linux environments. For this reason we don't currently provide {agent} container images for Windows.
+
 Considerations:
 
 * When {agent} runs inside a container, it cannot be upgraded through {fleet} as it expects that the container itself is upgraded.


### PR DESCRIPTION
A customer reported not being run Elastic Agent in Docker on Windows, which is not supported. This adds that restriction near the top of the [Run Elastic Agent in a container](https://www.elastic.co/guide/en/fleet/current/elastic-agent-container.html) page.

---


<img width="786" alt="Screenshot 2024-09-26 at 2 12 00 PM" src="https://github.com/user-attachments/assets/2f23e4f8-41bf-4f7a-93a7-0556344afa5d">
