### PR TITLE
Update Kafka Output settings documentation to indicate minimum version value for Kafka 4.0

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-output-kafka.asciidoc
@@ -19,7 +19,7 @@ NOTE: If you plan to use {ls} to modify {agent} output data before it's sent to 
 | The Kafka protocol version that {agent} will request when connecting. 
 Defaults to `1.0.0`.
 Currently Kafka versions from `0.8.2.0` to `2.6.0` are supported, however the latest 
-Kafka version (`3.x.x`) is expected to be compatible when version `2.6.0` is selected.
+Kafka version (`3.x.x`) is expected to be compatible when version `2.6.0` is selected. When using Kafka 4.0 and newer, the version must be set to at least `2.1.0`.
 
 // =============================================================================
 


### PR DESCRIPTION
Update Elastic Agent documents to indicate that the protocol version should be set to at least `2.1.0` when using Kafka 4.0

Related:
https://github.com/elastic/integrations/pull/11655
https://github.com/elastic/beats/pull/41540