### PR TITLE
Add a note about the agent status table limit of 10k records

### DIFF
--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -72,6 +72,8 @@ using {kibana-ref}/kuery-query.html[{kib} Query Language]. For example, enter
 
 You can also sort the list of agents by host, last activity time, or version, by clicking on the table headings for those fields. 
 
+To perform a bulk action on more than 10,000 agents, you can select the **Select everything on all pages** button.
+
 [discrete]
 [[view-agent-details]]
 = View details for an agent

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -33,6 +33,8 @@ To view the overall status of your {fleet}-managed agents, in {kib}, go to
 [role="screenshot"]
 image::images/kibana-fleet-agents.png[Agents tab showing status of each {agent}]
 
+IMPORTANT: The **Agents** tab in **{fleet}** displays a maximum of 10,000 agents, shown on 500 pages with 20 rows per page. If you have more than 10,000 agents, we recommend using the filtering and sorting options described in this section to narrow the table to fewer than 10,000 rows.
+
 {agent}s can have the following statuses:
 
 |===
@@ -66,6 +68,8 @@ image::images/agent-status-filter.png[Agent Status dropdown with multiple status
 For advanced filtering, use the search bar to create structured queries
 using {kibana-ref}/kuery-query.html[{kib} Query Language]. For example, enter
 `local_metadata.os.family : "darwin"` to see only agents running on macOS.
+
+You can also sort the list of agents by host, last activity time, or version, by clicking on the table headings for those fields. 
 
 [discrete]
 [[view-agent-details]]

--- a/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/monitor-elastic-agent.asciidoc
@@ -33,7 +33,8 @@ To view the overall status of your {fleet}-managed agents, in {kib}, go to
 [role="screenshot"]
 image::images/kibana-fleet-agents.png[Agents tab showing status of each {agent}]
 
-IMPORTANT: The **Agents** tab in **{fleet}** displays a maximum of 10,000 agents, shown on 500 pages with 20 rows per page. If you have more than 10,000 agents, we recommend using the filtering and sorting options described in this section to narrow the table to fewer than 10,000 rows.
+IMPORTANT: The **Agents** tab in **{fleet}** displays a maximum of 10,000 agents, shown on 500 pages with 20 rows per page.
+If you have more than 10,000 agents, we recommend using the filtering and sorting options described in this section to narrow the table to fewer than 10,000 rows.
 
 {agent}s can have the following statuses:
 


### PR DESCRIPTION
The updates [View agent status overview](https://www.elastic.co/guide/en/fleet/current/monitor-elastic-agent.html#view-agent-status) to note that the table is limited to 10k records.

Closes: #296

---

![Screenshot 2024-11-04 at 12 43 05 PM](https://github.com/user-attachments/assets/5e190589-aa34-4126-89c3-11ef6e14479f)

---

This also adds a note about the table sorting:

---

![Screenshot 2024-11-05 at 9 34 44 AM](https://github.com/user-attachments/assets/a6a8cd55-925c-4b03-b5bf-0c6d3f24adea)


