### PR TITLE
Add known issues for 'no agent found', Agent uninstall exception

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -109,9 +109,7 @@ This problem occurs when {agent} notifies {fleet} to audit the uninstall process
 
 *Impact* +
 
-This issue prevents {agent} from being uninstalled on Windows systems.
-
-We're currently investigating the issue and will update this page when a workaround becomes available.
+As a workaround, we recommend trying again to uninstall the agent.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -74,7 +74,7 @@ As a workaround for the issue, you can upgrade your {stack} to verion 8.16.1. Th
 
 *Details*
 
-{agent} sometimes throws an exception when uninstalling on Microsoft Windows systems.
+{fleet}-managed {agent} sometimes throws an exception when uninstalling on Microsoft Windows systems.
 
 For example:
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -63,7 +63,7 @@ This error can happen if the {agents} being searched and listed in the UI are us
 
 *Impact* +
 
-As a workaround for the issue, you can upgrade your {stack} to verion 8.16.1. The issue has been resolved by {kibana} link:https://github.com/elastic/kibana/pull/199325[#199325]. 
+As a workaround for the issue, you can upgrade your {stack} to verion 8.16.1. The issue has been resolved by {kib} link:https://github.com/elastic/kibana/pull/199325[#199325]. 
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -47,6 +47,27 @@ impact to your application.
 * When using the System integration, uppercase characters in the `host.hostname` are being converted to lowercase in {agent} output. This can possibly result in duplicated host entries appearing in {kib}. {beats-issue}39993[#3993]
 
 [discrete]
+[[known-issues-8.16.0]]
+=== Known issues
+
+[[known-issue-191661]]
+.{fleet} UI listing shows "No agent found"
+[%collapsible]
+====
+
+*Details*
+
+In the {fleet} UI in {kib}, the listing {agents} might show "No agent found" with a toast message "Error fetching agents" or "Agent policy ... not found".
+
+This error can happen if the {agents} being searched and listed in the UI are using an {agent} policy which doesn't exist.
+
+*Impact* +
+
+To resolve this issue, upgrade your {stack} to verion 8.16.1 in which the problem is fixed.
+
+====
+
+[discrete]
 [[new-features-8.16.0]]
 === New features
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -111,10 +111,7 @@ This problem occurs when {agent} notifies {fleet} to audit the uninstall process
 
 This issue prevents {agent} from being uninstalled on Windows systems.
 
-As a workaround you can...
-
-//* Upgrade your {stack}?
-//* Force uninstall the agent using a command?
+We're currently investigating the issue and will update this page when a workaround becomes available.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -63,7 +63,7 @@ This error can happen if the {agents} being searched and listed in the UI are us
 
 *Impact* +
 
-To resolve this issue, upgrade your {stack} to verion 8.16.1 in which the problem is fixed.
+As a workaround for the issue, you can upgrade your {stack} to verion 8.16.1. The issue has been resolved by {kibana} link:https://github.com/elastic/kibana/pull/199325[#199325]. 
 
 ====
 
@@ -109,7 +109,12 @@ This problem occurs when {agent} notifies {fleet} to audit the uninstall process
 
 *Impact* +
 
-TBD
+This issue prevents {agent} from being uninstalled on Windows systems.
+
+As a workaround you can...
+
+//* Upgrade your {stack}?
+//* Force uninstall the agent using a command?
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -67,6 +67,52 @@ To resolve this issue, upgrade your {stack} to verion 8.16.1 in which the proble
 
 ====
 
+[[known-issue-5952]]
+.{agent} throws exception when uninstalling on Windows
+[%collapsible]
+====
+
+*Details*
+
+{agent} sometimes throws an exception when uninstalling on Microsoft Windows systems.
+
+For example:
+
+[source,shell]
+----
+C:\>"C:\Program Files\Elastic\Agent\elastic-agent.exe" uninstall
+Elastic Agent will be uninstalled from your system at C:\Program Files\Elastic\Agent. Do you want to continue? [Y/n]:y
+[====] Attempting to notify Fleet of uninstall  [37s] unexpected fault address 0x18000473ef1
+fatal error: fault
+[signal 0xc0000005 code=0x1 addr=0x18000473ef1 pc=0x9f3004]
+
+goroutine 1 gp=0xc00007c000 m=5 mp=0xc000116008 [running]:
+runtime.throw({0x207a4ba?, 0xa2d986?})
+        runtime/panic.go:1023 +0x65 fp=0xc000067588 sp=0xc000067558 pc=0xcf8c5
+runtime.sigpanic()
+        runtime/signal_windows.go:414 +0xd0 fp=0xc0000675d0 sp=0xc000067588 pc=0xe6a10
+(...)
+        github.com/elastic/elastic-agent/internal/pkg/agent/errors/generators.go:23
+github.com/elastic/elastic-agent/internal/pkg/fleetapi.(*AuditUnenrollCmd).Execute(0xc00073f998, {0x4, 0x23cf148}, 0x0)
+        github.com/elastic/elastic-agent/internal/pkg/fleetapi/audit_unenroll_cmd.go:74 +0x324 fp=0xc000067738 sp=0xc0000675d0 pc=0x9f3004
+runtime: g 1: unexpected return pc for github.com/elastic/elastic-agent/internal/pkg/fleetapi.(*AuditUnenrollCmd).Execute called from 0xc0006817a0
+stack: frame={sp:0xc0000675d0, fp:0xc000067738} stack=[0xc000064000,0xc000068000)
+0x000000c0000674d0:  0x000000c000067508  0x00000000000d14af <runtime.gwrite+0x00000000000000ef>
+0x000000c0000674e0:  0x00000000023c9c90  0x0000000000000001
+0x000000c0000674f0:  0x0000000000000001  0x000000c00006756b
+(...)
+----
+
+For other examples, refer to {agent} link:https://github.com/elastic/elastic-agent/issues/5952#issuecomment-2475044465[issue #5952].
+
+This problem occurs when {agent} notifies {fleet} to audit the uninstall process.
+
+*Impact* +
+
+TBD
+
+====
+
 [discrete]
 [[new-features-8.16.0]]
 === New features


### PR DESCRIPTION
This adds docs for the known issues:
 - "no agent found", described in Knowledge Center [here](https://support.elastic.dev/knowledge/view/6d9d7467).
 - Fleet-managed agent throws an exception on uninstall in Windows, described in Knowledge Center [here](https://support.elastic.dev/knowledge/view/56de5be4).

Closes:  #1481
Closes: #1482

I'll update the "Impact" section of the second issue as soon as we have a suggested workaround (Blake or Craig, if you can please let me know once we have that).

---

![Screenshot 2024-11-19 at 10 47 19 AM](https://github.com/user-attachments/assets/cbfdb265-5cbc-4aaa-95a7-8fdda54c7e42)


