### PR TITLE
Update agent-policies.asciidoc

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -305,6 +305,7 @@ Note that adding custom tags is not supported for a small set of inputs:
 * `cloud-defend`
 * `fleet-server`
 * `pf-elastic-collector`, `pf-elastic-symbolizer`, and `pf-host-agent`
+* `endpoint` inputs. Instead, utilize the advanced settings(*.advanced.document_enrichment.fields) of the Elastic Defend Integration.
 
 
 [discrete]


### PR DESCRIPTION
Defend Integration ignores the Custom Fields added in Agent Policy UI as it uses the advanced settings below in the Elastic Defend Integration configuration:
- `windows.advanced.document_enrichment.fields`
- `mac.advanced.document_enrichment.fields`
- `linux.advanced.document_enrichment.fields`
![image](https://github.com/user-attachments/assets/19fde165-d2b7-4b19-862e-3ea9c61068d4)