### PR TITLE
Add Fleet & Agent 7.17.27 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,7 +14,9 @@
 
 This section summarizes the changes in each release.
 
-* <<release-notes-7.17.25>>
+* <<release-notes-7.17.27>>
+
+* <<release-notes-7.17.26>>
 
 * <<release-notes-7.17.25>>
 
@@ -72,6 +74,15 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.27 relnotes
+
+[[release-notes-7.17.27]]
+== {fleet} and {agent} 7.17.27
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 7.17.27 relnotes
 
 // begin 7.17.26 relnotes
 


### PR DESCRIPTION
This adds the 7.17.27 Fleet & Agent Release Notes:

 - Fleet: No changes in [Kibana RN PR](https://github.com/elastic/kibana/pull/206347)
 - Fleet Server: no new entries in [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/d697a1da15f6f574171f9c99cfedcdb36f1b895a/changelog/fragments)
 - Elastic Agent: no entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/0581ff6591512ea0a39137fa09fe4094db758f61/changelog/fragments)

---

<img width="773" alt="Screenshot 2025-01-06 at 11 32 55 AM" src="https://github.com/user-attachments/assets/8539d79f-efef-4e0e-9156-46d5fdaba9fd" />
