### PR TITLE
Add Fleet & Agent 7.17.25 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.25>>
+
 * <<release-notes-7.17.24>>
 
 * <<release-notes-7.17.23>>
@@ -68,6 +70,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.25 relnotes
+
+[[release-notes-7.17.25]]
+== {fleet} and {agent} 7.17.25
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.25 relnotes
 
 // begin 7.17.24 relnotes
 


### PR DESCRIPTION
This adds the 7.17.24 Fleet & Agent Release Notes:

 - Fleet: No entries in [Kibana RN PR](https://github.com/elastic/kibana/pull/196498)
 - Fleet Server: no new entries in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/7e17c51d72499b7eff1e1ab2e74d82ae5c04b1aa/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/bc2cbf4b71ba456adace751f9da04b065a4091a2/changelog/fragments)

---


![screen](https://github.com/user-attachments/assets/095efb8a-e73d-413e-9074-d71e65c02b13)
