### PR TITLE
Fix API docs link

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-api-docs.asciidoc
@@ -1,23 +1,8 @@
 [[fleet-api-docs]]
 = {kib} {fleet} APIs
 
-You can find details for all available {fleet} API endpoints in our generated
-<<fleet-apis,{fleet} API docs>>. This documentation is experimental and may be
-incomplete or change later.
-
-The main source of truth for the {fleet} API can be found in the
-https://github.com/elastic/kibana/blob/main/x-pack/plugins/fleet/common/openapi/bundled.json[self-contained spec file]
-that you can use to generate docs using Swagger or a similar tool.
-For more information, refer to the
-https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI readme].
-
-//However we do provide a self-contained spec file that you can
-//https://petstore.swagger.io/?url=https://raw.githubusercontent.com/elastic/kibana/{branch}/x-pack/plugins/fleet/common/openapi/bundled.json[view in Swagger]
-//(or a similar tool) to explore our Fleet APIs.
-
-//For more information, refer to the
-//https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/fleet/common/openapi/README.md[{fleet} OpenAPI file]
-//in the {kib} repository.
+You can find details for all available {fleet} API endpoints in our generated 
+{api-kibana}[Kibana API docs].
 
 In this section, we provide examples of some commonly used {fleet} APIs.
 


### PR DESCRIPTION
This updates the first paragraph of the [Kibana Fleet APIs](https://www.elastic.co/guide/en/fleet/current/fleet-api-docs.html) page to fix the broken link and point to the new generated API docs [here](https://www.elastic.co/docs/api/doc/kibana).

![Screenshot 2024-10-31 at 12 55 22 PM](https://github.com/user-attachments/assets/6e24d334-4fcd-4ffa-9486-cd7f897c1fa0)

Closes: https://github.com/elastic/ingest-docs/issues/1379

Note: I've left the examples on the page in place, but if these should be revised or moved, I'm happy to do that (separately from this PR).