### PR TITLE
Update titles in 'Deployment models' section

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -1,5 +1,5 @@
 [[add-fleet-server-cloud]]
-= Deploy on {ecloud}
+= Deploy {fleet-server} on {ecloud}
 
 To use {fleet} for central management, a <<fleet-server,{fleet-server}>> must
 be running and accessible to your hosts.

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -1,5 +1,5 @@
 [[add-fleet-server-on-prem]]
-= Deploy on-premises and self-managed
+= Deploy {fleet-server} on-premises and self-managed
 
 To use {fleet} for central management, a <<fleet-server,{fleet-server}>> must
 be running and accessible to your hosts.

--- a/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-deployment-models.asciidoc
@@ -1,5 +1,5 @@
 [[fleet-deployment-models]]
-= Deployment models
+= {fleet} Deployment models
 
 There are various models for setting up {agents} to work with {es}.
 The recommended approach is to use {fleet}, a web-based UI in Kibana, to centrally manage all of your {agents} and their policies.


### PR DESCRIPTION
Edu had [some feedback](https://github.com/elastic/ingest-docs/issues/1511) on improving the titles in the "Deployment models" section to make more clear that this is about Fleet, and also to improve consistency.

Closes: https://github.com/elastic/ingest-docs/issues/1511


---

**Original:**
![Screenshot 2024-12-02 at 10 13 47 AM](https://github.com/user-attachments/assets/7b0b400f-572d-40d2-8b43-4708f8554b62)


**Updated:**
![Screenshot 2024-12-02 at 10 12 01 AM](https://github.com/user-attachments/assets/5dcc3055-2797-4c52-a7f8-cf37e67b9299)


