### PR TITLE
Update bulk_reassign_agents_request to include batchSize body parameter

### DIFF
--- a/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
+++ b/docs/en/ingest-management/fleet/api-generated/rules/fleet-apis-passthru.asciidoc
@@ -7436,6 +7436,7 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">policy_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> new agent policy id </div>
+      <div class="param">batchSize (optional)</div><div class="param-desc"><span class="param-type"><a href="#number">Big Decimal</a></span>  </div>
 <div class="param">agents </div><div class="param-desc"><span class="param-type"><a href="#bulk_reassign_agents_request_agents">bulk_reassign_agents_request_agents</a></span>  </div>
     </div>  <!-- field-items -->
   </div>


### PR DESCRIPTION
This change documents the ability to leverage a `batchSize` body parameter for the `bulk_reassign_agents_request` which was introduced in the following PR: https://github.com/elastic/kibana/pull/134565

This will also help align the documentation with the following Kibana API docs: https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-agents-bulk-reassign