### PR TITLE
Update policy scaling recommendation

### DIFF
--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -556,4 +556,6 @@ The unenroll task runs every ten minutes, and it unenrolls a maximum of one thou
 [[agent-policy-scale]]
 == Policy scaling recommendations
 
-A single instance of {fleet} supports a maximum of 500 {agent} policies. If more policies are configured, UI performance might be impacted.
+A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted.
+
+If you are using {agent} with link:{serverless-docs}[{serverless-full}], the maximum supported number of {agent} policies is 500.

--- a/docs/en/ingest-management/agent-policies.asciidoc
+++ b/docs/en/ingest-management/agent-policies.asciidoc
@@ -556,6 +556,6 @@ The unenroll task runs every ten minutes, and it unenrolls a maximum of one thou
 [[agent-policy-scale]]
 == Policy scaling recommendations
 
-A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted.
+A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted. The maximum number of policies is not affected by the number of spaces in which the policies are used.
 
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], the maximum supported number of {agent} policies is 500.

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -232,7 +232,7 @@ of these operations.
 
 **{agent} policies**
 
-A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted.
+A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted. The maximum number of policies is not affected by the number of spaces in which the policies are used.
 
 If you are using {agent} with link:{serverless-docs}[{serverless-full}], the maximum supported number of {agent} policies is 500.
 

--- a/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-server-scaling.asciidoc
@@ -232,7 +232,9 @@ of these operations.
 
 **{agent} policies**
 
-A single instance of {fleet} supports a maximum of 500 {agent} policies. If more policies are configured, UI performance might be impacted.
+A single instance of {fleet} supports a maximum of 1000 {agent} policies. If more policies are configured, UI performance might be impacted.
+
+If you are using {agent} with link:{serverless-docs}[{serverless-full}], the maximum supported number of {agent} policies is 500.
 
 **{agents}**
 


### PR DESCRIPTION
This updates the policy scaling recommendation that appears [here](https://www.elastic.co/guide/en/fleet/current/fleet-server-scalability.html#agent-policy-scaling-recommendations) and [here](https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-scale). The recommendation is updated for stateful and added in for Serverless, which we previously didn't mention.

@kpollich  Should this target just 8.x, or is 8.17 also updated?

Closes: https://github.com/elastic/ingest-docs/issues/1551

---

![Screenshot 2024-12-16 at 4 38 49 PM](https://github.com/user-attachments/assets/1c5efffc-0a56-4ecf-8486-242f43548aba)
