### PR TITLE
Add placeholder for 'transform to OTel Collector' docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
@@ -1,0 +1,7 @@
+[[otel-agent-transform]]
+= Transform an installed {agent} to run as an OTel Collector
+
+preview::[]
+
+If you have a currently installed {agent}, you can follow these steps to run it as an <<otel-agent,OTel Collector>>.
+

--- a/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
@@ -9,7 +9,7 @@ To transform {agent} to an OTel Collector:
 
 . Some instruction.
 
-. Some other instruction. Run the 'elastic-agent -transform-otel` command:
+. Some other instruction. Run the `elastic-agent -transform-otel` command:
 +
 [source,shell]
 ----

--- a/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent-transform.asciidoc
@@ -1,7 +1,20 @@
 [[otel-agent-transform]]
-= Transform an installed {agent} to run as an OTel Collector
+== Transform an installed {agent} to run as an OTel Collector
 
 preview::[]
 
-If you have a currently installed {agent}, you can follow these steps to run it as an <<otel-agent,OTel Collector>>.
+If you have a currently installed {agent}, you change it to run as an <<otel-agent,OTel Collector>>.
+
+To transform {agent} to an OTel Collector:
+
+. Some instruction.
+
+. Some other instruction. Run the 'elastic-agent -transform-otel` command:
++
+[source,shell]
+----
+elastic-agent -switch-me-to-otel-please
+----
+
+
 

--- a/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
@@ -8,3 +8,5 @@ The link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector] is a 
 When you run {agent} in `otel` mode it supports the standard OTel Collector configuration format that defines a set of receivers, processors, exporters, and connectors. Logs, metrics, and traces can be ingested using OpenTelemetry data formats.
 
 For a full overview and steps to configure {agent} in `otel` mode, including a guided onboarding, refer to the link:https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions for OpenTelemetry] repository in GitHub. You can also check the <<elastic-agent-otel-command,`elastic-agent otel` command>> in the {fleet} and {agent} Command reference.
+
+// If you have a currently running {agent} you can <<otel-agent-transform,transform it to run as an OTel Collector>>.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -71,6 +71,8 @@ include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]
 
 include::elastic-agent/otel-agent.asciidoc[leveloffset=+2]
 
+//include::elastic-agent/otel-agent-transform.asciidoc[leveloffset=+2]
+
 include::elastic-agent/elastic-agent-unprivileged-mode.asciidoc[leveloffset=+2]
 
 include::elastic-agent/install-agent-msi.asciidoc[leveloffset=+2]


### PR DESCRIPTION
This adds a placeholder where the "how to transform an agent to run as an OTel collector" will eventually land.

The `include` statement is commented out so this PR has no visible effect in the current docs.

Closes: #1549

---

![screen](https://github.com/user-attachments/assets/1ce0a580-dd70-4562-8e80-32acf8d3ec7b)


