### PR TITLE
Add documentation in add_cloud_metadata processor about the usage of BEATS_ADD_CLOUD_METADATA_PROVIDERS env var

### DIFF
--- a/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
@@ -60,7 +60,7 @@ include::processors.asciidoc[tag=processor-limitations]
 |
 a| List of provider names to use. If `providers` is not configured,
 all providers that do not access a remote endpoint are enabled by default.
-The list of providers may alternatively be configured with the environment variable BEATS_ADD_CLOUD_METADATA_PROVIDERS,
+The list of providers may alternatively be configured with the environment variable `BEATS_ADD_CLOUD_METADATA_PROVIDERS`,
 by setting it to a comma-separated list of provider names.
 
 The list of supported provider names includes:

--- a/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
+++ b/docs/en/ingest-management/processors/processor-add_cloud_metadata.asciidoc
@@ -60,6 +60,8 @@ include::processors.asciidoc[tag=processor-limitations]
 |
 a| List of provider names to use. If `providers` is not configured,
 all providers that do not access a remote endpoint are enabled by default.
+The list of providers may alternatively be configured with the environment variable BEATS_ADD_CLOUD_METADATA_PROVIDERS,
+by setting it to a comma-separated list of provider names.
 
 The list of supported provider names includes:
 


### PR DESCRIPTION
This PR adds documentation for the usage of `BEATS_ADD_CLOUD_METADATA_PROVIDERS` environment variable.
This variable is alternative way of configuring the list of cloud providers that the processor needs to detect.

It helps in cases where the processor fails to correctly detect the cloud provider.