### PR TITLE
Add PowerShell variant to MSI install docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-agent-msi.asciidoc
@@ -10,11 +10,20 @@ The MSI package installer must be run by an administrator account. The installer
 
 . Download the latest Elastic Agent MSI binary from the link:https://www.elastic.co/downloads/elastic-agent[{agent} download page].
 
-. Run the installer:
+. Run the installer. The command varies slightly depending on whether you're using Bash or PowerShell.
++
+** Using Bash:
 +
 [source,shell]
 ----
 elastic-agent-<VERSION>-windows-x86_64.msi INSTALLARGS="--url=<URL> --enrollment-token=<TOKEN>"
+----
++
+** Using PowerShell:
++
+[source,shell]
+----
+./elastic-agent-<VERSION>-windows-x86_64.msi --% INSTALLARGS="--url=<URL> --enrollment-token=<TOKEN>"
 ----
 +
 Where:


### PR DESCRIPTION
This updates the [MSI install page](https://www.elastic.co/guide/en/fleet/current/install-agent-msi.html) since the PowerShell version of the install command for Elastic Agent is a bit different.

Closes: https://github.com/elastic/ingest-docs/issues/1547

---

![Screenshot 2024-12-16 at 1 26 26 PM](https://github.com/user-attachments/assets/4c141e7d-0020-4795-9825-2be4d39deec0)
