### PR TITLE
Fix uninstall warning about current directory

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -1106,15 +1106,18 @@ to remove files.
 
 [IMPORTANT]
 ====
-Be sure to run the `uninstall` command from the directory where {agent} is installed and not from the directory where you previously ran the `install` command.
+Be sure to run the `uninstall` command from the directory outside where {agent} is installed.
 
---
+For example, on a Windows system the install location is `C:\Program Files\Elastic\Agent`. Run the uninstall command from `C:\Program Files\Elastic` or `\tmp`, or even your default home directory:
 
-include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/uninstall-widget.asciidoc[]
-
---
+[source,shell]
+----
+C:\"Program Files"\Elastic\Agent\elastic-agent.exe uninstall
+----
 
 ====
+
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/uninstall-widget.asciidoc[]
 
 [discrete]
 === Synopsis

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -1106,7 +1106,7 @@ to remove files.
 
 [IMPORTANT]
 ====
-Be sure to run the `uninstall` command from the directory outside where {agent} is installed.
+Be sure to run the `uninstall` command from a directory outside of where {agent} is installed.
 
 For example, on a Windows system the install location is `C:\Program Files\Elastic\Agent`. Run the uninstall command from `C:\Program Files\Elastic` or `\tmp`, or even your default home directory:
 

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -7,7 +7,18 @@
 To uninstall {agent}, run the `uninstall` command from the directory where
 {agent} is running.
 
-IMPORTANT: Be sure to run the `uninstall` command from the directory where {agent} is running, as shown in the example below, and not from the directory where you previously ran the `install` command. Running the command from the wrong directory can leave the agent in an inconsistent state.
+[IMPORTANT]
+====
+Be sure to run the `uninstall` command from the directory outside where {agent} is installed.
+
+For example, on a Windows system the install location is `C:\Program Files\Elastic\Agent`. Run the uninstall command from `C:\Program Files\Elastic` or `\tmp`, or even your default home directory:
+
+[source,shell]
+----
+C:\"Program Files"\Elastic\Agent\elastic-agent.exe uninstall
+----
+
+====
 
 --
 include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/uninstall-widget.asciidoc[]

--- a/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/uninstall-elastic-agent.asciidoc
@@ -9,7 +9,7 @@ To uninstall {agent}, run the `uninstall` command from the directory where
 
 [IMPORTANT]
 ====
-Be sure to run the `uninstall` command from the directory outside where {agent} is installed.
+Be sure to run the `uninstall` command from a directory outside of where {agent} is installed.
 
 For example, on a Windows system the install location is `C:\Program Files\Elastic\Agent`. Run the uninstall command from `C:\Program Files\Elastic` or `\tmp`, or even your default home directory:
 


### PR DESCRIPTION
This fixes the warning about running the `elastic-agent uninstall` to indicate that the command shouldn't be run from the directory where agent is installed. This appears in the [command reference](https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-uninstall-command) and the [uninstall instructions page](https://www.elastic.co/guide/en/fleet/current/uninstall-elastic-agent.html#_uninstall_on_macos_linux_and_windows).

Closes: https://github.com/elastic/ingest-docs/issues/1364
Rel: https://github.com/elastic/sdh-beats/issues/5224#issuecomment-2391715465

---

![Screenshot 2024-10-07 at 2 12 05 PM](https://github.com/user-attachments/assets/18604fb5-e7d5-45a4-b022-abdd3dd615c4)

