### PR TITLE
Add docs for 'delete unenrolled agents'

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -139,7 +139,7 @@ For full details about proxy configuration refer to <<fleet-agent-proxy-support,
 
 After an {agent} has been unenrolled in {fleet}, a number of documents about the agent are retained just in case the agent needs to be recovered at some point. You can choose to have all data related to an unenrolled agent deleted automatically.
 
-Note that this option is enabled only if the `xpack.fleet.enableDeleteUnenrolledAgents` setting is not already set to `false` in the {kibana-ref}/[{kib} settings file].
+Note that this option can also be enabled by adding the `xpack.fleet.enableDeleteUnenrolledAgents: true` setting to the {kibana-ref}/[{kib} settings file].
 
 To enable automatic deletion of unenrolled agents:
 

--- a/docs/en/ingest-management/fleet/fleet-settings.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings.asciidoc
@@ -132,3 +132,16 @@ in the agent policy.
 
 You can specify a proxy server to be used in {fleet-server}, {agent} outputs, or for any agent binary download sources. 
 For full details about proxy configuration refer to <<fleet-agent-proxy-support,Using a proxy server with {agent} and {fleet}>>.
+
+[discrete]
+[[delete-unenrolled-agents-setting]]
+== Delete unenrolled agents
+
+After an {agent} has been unenrolled in {fleet}, a number of documents about the agent are retained just in case the agent needs to be recovered at some point. You can choose to have all data related to an unenrolled agent deleted automatically.
+
+Note that this option is enabled only if the `xpack.fleet.enableDeleteUnenrolledAgents` setting is not already set to `false` in the {kibana-ref}/[{kib} settings file].
+
+To enable automatic deletion of unenrolled agents:
+
+. Go to **{fleet} -> Settings**.
+. Under **Advanced Settings**, enable the **Delete unenrolled agents** option.


### PR DESCRIPTION
This adds a section to the [Fleet settings](https://www.elastic.co/guide/en/fleet/master/fleet-settings.html) page for the new 'Delete unenrolled agents' option.

Targets 8.16
Closes: #1376

---

![Screenshot 2024-10-15 at 11 09 44 AM](https://github.com/user-attachments/assets/3fa31cc0-36ca-4dcb-a2a3-7b52a769d3d8)
