### PR TITLE
Updated docs about the new flag --skip-fleet-audit to skip fleet audit/unenroll during agent uninstall

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -1164,6 +1164,9 @@ elastic-agent uninstall [--force] [--help] [global-flags]
 Uninstall {agent} and do not prompt for confirmation. This flag is helpful
 when using automation software or scripted deployments.
 
+`--skip-fleet-audit`::
+Skip notifying / auditing the fleet server.
+
 `--help`::
 Show help for the `uninstall` command.
 

--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -1165,7 +1165,7 @@ Uninstall {agent} and do not prompt for confirmation. This flag is helpful
 when using automation software or scripted deployments.
 
 `--skip-fleet-audit`::
-Skip notifying / auditing the fleet server.
+Skip auditing with the fleet server.
 
 `--help`::
 Show help for the `uninstall` command.


### PR DESCRIPTION
Updated docs about the new flag (--skip-fleet-audit)  to skip fleet audit/unenroll during agent uninstall. 

Must be merged after merging the below PR:
https://github.com/elastic/elastic-agent/pull/6206