### PR TITLE
Update docs to indicate that providers are no longer enabled by default

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -91,7 +91,7 @@ configuration.
 
 [discrete]
 [[enable-providers-by-default]]
-=== Enabling providers By default
+=== Disabling Providers By Default
 
 All registered providers are disabled by default until they are referenced in a policy.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -35,8 +35,7 @@ providers:
       - item: key2
 ----
 
-Providers are disabled by default.
-Explicitly enable a provider by setting `enabled: true`.
+Providers are enabled automatically if a provider is referenced in an {agent} policy.
 All providers are prefixed without name collisions.
 The name of the provider is in the key in the configuration.
 
@@ -96,7 +95,7 @@ configuration.
 
 All registered providers are disabled by default.
 
-Enable all providers by default and only disable explicitly configured providers by setting `agent.providers.initial_default: true`.
+Disable all providers by default and only enable explicitly configured providers by setting `agent.providers.initial_default: false`.
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -97,12 +97,14 @@ All registered providers are disabled by default until they are referenced in a 
 
 You can disable all providers even if they are referenced in a policy by setting `agent.providers.initial_default: false`.
 
+The following configuration disables all providers from running except for the docker provider, if it becomes referenced in the policy:
+
 [source,yaml]
 ----
-agent.providers.initial_default: true
+agent.providers.initial_default: false
 providers:
   docker:
-    enabled: false
+    enabled: true
 ----
 
 include::local-provider.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -95,7 +95,7 @@ configuration.
 
 All registered providers are disabled by default.
 
-Disable all providers by default and only enable explicitly configured providers by setting `agent.providers.initial_default: false`.
+You can disable all providers even if they are referenced in a policy by setting `agent.providers.initial_default: false`.
 
 [source,yaml]
 ----

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -90,7 +90,7 @@ configuration.
 * <<kubernetes-provider,Kubernetes Provider>>
 
 [discrete]
-[[enable-providers-by-default]]
+[[disable-providers-by-default]]
 === Disabling Providers By Default
 
 All registered providers are disabled by default until they are referenced in a policy.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -93,7 +93,7 @@ configuration.
 [[enable-providers-by-default]]
 === Enabling providers By default
 
-All registered providers are disabled by default.
+All registered providers are disabled by default until they are referenced in a policy.
 
 You can disable all providers even if they are referenced in a policy by setting `agent.providers.initial_default: false`.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/elastic-agent-providers.asciidoc
@@ -35,8 +35,10 @@ providers:
       - item: key2
 ----
 
-Explicitly disable a provider by setting `enabled: false`. All providers
-are prefixed without name collisions. The name of the provider is in the key in the configuration.
+Providers are disabled by default.
+Explicitly enable a provider by setting `enabled: true`.
+All providers are prefixed without name collisions.
+The name of the provider is in the key in the configuration.
 
 [source,yaml]
 ----
@@ -89,19 +91,19 @@ configuration.
 * <<kubernetes-provider,Kubernetes Provider>>
 
 [discrete]
-[[disable-providers-by-default]]
-=== Disabling Providers By Default
+[[enable-providers-by-default]]
+=== Enabling providers By default
 
-All registered providers are enabled by default.
+All registered providers are disabled by default.
 
-Disable all providers by default and only enable explicitly configured providers by setting `agent.providers.initial_default: false`.
+Enable all providers by default and only disable explicitly configured providers by setting `agent.providers.initial_default: true`.
 
 [source,yaml]
 ----
-agent.providers.initial_default: false
+agent.providers.initial_default: true
 providers:
   docker:
-    enabled: true
+    enabled: false
 ----
 
 include::local-provider.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -23,8 +23,7 @@ providers.kubernetes_leaderelection:
   #leader_renewdeadline: 10
 ----
 
-`enabled`:: (Optional) Defaults to false. To explicitly enable the LeaderElection provider,
-set `enabled: true`.
+`enabled`:: (Optional) Defaults to false. The LeaderElection provider is enabled automatically when the `kubernetes_leaderelection` is referenced anywhere in the {agemt} policy.
 `kube_config`:: (Optional) Use the given config file as configuration for the Kubernetes
 client. If `kube_config` is not set, `KUBECONFIG` environment variable will be
 checked and will fall back to InCluster if it's not present.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -12,7 +12,7 @@ It can automatically reach the API if it's running in an InCluster environment (
 [source,yaml]
 ----
 providers.kubernetes_leaderelection:
-  #enabled: true
+  #enabled: false
   #kube_config: /Users/elastic-agent/.kube/config
   #kube_client_options:
   #  qps: 5
@@ -23,8 +23,8 @@ providers.kubernetes_leaderelection:
   #leader_renewdeadline: 10
 ----
 
-`enabled`:: (Optional) Defaults to true. To explicitly disable the LeaderElection provider,
-set `enabled: false`.
+`enabled`:: (Optional) Defaults to false. To explicitly enable the LeaderElection provider,
+set `enabled: true`.
 `kube_config`:: (Optional) Use the given config file as configuration for the Kubernetes
 client. If `kube_config` is not set, `KUBECONFIG` environment variable will be
 checked and will fall back to InCluster if it's not present.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -12,7 +12,7 @@ It can automatically reach the API if it's running in an InCluster environment (
 [source,yaml]
 ----
 providers.kubernetes_leaderelection:
-  #enabled: false
+  #enabled: true
   #kube_config: /Users/elastic-agent/.kube/config
   #kube_client_options:
   #  qps: 5
@@ -23,8 +23,8 @@ providers.kubernetes_leaderelection:
   #leader_renewdeadline: 10
 ----
 
-`enabled`:: (Optional) Defaults to false.
-The LeaderElection provider is enabled automatically when the `kubernetes_leaderelection` is referenced anywhere in the {agemt} policy.
+`enabled`:: (Optional) Defaults to true. To explicitly disable the LeaderElection provider,
+set `enabled: false`.
 `kube_config`:: (Optional) Use the given config file as configuration for the Kubernetes
 client. If `kube_config` is not set, `KUBECONFIG` environment variable will be
 checked and will fall back to InCluster if it's not present.

--- a/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/providers/kubernetes_leaderelection-provider.asciidoc
@@ -23,7 +23,8 @@ providers.kubernetes_leaderelection:
   #leader_renewdeadline: 10
 ----
 
-`enabled`:: (Optional) Defaults to false. The LeaderElection provider is enabled automatically when the `kubernetes_leaderelection` is referenced anywhere in the {agemt} policy.
+`enabled`:: (Optional) Defaults to false.
+The LeaderElection provider is enabled automatically when the `kubernetes_leaderelection` is referenced anywhere in the {agemt} policy.
 `kube_config`:: (Optional) Use the given config file as configuration for the Kubernetes
 client. If `kube_config` is not set, `KUBECONFIG` environment variable will be
 checked and will fall back to InCluster if it's not present.


### PR DESCRIPTION
This updates the Provider docs to indicate that providers are no longer enabled by default, as a result of https://github.com/elastic/elastic-agent/pull/6169

 - The main change is to [Configure providers for standalone Elastic Agent](https://www.elastic.co/guide/en/fleet/current/providers.html): 
    ![screen](https://github.com/user-attachments/assets/c3a1971b-68d5-49b3-bbd5-1e7bb8461b80)

 - I've also updated the [Kubernetes LeaderElection Provider](https://www.elastic.co/guide/en/fleet/current/kubernetes_leaderelection-provider.html)

 - I don't think any other providers pages need updating. The [Kubernetes provider](https://www.elastic.co/guide/en/fleet/current/kubernetes-provider.html) supports enabling individual resources (pods, nodes, or services), but I assume the defaults for that remain as is.

---

Closes: https://github.com/elastic/ingest-docs/issues/1529
Target: 8.18
