### PR TITLE
Add Fleet & Agent 7.17.26 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -16,6 +16,8 @@ This section summarizes the changes in each release.
 
 * <<release-notes-7.17.25>>
 
+* <<release-notes-7.17.25>>
+
 * <<release-notes-7.17.24>>
 
 * <<release-notes-7.17.23>>
@@ -70,6 +72,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.26 relnotes
+
+[[release-notes-7.17.26]]
+== {fleet} and {agent} 7.17.26
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.26 relnotes
 
 // begin 7.17.25 relnotes
 


### PR DESCRIPTION
This adds the 7.17.26 Fleet & Agent Release Notes:

 - Fleet: No entries in [Kibana RN PR](https://github.com/elastic/kibana/pull/202122)
 - Fleet Server: no new entries in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/8990f4d35031af38de09b9a460b850823fec6664/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/5b41c60f8a028d1a883be72fb157a1c4ea8aa911/changelog/fragments)

---

![Screenshot 2024-11-28 at 9 43 37 AM](https://github.com/user-attachments/assets/a3170a21-459f-4c9a-a06f-4a89c667c2ec)
