### PR TITLE
Add mention of reusable integration policies

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -158,7 +158,8 @@ Also see <<create-a-policy-no-ui>>.
 == Add an integration to a policy
 
 An {agent} policy consists of one or more integrations that are applied to the agents enrolled in that policy.
-When you add an integration, the policy created for that integration can be shared with multiple {agent} policies. This reduces the number of integrations policies that you need to actively manage.
+When you add an integration, the policy created for that integration can be shared with multiple {agent} policies.
+This reduces the number of integrations policies that you need to actively manage.
 
 To add a new integration to one or more {agent} policies:
 

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -158,6 +158,8 @@ Also see <<create-a-policy-no-ui>>.
 == Add an integration to a policy
 
 An {agent} policy consists of one or more integrations that are applied to the agents enrolled in that policy.
+When you add an integration, the policy created for that integration can be shared with multiple {agent} policies. This reduces the number of integrations policies that you need to actively manage.
+
 To add a new integration to one or more {agent} policies:
 
 . In {fleet}, click **Agent policies**.

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -6,6 +6,8 @@
 ++++
 
 An <<agent-policy,{agent} policy>> consists of one or more integrations that are applied to the agents enrolled in that policy.
+When you add an integration, the policy created for that integration can be shared with multiple {agent} policies. This reduces the number of integrations policies that you need to actively manage.
+
 To add a new integration to one or more {agent} policies:
 
 . In {kib}, go to the **Integrations** page.

--- a/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
+++ b/docs/en/ingest-management/integrations/add-integration-to-policy.asciidoc
@@ -6,7 +6,8 @@
 ++++
 
 An <<agent-policy,{agent} policy>> consists of one or more integrations that are applied to the agents enrolled in that policy.
-When you add an integration, the policy created for that integration can be shared with multiple {agent} policies. This reduces the number of integrations policies that you need to actively manage.
+When you add an integration, the policy created for that integration can be shared with multiple {agent} policies.
+This reduces the number of integrations policies that you need to actively manage.
 
 To add a new integration to one or more {agent} policies:
 


### PR DESCRIPTION
Requested by NIma, this adds a note to emphasize the new reusuable integration policies feature.

![screen](https://github.com/user-attachments/assets/08070dab-2eee-4918-ac9b-1a06cde2c1d2)
