### PR TITLE
Remove TLSv1.0 from supported protocols

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/authentication/ssl-settings.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/authentication/ssl-settings.asciidoc
@@ -142,10 +142,10 @@ NOTE: SSL settings are disabled if either `enabled` is set to `false` or the
 
 | (list) List of allowed SSL/TLS versions. If the SSL/TLS server supports none
 of the specified versions, the connection will be dropped during or after the
-handshake. The list of allowed protocol versions include: `SSLv3`, `TLSv1`
-for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and `TLSv1.3`.
+handshake. The list of allowed protocol versions include: `TLSv1.1`, `TLSv1.2`,
+and `TLSv1.3`.
 
-*Default:* `[TLSv1.1, TLSv1.2, TLSv1.3]`
+*Default:* `[TLSv1.2, TLSv1.3]`
 
 // =============================================================================
 

--- a/docs/en/ingest-management/elastic-agent/configuration/yaml/elastic-agent-reference-yaml.yml
+++ b/docs/en/ingest-management/elastic-agent/configuration/yaml/elastic-agent-reference-yaml.yml
@@ -76,7 +76,7 @@ inputs:
 #     #service_token: "example-token"
 #     #path: ""
 #     #ssl.verification_mode: full
-#     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+#     #ssl.supported_protocols: [TLSv1.2, TLSv1.3]
 #     #ssl.cipher_suites: []
 #     #ssl.curve_types: []
 #   reporting:


### PR DESCRIPTION
Remove TLSv1.0 from supported_protocols list and set defaults to TLSv1.2, TLSv1.3 for the 9.x release

- Relates https://github.com/elastic/elastic-agent/issues/5996
- Relates https://github.com/elastic/fleet-server/issues/4107