### PR TITLE
Wording tweak to agent resource requirements table

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -84,7 +84,7 @@ These tests are representative of use cases that attempt to ingest data as fast 
 [options,header]
 |===
 | **Resource** | **Throughput** | **Scale**
-| **CPU*** | ~67% total | ~20%
+| **CPU*** | ~67% | ~20%
 | **RSS memory size*** | ~280 MB | ~220 MB
 | **Write network throughput** | ~3.5 MB/s | 480 KB/s
 |===


### PR DESCRIPTION
Removing the word "total" from the agent resource requirements table to make the columns consistent on CPU metrics.