### PR TITLE
Update output-elasticsearch.asciidoc

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -104,6 +104,7 @@ outputs:
 `https://10.45.3.1:9230/elasticsearch`.
 // end::hosts-setting[]
 
+Note that Elasticsearch Nodes on link:{serverless-docs}[{serverless-full}] environment are exposed on port 443.
 // =============================================================================
 
 // tag::protocol-setting[]

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-elasticsearch.asciidoc
@@ -102,9 +102,10 @@ outputs:
 <1> In this example, the {es} nodes are available at
 `https://10.45.3.2:9220/elasticsearch` and
 `https://10.45.3.1:9230/elasticsearch`.
+
+Note that Elasticsearch Nodes in the link:{serverless-docs}[{serverless-full}] environment are exposed on port 443.
 // end::hosts-setting[]
 
-Note that Elasticsearch Nodes on link:{serverless-docs}[{serverless-full}] environment are exposed on port 443.
 // =============================================================================
 
 // tag::protocol-setting[]


### PR DESCRIPTION
This PR adds a note that elasticsearch nodes on elastic cloud are exposed on port 443. This will help avoid some common pitfalls while configuring ES. 