### PR TITLE
Move section about Logstash to bottom of Kafka output page

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -5,33 +5,7 @@
 
 Specify these settings to send data over a secure connection to Kafka. In the {fleet} <<output-settings,Output settings>>, make sure that the Kafka output type is selected. 
 
-== Kafka output and using {ls} to index data to {es}
-
-If you are considering using {ls} to ship the data from `kafka` to {es}, please
-be aware the structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
-We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec in order
-to make sure the input doesn't edit the fields and their contents.
-
-The data streams setup by the integrations expect to receive events having the same structure and
-field names as they were sent directly from an {agent}.
-
-The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
-We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
-
-Refer to the <<ls-output-settings,{ls} output for {agent}>> documentation for more details.
-
-[source,yaml]
-----
-inputs {
-  kafka {
-    ...
-    ecs_compatibility => "disabled"
-    codec => json { ecs_compatibility => "disabled" }
-    ...
-  }
-}
-...
-----
+NOTE: If you plan to use {ls} to modify {agent} output data before it's sent to Kafka, please refer to our <<kafka-output-settings-ls-warning,guidance>> for doing so, further in on this page.
 
 [discrete]
 == General settings
@@ -569,5 +543,34 @@ include::../elastic-agent/configuration/outputs/output-shared-settings.asciidoc[
 // =============================================================================
 
 |===
+
+[[kafka-output-settings-ls-warning]]
+== Kafka output and using {ls} to index data to {es}
+
+If you are considering using {ls} to ship the data from `kafka` to {es}, please
+be aware the structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
+We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec in order
+to make sure the input doesn't edit the fields and their contents.
+
+The data streams setup by the integrations expect to receive events having the same structure and
+field names as they were sent directly from an {agent}.
+
+The structure of the documents sent from {agent} to `kafka` must not be modified by {ls}.
+We suggest disabling `ecs_compatibility` on both the `kafka` input and the `json` codec.
+
+Refer to the <<ls-output-settings,{ls} output for {agent}>> documentation for more details.
+
+[source,yaml]
+----
+inputs {
+  kafka {
+    ...
+    ecs_compatibility => "disabled"
+    codec => json { ecs_compatibility => "disabled" }
+    ...
+  }
+}
+...
+----
 
 :type!:


### PR DESCRIPTION
At the top of the [Kafka output settings](https://www.elastic.co/guide/en/fleet/current/kafka-output-settings.html#_kafka_output_and_using_logstash_to_index_data_to_elasticsearch) page is a section warning users about potential problems when they use use Logstash to modify the Kafka output on its way to Elasticsearch. It's not ideal for all users to start their Kafka output journey with that section.

I think it'd be better to have that section at the bottom of the Kafka output settings page, and to make sure people find the section we can add a warning at the top of the page, like this:

![screen](https://github.com/user-attachments/assets/46380504-fee6-43e4-9118-1ece09de9b72)

---

The guidance for Logstash appears just as before, but at the bottom of the page:

---

![Screenshot 2024-11-04 at 5 53 08 PM](https://github.com/user-attachments/assets/89c6b9de-989d-4554-9ab9-37d0217984e8)


---

@lucabelluccini, @nimarezainia  Any thoughts or concerns?