### PR TITLE
known issue for when an integration level output is set to default

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -235,6 +235,19 @@ curl -XPOST -H 'Authorization: Bearer ${TOKEN}' -H 'x-elastic-product-origin:fle
 ====
 
 [discrete]
+[[known-issue-206131]]
+.
+[%collapsible]
+====
+*Details* +
+Beginning in version 8.16.0 you can specify an output per integration policy. However, setting the integration output to the default creates an invalid output name.
+
+*Impact* +
+Until this issue is resolved, as a workaround you can clone the default output before setting as the output for a specific integration policy. Refer to issue link:https://github.com/elastic/kibana/issues/206131[#206131] for details.
+
+====
+
+[discrete]
 [[new-features-8.16.0]]
 === New features
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -236,14 +236,14 @@ curl -XPOST -H 'Authorization: Bearer ${TOKEN}' -H 'x-elastic-product-origin:fle
 
 [discrete]
 [[known-issue-206131]]
-.
+.Integration output fails when using default output
 [%collapsible]
 ====
 *Details* +
 Beginning in version 8.16.0 you can specify an output per integration policy. However, setting the integration output to the default creates an invalid output name.
 
 *Impact* +
-Until this issue is resolved, as a workaround you can clone the default output before setting as the output for a specific integration policy. Refer to issue link:https://github.com/elastic/kibana/issues/206131[#206131] for details.
+Until this issue is resolved, as a workaround you can create a clone of the default output and then set it as the output for an integration policy. Refer to issue link:https://github.com/elastic/kibana/issues/206131[#206131] for details.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -243,7 +243,7 @@ curl -XPOST -H 'Authorization: Bearer ${TOKEN}' -H 'x-elastic-product-origin:fle
 Beginning in version 8.16.0 you can specify an output per integration policy. However, setting the integration output to the default creates an invalid output name.
 
 *Impact* +
-Until this issue is resolved, as a workaround you can create a clone of the default output and then set it as the output for an integration policy. Refer to issue link:https://github.com/elastic/kibana/issues/206131[#206131] for details.
+As a workaround, you can create a clone of the default output and then set it as the output for an integration policy. Refer to issue link:https://github.com/elastic/kibana/issues/206131[#206131] for details and status.
 
 ====
 


### PR DESCRIPTION
This updates the 8.16.0 release notes as shown:

<img width="1116" alt="Screenshot 2025-01-10 at 11 12 16 AM" src="https://github.com/user-attachments/assets/6e8e5eb0-d16f-4425-ae81-256c8af21d6e" />

---

Closes: https://github.com/elastic/ingest-docs/issues/1613