### PR TITLE
Add Fleet & Agent 8.16.3 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.16.3>>
 * <<release-notes-8.16.2>>
 * <<release-notes-8.16.1>>
 * <<release-notes-8.16.0>>
@@ -22,6 +23,22 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.16.3 relnotes
+
+[[release-notes-8.16.3]]
+== {fleet} and {agent} 8.16.3
+
+Review important information about the {fleet} and {agent} 8.16.2 release.
+
+[discrete]
+[[bug-fixes-8.16.3]]
+=== Bug fixes
+
+{fleet}::
+* Fixed an issue that prevented {agent} tags from being displayed when the agent list is filtered. ({kibana-pull}205163[#205163])
+
+// end 8.16.3 relnotes
 
 // begin 8.16.2 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -29,7 +29,7 @@ Also see:
 [[release-notes-8.16.3]]
 == {fleet} and {agent} 8.16.3
 
-Review important information about the {fleet} and {agent} 8.16.2 release.
+Review important information about the {fleet} and {agent} 8.16.3 release.
 
 [discrete]
 [[bug-fixes-8.16.3]]


### PR DESCRIPTION
This adds the 8.16.3 Fleet & Elastic Agent Release Notes:

* Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/206156)
* No new Fleet Server contents in [BC1 changelog](https://github.com/elastic/fleet-server/tree/915f0aeb9aa1e9c293224f4af66e86d09560f648/changelog/fragments)
* No new Elastic Agent contents in [BC1 changelog](https://github.com/elastic/elastic-agent/tree/5f3c247f70bffffe9764eb8592c2a067e5f57e5b/changelog/fragments)

Rel: https://github.com/elastic/ingest-docs/issues/1611

---

<img width="1058" alt="screen" src="https://github.com/user-attachments/assets/54b8f80b-19c7-4511-b33f-4ca521723c51" />


