### PR TITLE
Add download steps for Wolfi container images

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -36,11 +36,25 @@ Run the `docker pull` command against the Elastic Docker registry:
 docker pull docker.elastic.co/elastic-agent/elastic-agent:{version}
 ----
 
+Alternately, you can use the hardened link:https://wolfi.dev/[Wolfi] image. Using Wolfi images requires Docker version 20.10.10 or higher.
+
+[source,terminal,subs="attributes"]
+----
+docker pull docker.elastic.co/elastic-agent/elastic-agent-wolfi:{version}
+----
+
 If you want to run Synthetics tests, run the `docker pull` command to fetch the *elastic-agent-complete* image:
 
 [source,terminal,subs="attributes"]
 ----
 docker pull docker.elastic.co/elastic-agent/elastic-agent-complete:{version}
+----
+
+To run Synthetics tests using the hardened link:https://wolfi.dev/[Wolfi] image, run:
+
+[source,terminal,subs="attributes"]
+----
+docker pull docker.elastic.co/elastic-agent/elastic-agent-complete-wolfi:{version}
 ----
 
 [discrete]


### PR DESCRIPTION
This adds the download instructions for the new Wolfi container install images for Elastic Agent.

@leemthompo Thanks for finding out about the wording we should use!

![Screenshot 2024-12-16 at 9 40 55 AM](https://github.com/user-attachments/assets/1b9ea4fb-3bf3-44dc-a622-7d943ffe2701)
