### PR TITLE
Fixed very small typo in air-gapped.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -259,7 +259,7 @@ sub-directories that follow the same convention used by the {artifact-registry}:
 Where:
 +
 * `<artifact_type>` is in the format `beats/elastic-agent`, `fleet-server`, `endpoint-dev`, and so on.
-* `<artifict_name>` is om the format `elastic-agent`, `endpoint-security`, or `fleet-server` and so on.
+* `<artifict_name>` is in the format `elastic-agent`, `endpoint-security`, or `fleet-server` and so on.
 * `arch-package-type` is in the format `linux-x86_64`, `linux-arm64`, `windows_x86_64`, `darwin_x86_64`, or 
 darwin_aarch64`.
 * If you're using the DEB package manager:


### PR DESCRIPTION
Typo fix: "om" replaced with "in"