### PR TITLE
Add note: integration-level outputs must be at same sub level

### DIFF
--- a/docs/en/ingest-management/integrations/integration-level-outputs.asciidoc
+++ b/docs/en/ingest-management/integrations/integration-level-outputs.asciidoc
@@ -1,9 +1,9 @@
 [[integration-level-outputs]]
 = Set integration-level outputs
 
-If you have an `Enterprise` link:https://www.elastic.co/subscriptions[{stack} subscription], you can configure {agent} data to be sent to different outputs for different integration policies.
-Integration-level outputs are very useful for certain scenarios.
-For example:
+If you have an `Enterprise` link:https://www.elastic.co/subscriptions[{stack} subscription], you can configure {agent} data to be sent to different outputs for different integration policies. Note that the output clusters that you send data to must also be on the same subscription level.
+
+Integration-level outputs are very useful for certain scenarios. For example:
 
 * You can may want to send security logs monitored by an {agent} to one {ls} output, while informational logs are sent to a another {ls} output.
 * If you operate multiple {beats} on a system and want to migrate these to {agent}, integration-level outputs enable you to maintain the distinct outputs that are currently used by each Beat.


### PR DESCRIPTION
This adds a restriction to the [integration-level outputs](https://www.elastic.co/guide/en/fleet/master/integration-level-outputs.html) page.

![Screenshot 2024-10-16 at 6 42 58 PM](https://github.com/user-attachments/assets/cad71473-c90b-4046-8fff-bbea5fb31f27)




