### PR TITLE
Add details for Wolfi install image

### DIFF
--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -36,7 +36,11 @@ Run the `docker pull` command against the Elastic Docker registry:
 docker pull docker.elastic.co/elastic-agent/elastic-agent:{version}
 ----
 
-Alternately, you can use the hardened link:https://wolfi.dev/[Wolfi] image. Using Wolfi images requires Docker version 20.10.10 or higher.
+Alternately, you can use the hardened link:https://wolfi.dev/[Wolfi] image.
+Using Wolfi images requires Docker version 20.10.10 or higher.
+For details about why the Wolfi images have been introduced, refer to our article 
+link:https://www.elastic.co/blog/reducing-cves-in-elastic-container-images[Reducing CVEs in Elastic container images].
+
 
 [source,terminal,subs="attributes"]
 ----

--- a/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/elastic-agent-container.asciidoc
@@ -37,7 +37,7 @@ docker pull docker.elastic.co/elastic-agent/elastic-agent:{version}
 ----
 
 Alternately, you can use the hardened link:https://wolfi.dev/[Wolfi] image.
-Using Wolfi images requires Docker version 20.10.10 or higher.
+Using Wolfi images requires Docker version 20.10.10 or later.
 For details about why the Wolfi images have been introduced, refer to our article 
 link:https://www.elastic.co/blog/reducing-cves-in-elastic-container-images[Reducing CVEs in Elastic container images].
 


### PR DESCRIPTION
This updates the [Run Elastic Agent in a container](https://www.elastic.co/guide/en/fleet/current/elastic-agent-container.html) page with a link to the blog article about why the Wolfi images were introduced.

Rel: #1608 
Associated Beats PR: https://github.com/elastic/beats/pull/42268

---

<img width="1113" alt="agent" src="https://github.com/user-attachments/assets/8985af6d-eecd-4de8-95c2-2d352e614fea" />
