### PR TITLE
Fix link to 8.15.x memory queue issue in Beats.

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -59,7 +59,7 @@ Review important information about the {fleet} and {agent} 8.15.3 release.
 
 In 8.15, events in the memory queue are not freed when they are acknowledged (as intended), but only when they are overwritten by later events in the queue buffer. This means for example if a configuration has a queue size of 5000, but the input data is low-volume and only 100 events are active at once, then the queue will gradually store more events until reaching 5000 in memory at once, then start replacing those with new events.
 
-See {beats} issue link:https://github.com/elastic/beats/issues/40705[#40705].
+See {beats} issue link:https://github.com/elastic/beats/issues/41355[#41355].
 
 *Impact* +
 
@@ -117,7 +117,7 @@ Review important information about the {fleet} and {agent} 8.15.2 release.
 
 In 8.15, events in the memory queue are not freed when they are acknowledged (as intended), but only when they are overwritten by later events in the queue buffer. This means for example if a configuration has a queue size of 5000, but the input data is low-volume and only 100 events are active at once, then the queue will gradually store more events until reaching 5000 in memory at once, then start replacing those with new events.
 
-See {beats} issue link:https://github.com/elastic/beats/issues/40705[#40705].
+See {beats} issue link:https://github.com/elastic/beats/issues/41355[#41355].
 
 *Impact* +
 
@@ -226,7 +226,7 @@ same package versions.
 
 In 8.15, events in the memory queue are not freed when they are acknowledged (as intended), but only when they are overwritten by later events in the queue buffer. This means for example if a configuration has a queue size of 5000, but the input data is low-volume and only 100 events are active at once, then the queue will gradually store more events until reaching 5000 in memory at once, then start replacing those with new events.
 
-See {beats} issue link:https://github.com/elastic/beats/issues/40705[#40705].
+See {beats} issue link:https://github.com/elastic/beats/issues/41355[#41355].
 
 *Impact* +
 
@@ -285,7 +285,7 @@ If you're using {agent} on Windows with any integration which makes use of the A
 
 In 8.15, events in the memory queue are not freed when they are acknowledged (as intended), but only when they are overwritten by later events in the queue buffer. This means for example if a configuration has a queue size of 5000, but the input data is low-volume and only 100 events are active at once, then the queue will gradually store more events until reaching 5000 in memory at once, then start replacing those with new events.
 
-See {beats} issue link:https://github.com/elastic/beats/issues/40705[#40705].
+See {beats} issue link:https://github.com/elastic/beats/issues/41355[#41355].
 
 *Impact* +
 


### PR DESCRIPTION
There was a copy/paste error linking to the network connection issue in the wrong place.