### PR TITLE
Add missing environment variables for container setup

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -92,6 +92,10 @@ At least one {fleet-server} is required in a deployment.
 
 include::shared-env.asciidoc[tag=fleet-force]
 
+include::shared-env.asciidoc[tag=fleet-header]
+
+include::shared-env.asciidoc[tag=fleet-kibana-header]
+
 include::shared-env.asciidoc[tag=fleet-server-client-auth]
 
 include::shared-env.asciidoc[tag=fleet-server-enable]
@@ -103,6 +107,8 @@ include::shared-env.asciidoc[tag=fleet-server-elasticsearch-ca]
 include::shared-env.asciidoc[tag=fleet-server-es-cert]
 
 include::shared-env.asciidoc[tag=fleet-server-es-cert-key]
+
+include::shared-env.asciidoc[tag=fleet-server-insecure-http]
 
 include::shared-env.asciidoc[tag=fleet-server-service-token]
 
@@ -123,6 +129,10 @@ include::shared-env.asciidoc[tag=fleet-server-cert-key]
 include::shared-env.asciidoc[tag=fleet-server-cert-key-passphrase]
 
 include::shared-env.asciidoc[tag=fleet-server-es-ca-trusted-fingerprint]
+
+include::shared-env.asciidoc[tag=fleet-daemon-timeout]
+
+include::shared-env.asciidoc[tag=fleet-server-timeout]
 
 |===
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -124,10 +124,6 @@ include::shared-env.asciidoc[tag=fleet-server-client-auth]
 
 include::shared-env.asciidoc[tag=fleet-server-es-ca-trusted-fingerprint]
 
-include::shared-env.asciidoc[tag=fleet-header]
-
-include::shared-env.asciidoc[tag=fleet-kibana-header]
-
 include::shared-env.asciidoc[tag=fleet-daemon-timeout]
 
 include::shared-env.asciidoc[tag=fleet-server-timeout]

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -90,14 +90,6 @@ At least one {fleet-server} is required in a deployment.
 |===
 | Settings | Description
 
-include::shared-env.asciidoc[tag=fleet-force]
-
-include::shared-env.asciidoc[tag=fleet-header]
-
-include::shared-env.asciidoc[tag=fleet-kibana-header]
-
-include::shared-env.asciidoc[tag=fleet-server-client-auth]
-
 include::shared-env.asciidoc[tag=fleet-server-enable]
 
 include::shared-env.asciidoc[tag=fleet-server-elasticsearch-host]
@@ -128,7 +120,13 @@ include::shared-env.asciidoc[tag=fleet-server-cert-key]
 
 include::shared-env.asciidoc[tag=fleet-server-cert-key-passphrase]
 
+include::shared-env.asciidoc[tag=fleet-server-client-auth]
+
 include::shared-env.asciidoc[tag=fleet-server-es-ca-trusted-fingerprint]
+
+include::shared-env.asciidoc[tag=fleet-header]
+
+include::shared-env.asciidoc[tag=fleet-kibana-header]
 
 include::shared-env.asciidoc[tag=fleet-daemon-timeout]
 
@@ -148,11 +146,6 @@ Settings used to enroll an {agent} into a {fleet-server}.
 [cols="2*<a"]
 |===
 | Settings | Description
-
-
-include::shared-env.asciidoc[tag=elastic-agent-cert]
-
-include::shared-env.asciidoc[tag=elastic-agent-cert-key]
 
 include::shared-env.asciidoc[tag=elastic-agent-tag]
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -66,8 +66,6 @@ Settings used to prepare the {fleet} plugin in {kib}.
 |===
 | Settings | Description
 
-include::shared-env.asciidoc[tag=kibana-fleet-setup]
-
 include::shared-env.asciidoc[tag=kibana-fleet-host]
 
 include::shared-env.asciidoc[tag=kibana-fleet-username]
@@ -92,11 +90,19 @@ At least one {fleet-server} is required in a deployment.
 |===
 | Settings | Description
 
+include::shared-env.asciidoc[tag=fleet-force]
+
+include::shared-env.asciidoc[tag=fleet-server-client-auth]
+
 include::shared-env.asciidoc[tag=fleet-server-enable]
 
 include::shared-env.asciidoc[tag=fleet-server-elasticsearch-host]
 
 include::shared-env.asciidoc[tag=fleet-server-elasticsearch-ca]
+
+include::shared-env.asciidoc[tag=fleet-server-es-cert]
+
+include::shared-env.asciidoc[tag=fleet-server-es-cert-key]
 
 include::shared-env.asciidoc[tag=fleet-server-service-token]
 
@@ -133,9 +139,16 @@ Settings used to enroll an {agent} into a {fleet-server}.
 |===
 | Settings | Description
 
+
+include::shared-env.asciidoc[tag=elastic-agent-cert]
+
+include::shared-env.asciidoc[tag=elastic-agent-cert-key]
+
 include::shared-env.asciidoc[tag=elastic-agent-tag]
 
 include::shared-env.asciidoc[tag=fleet-enroll]
+
+include::shared-env.asciidoc[tag=fleet-force]
 
 include::shared-env.asciidoc[tag=fleet-url]
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/container-envs.asciidoc
@@ -147,6 +147,10 @@ Settings used to enroll an {agent} into a {fleet-server}.
 |===
 | Settings | Description
 
+include::shared-env.asciidoc[tag=elastic-agent-cert]
+
+include::shared-env.asciidoc[tag=elastic-agent-cert-key]
+
 include::shared-env.asciidoc[tag=elastic-agent-tag]
 
 include::shared-env.asciidoc[tag=fleet-enroll]

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -126,32 +126,6 @@ This flag is helpful when using automation software or scripted deployments.
 
 // =============================================================================
 
-// tag::fleet-header[]
-|
-[id="env-{type}-fleet-header"]
-`FLEET_HEADER`
-
-| (string) Specify any headers that {agent} should send to {fleet-server} during enrollment.
-
-*Default:* none
-
-// end::fleet-header[]
-
-// =============================================================================
-
-// tag::fleet-kibana-header[]
-|
-[id="env-{type}-fleet-kibana-header"]
-`FLEET_KIBANA_HEADER`
-
-| (string) Specify any headers that {agent} should send when contacting {kib}.
-
-*Default:* none
-
-// end::fleet-kibana-header[]
-
-// =============================================================================
-
 // tag::fleet-server-enable[]
 |
 [id="env-{type}-fleet-server-enable"]

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -17,6 +17,28 @@ OPTIONAL INFO AND EXAMPLE
 
 // =============================================================================
 
+// tag::elastic-agent-cert[]
+|
+[id="env-{type}-elastic-agent-cert"]
+`ELASTIC_AGENT_CERT`
+
+| (string) The path to the mutual TLS client certificate that that {agent} will use to connect to {fleet-server}.
+
+// end::elastic-agent-cert[]
+
+// =============================================================================
+
+// tag::elastic-agent-cert-key[]
+|
+[id="env-{type}-elastic-agent-cert-key"]
+`ELASTIC_AGENT_CERT_KEY`
+
+| (string) The path to the mutual TLS private key that that {agent} will use to connect to {fleet-server}.
+
+// end::elastic-agent-cert-key[]
+
+// =============================================================================
+
 // tag::elastic-agent-tag[]
 |
 [id="env-{type}-elastic-agent-tag"]
@@ -26,21 +48,6 @@ OPTIONAL INFO AND EXAMPLE
 You can use these tags to filter the list of agents in {fleet}.
 
 // end::elastic-agent-tag[]
-
-// =============================================================================
-
-// tag::kibana-fleet-setup[]
-|
-[id="env-{type}-kibana-fleet-setup"]
-`KIBANA_FLEET_SETUP`
-
-| (int) Set to `1` to enable {fleet} setup.
-Enabling {fleet} is required before {fleet-server} will start.
-When this action is not performed, a user must manually log in to {kib} and visit the {fleet} page to enable setup.
-
-*Default:* none
-
-// end::kibana-fleet-setup[]
 
 // =============================================================================
 
@@ -102,6 +109,20 @@ contains your CA's certificate.
 *Default:* `""`
 
 // end::kibana-fleet-ca[]
+
+// =============================================================================
+
+// tag::fleet-force[]
+|
+[id="env-{type}-fleet-force"]
+`FLEET_FORCE`
+
+| (int) Set to `1` to force overwrite of the current configuration without prompting for confirmation.
+This flag is helpful when using automation software or scripted deployments.
+
+*Default:* none
+
+// end::fleet-force[]
 
 // =============================================================================
 
@@ -273,6 +294,21 @@ Overrides the port defined in the policy.
 
 // =============================================================================
 
+// tag::fleet-server-client-auth[]
+|
+[id="env-{type}-fleet-server-client-auth"]
+`FLEET_SERVER_CLIENT_AUTH`
+
+| (string) One of `none`, `optional`, or `required`.
+{fleet-server}'s client authentication option for client mTLS connections.
+If `optional` or `required` is specified, client certificates are verified using CAs.
+
+*Default:* none
+
+// end::fleet-server-client-auth[]
+
+// =============================================================================
+
 // tag::fleet-server-es-ca-trusted-fingerprint[]
 |
 [id="env-{type}-fleet-server-es-ca-trusted-fingerprint"]
@@ -285,6 +321,32 @@ by {agent} for communication. This flag is required when using self-signed certi
 *Default:* `""`
 
 // end::fleet-server-es-ca-trusted-fingerprint[]
+
+// =============================================================================
+
+// tag::fleet-server-es-cert[]
+|
+[id="env-{type}-fleet-server-es-cert"]
+`FLEET_SERVER_ES_CERT`
+
+| (string) The path to the mutual TLS client certificate that that {fleet-server} will use to connect to {es}.
+
+*Default:* `""`
+
+// end::fleet-server-es-cert[]
+
+// =============================================================================
+
+// tag::fleet-server-es-cert-key[]
+|
+[id="env-{type}-fleet-server-es-cert-key"]
+`FLEET_SERVER_ES_CERT_KEY`
+
+| (string) The path to the mutual TLS private key that that {fleet-server} will use to connect to {es}.
+
+*Default:* `""`
+
+// end::fleet-server-es-cert-key[]
 
 // =============================================================================
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -117,12 +117,38 @@ contains your CA's certificate.
 [id="env-{type}-fleet-force"]
 `FLEET_FORCE`
 
-| (int) Set to `1` to force overwrite of the current configuration without prompting for confirmation.
+| (bool) Set to `true` to force overwrite of the current {agent} configuration without prompting for confirmation.
 This flag is helpful when using automation software or scripted deployments.
+
+*Default:* `false`
+
+// end::fleet-force[]
+
+// =============================================================================
+
+// tag::fleet-header[]
+|
+[id="env-{type}-fleet-header"]
+`FLEET_HEADER`
+
+| (string) Specify any headers that that {agent} should send to {fleet-server} during enrollment.
 
 *Default:* none
 
-// end::fleet-force[]
+// end::fleet-header[]
+
+// =============================================================================
+
+// tag::fleet-kibana-header[]
+|
+[id="env-{type}-fleet-kibana-header"]
+`FLEET_KIBANA_HEADER`
+
+| (string) Specify any headers that that {agent} should send when contacting {kib}.
+
+*Default:* none
+
+// end::fleet-kibana-header[]
 
 // =============================================================================
 
@@ -347,6 +373,42 @@ by {agent} for communication. This flag is required when using self-signed certi
 *Default:* `""`
 
 // end::fleet-server-es-cert-key[]
+
+// =============================================================================
+
+// tag::fleet-server-insecure-http[]
+|
+[id="env-{type}-fleet-server-insecure-http"]
+`FLEET_SERVER_INSECURE_HTTP`
+
+| (bool) When `true`, {fleet-server} is exposed over insecure or unverified HTTP.
+Setting this to `true` is not recommended.
+
+*Default:* `false`
+
+// end::fleet-server-insecure-http[]
+
+// =============================================================================
+
+// tag::fleet-daemon-timeout[]
+|
+[id="env-{type}-fleet-daemon-timeout"]
+`FLEET_DAEMON_TIMEOUT`
+
+| (duration) Set to indicate how long {fleet-server} will wait during the bootstrap process for {elastic-agent}.
+
+// end::fleet-daemon-timeout[]
+
+// =============================================================================
+
+// tag::fleet-server-timeout[]
+|
+[id="env-{type}-fleet-server-timeout"]
+`FLEET_SERVER_TIMEOUT`
+
+| (duration) Set to indicate how long {agent} will wait for {fleet-server} to check in as healthy.
+
+// end::fleet-server-timeout[]
 
 // =============================================================================
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -22,7 +22,7 @@ OPTIONAL INFO AND EXAMPLE
 [id="env-{type}-elastic-agent-cert"]
 `ELASTIC_AGENT_CERT`
 
-| (string) The path to the mutual TLS client certificate that that {agent} will use to connect to {fleet-server}.
+| (string) The path to the mutual TLS client certificate that {agent} will use to connect to {fleet-server}.
 
 // end::elastic-agent-cert[]
 
@@ -33,7 +33,7 @@ OPTIONAL INFO AND EXAMPLE
 [id="env-{type}-elastic-agent-cert-key"]
 `ELASTIC_AGENT_CERT_KEY`
 
-| (string) The path to the mutual TLS private key that that {agent} will use to connect to {fleet-server}.
+| (string) The path to the mutual TLS private key that {agent} will use to connect to {fleet-server}.
 
 // end::elastic-agent-cert-key[]
 
@@ -131,7 +131,7 @@ This flag is helpful when using automation software or scripted deployments.
 [id="env-{type}-fleet-header"]
 `FLEET_HEADER`
 
-| (string) Specify any headers that that {agent} should send to {fleet-server} during enrollment.
+| (string) Specify any headers that {agent} should send to {fleet-server} during enrollment.
 
 *Default:* none
 
@@ -144,7 +144,7 @@ This flag is helpful when using automation software or scripted deployments.
 [id="env-{type}-fleet-kibana-header"]
 `FLEET_KIBANA_HEADER`
 
-| (string) Specify any headers that that {agent} should send when contacting {kib}.
+| (string) Specify any headers that {agent} should send when contacting {kib}.
 
 *Default:* none
 
@@ -355,7 +355,7 @@ by {agent} for communication. This flag is required when using self-signed certi
 [id="env-{type}-fleet-server-es-cert"]
 `FLEET_SERVER_ES_CERT`
 
-| (string) The path to the mutual TLS client certificate that that {fleet-server} will use to connect to {es}.
+| (string) The path to the mutual TLS client certificate that {fleet-server} will use to connect to {es}.
 
 *Default:* `""`
 
@@ -368,7 +368,7 @@ by {agent} for communication. This flag is required when using self-signed certi
 [id="env-{type}-fleet-server-es-cert-key"]
 `FLEET_SERVER_ES_CERT_KEY`
 
-| (string) The path to the mutual TLS private key that that {fleet-server} will use to connect to {es}.
+| (string) The path to the mutual TLS private key that {fleet-server} will use to connect to {es}.
 
 *Default:* `""`
 

--- a/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/env/shared-env.asciidoc
@@ -329,7 +329,7 @@ Overrides the port defined in the policy.
 {fleet-server}'s client authentication option for client mTLS connections.
 If `optional` or `required` is specified, client certificates are verified using CAs.
 
-*Default:* none
+*Default:* `none`
 
 // end::fleet-server-client-auth[]
 


### PR DESCRIPTION
This updates the [Elastic Agent environment variables](https://www.elastic.co/guide/en/fleet/current/agent-environment-variables.html) page to add/remove variables as described [here](https://github.com/elastic/ingest-docs/issues/1075#issuecomment-2362112155).

For easier reviewing, I've copied the output into [this google doc](https://docs.google.com/document/d/10NH4LMPZksG2R7-sd3lKbxms_-PZzxpy05z4kfna7NE/edit).

Removed variables:

 - `KIBANA_FLEET_SETUP ` has been removed for a while: https://github.com/elastic/elastic-agent/issues/2910

Added variables:

- `FLEET_FORCE` - same as the `--force flag`
- `ELASTIC_AGENT_CERT` & `ELASTIC_AGENT_CERT_KEY` - paths to mtls cert and key the agent will use to connect to fleet-server. (corresponding var for passphrase is missing)
- `FLEET_SERVER_CLIENT_AUTH` - set fleet-server mtls settings, one of: `none` (default), `optional`, `required`
- `FLEET_SERVER_ES_CERT` & `FLEET_SERVER_ES_CERT_KEY` - fleet-server -> es mTLS cert paths. (corresponding var for passphrase is missing)
- `FLEET_SERVER_INSECURE_HTTP` - expose fleet-server as an http server
- ~~`FLEET_HEADER` - I think this one is headers the agent will send to fleet-server~~ (internal setting according to Craig)
- ~~`FLEET_KIBANA_HEADER` - headers used when contacting Kibana~~  (internal setting according to Craig)
- `FLEET_SERVER_TIMEOUT` - how long elastic-agent will wait for fleet-server to checkin as healthy
- `FLEET_DAEMON_TIMEOUT` - how long fleet-server will wait during the bootstrap process for elastic-agent


Closes: https://github.com/elastic/ingest-docs/issues/1355
Rel: #1075