### PR TITLE
Enable new agent -> OTel-agent transform docs

### DIFF
--- a/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/otel-agent.asciidoc
@@ -9,4 +9,4 @@ When you run {agent} in `otel` mode it supports the standard OTel Collector conf
 
 For a full overview and steps to configure {agent} in `otel` mode, including a guided onboarding, refer to the link:https://github.com/elastic/opentelemetry/tree/main[Elastic Distributions for OpenTelemetry] repository in GitHub. You can also check the <<elastic-agent-otel-command,`elastic-agent otel` command>> in the {fleet} and {agent} Command reference.
 
-// If you have a currently running {agent} you can <<otel-agent-transform,transform it to run as an OTel Collector>>.
+If you have a currently running {agent} you can <<otel-agent-transform,transform it to run as an OTel Collector>>.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -71,7 +71,7 @@ include::elastic-agent/configuration/env/container-envs.asciidoc[leveloffset=+3]
 
 include::elastic-agent/otel-agent.asciidoc[leveloffset=+2]
 
-//include::elastic-agent/otel-agent-transform.asciidoc[leveloffset=+2]
+include::elastic-agent/otel-agent-transform.asciidoc[leveloffset=+2]
 
 include::elastic-agent/elastic-agent-unprivileged-mode.asciidoc[leveloffset=+2]
 


### PR DESCRIPTION
This enables the new "Transform an installed Elastic Agent to run as an OTel Collector" docs. The page had been created but commented out.

No need to backport. In 8.x these are enabled via https://github.com/elastic/ingest-docs/pull/1559