### PR TITLE
Add Fleet & Agent 8.15.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -30,7 +30,11 @@ Also see:
 [[release-notes-8.15.4]]
 == {fleet} and {agent} 8.15.4
 
-There are no bug fixes for {fleet}, {fleet-server}, or {agent} in this release.
+[discrete]
+[[bug-fixes-8.15.4]]
+=== Bug fixes
+{agent}::
+* Improve upgrade experience by assuming that {agent} is installed, allowing to use proper control socket path to communicate with running {agent}. {agent-pull}5879[#5879]
 
 // end 8.15.4 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -33,6 +33,7 @@ Also see:
 [discrete]
 [[bug-fixes-8.15.4]]
 === Bug fixes
+
 {agent}::
 * Improve upgrade experience by assuming that {agent} is installed, allowing to use proper control socket path to communicate with running {agent}. {agent-pull}5879[#5879]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -30,27 +30,7 @@ Also see:
 [[release-notes-8.15.4]]
 == {fleet} and {agent} 8.15.4
 
-Review important information about the {fleet} and {agent} 8.15.4 release.
-
-[discrete]
-[[security-updates-8.15.4]]
-=== Security updates
-
-{agent}::
-//* Update Go version to 1.22.8. {agent-pull}5718[#5718]
-
-[discrete]
-[[enhancements-8.15.4]]
-
-=== Enhancements
-
-{agent}::
-
-[discrete]
-[[bug-fixes-8.15.4]]
-=== Bug fixes
-
-{agent}::
+There are no bug fixes for {fleet}, {fleet-server}, or {agent} in this release.
 
 // end 8.15.4 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.15.4>>
 * <<release-notes-8.15.3>>
 * <<release-notes-8.15.2>>
 * <<release-notes-8.15.1>>
@@ -23,6 +24,35 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.15.4 relnotes
+
+[[release-notes-8.15.4]]
+== {fleet} and {agent} 8.15.4
+
+Review important information about the {fleet} and {agent} 8.15.4 release.
+
+[discrete]
+[[security-updates-8.15.4]]
+=== Security updates
+
+{agent}::
+//* Update Go version to 1.22.8. {agent-pull}5718[#5718]
+
+[discrete]
+[[enhancements-8.15.4]]
+
+=== Enhancements
+
+{agent}::
+
+[discrete]
+[[bug-fixes-8.15.4]]
+=== Bug fixes
+
+{agent}::
+
+// end 8.15.4 relnotes
 
 // begin 8.15.3 relnotes
 


### PR DESCRIPTION
This adds the 8.15.4 Fleet & Elastic Agent Release Notes:

* No Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/198565)
* No Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/940c4d76aa0a8d48b508c51615a0def586974494/changelog/fragments)
* No Elastic Agent contents in [BC1 changelog](https://github.com/elastic/elastic-agent/tree/099e5882ccda4cbc344ab8cc8f18e631325fa439/changelog/fragments)

---

![Screenshot 2024-11-04 at 1 55 52 PM](https://github.com/user-attachments/assets/987e1849-6b14-49a7-80d3-50a693a53598)
