### PR TITLE
Add Fleet & Agent 8.15.5 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.15.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.15.5>>
 * <<release-notes-8.15.4>>
 * <<release-notes-8.15.3>>
 * <<release-notes-8.15.2>>
@@ -24,6 +25,20 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.15.5 relnotes
+
+[[release-notes-8.15.5]]
+== {fleet} and {agent} 8.15.5
+
+[discrete]
+[[enhancements-8.15.5]]
+=== Enhancements
+
+{agent}::
+* Emit Pod data only for running Pods in the Kubernetes provider. {agent-pull}6011[#6011] {agent-issue}5835[#5835] {agent-issue}5991[#5991]
+
+// end 8.15.5 relnotes
 
 // begin 8.15.4 relnotes
 


### PR DESCRIPTION
This adds the 8.15.5 Fleet & Elastic Agent Release Notes:

* No Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/201050)
* No Fleet Server contents in [BC2 changelog](https://github.com/elastic/fleet-server/tree/2782f7f6466ede97855ed14b014161d059820d0c/changelog/fragments)
* Elastic Agent contents in [BC2 changelog](https://github.com/elastic/elastic-agent/tree/1672605efebb153e23fb89aabe160b2bf0403d93/changelog/fragments)


Closes: https://github.com/elastic/ingest-docs/issues/1497

---

![Screenshot 2024-11-25 at 9 27 07 AM](https://github.com/user-attachments/assets/5d7e2cfb-0228-4270-af3a-05566ef5182d)
