### PR TITLE
Fix version compatibility statement

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-cloud.asciidoc
@@ -30,8 +30,7 @@ image::images/fleet-server-cloud-deployment.png[{fleet-server} Cloud deployment 
 {fleet-server} is compatible with the following Elastic products:
 
 * {stack} 7.13 or later.
-** For version compatibility: {es} >= {fleet-server} >= {agent} (except for
-bugfix releases)
+** For version compatibility, {es} must be at the same or a later version than {fleet-server}, and {fleet-server} needs to be at the same or a later version than {agent} (not including patch releases).
 ** {kib} should be on the same minor version as {es}.
 
 * {ece} 2.10 or later

--- a/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-mixed.asciidoc
@@ -33,8 +33,7 @@ you need to:
 {fleet-server} is compatible with the following Elastic products:
 
 * {stack} 7.13 or later
-** For version compatibility: {es} >= {fleet-server} >= {agent} (except for
-bugfix releases)
+** For version compatibility, {es} must be at the same or a later version than {fleet-server}, and {fleet-server} needs to be at the same or a later version than {agent} (not including patch releases).
 ** {kib} should be on the same minor version as {es}
 
 * {ece} 2.9 or later--allows you to use a hosted {fleet-server} on {ecloud}.

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -39,8 +39,7 @@ containerized {fleet-server}.
 {fleet-server} is compatible with the following Elastic products:
 
 * {stack} 7.13 or later.
-** For version compatibility: {es} >= {fleet-server} >= {agent} (except for
-bugfix releases)
+** For version compatibility, {es} must be at the same or a later version than {fleet-server}, and {fleet-server} needs to be at the same or a later version than {agent} (not including patch releases).
 ** {kib} should be on the same minor version as {es}.
 
 * {ece} 2.9 or later


### PR DESCRIPTION
This rephrases the version compatibility statement in the Fleet Server install docs to be a little bit more clear.
