### PR TITLE
Add Fleet & Agent 8.16.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -34,7 +34,7 @@ Review important information about the {fleet} and {agent} 8.16.2 release.
 [[enhancements-8.16.2]]
 === Enhancements
 
-In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] image to provide secure containers to our self-managed customers, help with compliance regulations, and improve our supply chain security posture. Wolfi-based images require Docker version 20.10.10 or higher.
+In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] image to provide additional security to our self-managed customers, and improve our supply chain security posture. Wolfi-based images require Docker version 20.10.10 or higher.
 
 {agent}::
 * Perform check for an external package manager only at startup. {agent-pull}6178[#6178] {agent-issue}5835[#5835] {agent-issue}5991[#5991]

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -30,11 +30,11 @@ Also see:
 
 Review important information about the {fleet} and {agent} 8.16.2 release.
 
-In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] image to provide secure containers to our self-managed customers, help with compliance regulations, and improve our supply chain security posture.
-
 [discrete]
 [[enhancements-8.16.2]]
 === Enhancements
+
+In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] image to provide secure containers to our self-managed customers, help with compliance regulations, and improve our supply chain security posture. Wolfi-based images require Docker version 20.10.10 or higher.
 
 {agent}::
 * Perform check for an external package manager only at startup. {agent-pull}6178[#6178] {agent-issue}5835[#5835] {agent-issue}5991[#5991]

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.16.2>>
 * <<release-notes-8.16.1>>
 * <<release-notes-8.16.0>>
 
@@ -22,10 +23,33 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
-// begin 8.16.0 relnotes
+// begin 8.16.2 relnotes
+
+[[release-notes-8.16.2]]
+== {fleet} and {agent} 8.16.2
+
+Review important information about the {fleet} and {agent} 8.16.2 release.
+
+In this release we've introduced an image based on the hardened link:https://github.com/wolfi-dev/[Wolfi] image to provide secure containers to our self-managed customers, help with compliance regulations, and improve our supply chain security posture.
+
+[discrete]
+[[enhancements-8.16.2]]
+=== Enhancements
+
+{agent}::
+* Perform check for an external package manager only at startup. {agent-pull}6178[#6178] {agent-issue}5835[#5835] {agent-issue}5991[#5991]
+* Remove some unnecessary copies when generating component configuration. {agent-pull}6184[#6184] {agent-issue}5835[#5835] {agent-issue}5991[#5991]
+* Use xxHash instead of sha256 for hashing AST nodes when generating component configuration. {agent-pull}6192[#6192] {agent-issue}5835[#5835] {agent-issue}5991[#5991]
+* Cache conditional sections when applying variables to component configuration. {agent-pull}6229[#6229] {agent-issue}5835[#5835] {agent-issue}5991[#5991]
+
+// end 8.16.2 relnotes
+
+// begin 8.16.1 relnotes
 
 [[release-notes-8.16.1]]
 == {fleet} and {agent} 8.16.1
+
+Review important information about the {fleet} and {agent} 8.16.1 release.
 
 [discrete]
 [[bug-fixes-8.16.1]]


### PR DESCRIPTION
This adds the 8.16.2 Fleet & Elastic Agent Release Notes:

* No new Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/204126)
* No new Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/2d32c2841a221d2a24694aca77bf97443cb90549/changelog/fragments)
* Elastic Agent contents from [BC1 changelog](https://github.com/elastic/elastic-agent/tree/05896198ad3cbb41c61d403c9c33b11f8bebd39a/changelog/fragments)
* The note about Wolfi images is requested in https://github.com/elastic/dev/issues/2926

Closes: https://github.com/elastic/ingest-docs/issues/1528

---

![Screenshot 2024-12-16 at 9 30 58 AM](https://github.com/user-attachments/assets/87b1deab-ab27-47b1-ba0a-aa98f294afb8)



