### PR TITLE
Add the ability to backport to `main`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,19 @@ pull_request_rules:
           git merge <remote-repo>/{{base}}
           git push <remote-repo> {{head}}
           ```
+  - name: backport patches to main branch
+    conditions:
+      - merged
+      - label=backport-main
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        labels:
+          - "backport"
+        branches:
+          - "main"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.x branch
     conditions:
       - merged


### PR DESCRIPTION
### Summary

Adds the ability to use `backport-main` to backport to `main`.

Useful when contributors use `edit` links in the public documentation.