### PR TITLE
Add Fleet & Agent 8.16.1 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -28,7 +28,7 @@ Also see:
 == {fleet} and {agent} 8.16.1
 
 [discrete]
-[[bug-fixes-8.16.0]]
+[[bug-fixes-8.16.1]]
 === Bug fixes
 
 {agent}::

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -14,12 +14,29 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.16.1>>
 * <<release-notes-8.16.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.16.0 relnotes
+
+[[release-notes-8.16.1]]
+== {fleet} and {agent} 8.16.1
+
+[discrete]
+[[bug-fixes-8.16.0]]
+=== Bug fixes
+
+{agent}::
+* During an {agent} upgrade, resolve paths to a proper value assuming that the upgrading agent is installed. {agent-pull}5879[#5879] {agent-issue}5872[#5872]
+* Trim spaces in the user input accepted by the cli.confirm function. This allows users to enter spaces around the `yes/no` inputs in CLI confirmation prompts. {agent-pull}5909[#5909]
+* Skip calling the `notifyFleetAuditUninstall` function to notify {fleet} on Windows during {agent} uninstall, to significantly reduce likelihood of an exception being thrown. {agent-pull}6065[#6065] {agent-issue}5952[#5952]
+
+// end 8.16.1 relnotes
 
 // begin 8.16.0 relnotes
 


### PR DESCRIPTION
This adds the 8.16.1 Fleet & Elastic Agent Release Notes:

* No Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/200693)
* No Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/98286a5d8869e04e3ff8920b915e86770d89f458/changelog/fragments)
* Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/b6da7f8ebb1d0d06c1f1929dfed8458708a5bedf/changelog/fragments)

Closes: https://github.com/elastic/ingest-docs/issues/1485

---

![screen](https://github.com/user-attachments/assets/6fe0dd48-369b-4426-a793-079d0e7d8f60)
