### PR TITLE
Add restrictions for synthetic `_source`

### DIFF
--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -704,7 +704,7 @@ Refer to <<data-streams-pipelines>> to learn more.
 * link:{ref}/mapping-source-field.html#synthetic-source[Synthetic `_source`]
 
 These features can be enabled and disabled for {fleet}-managed data streams by using the index template API and a few key settings.
-Note that in versions 8.17.0 and later, Synthetic `_source` requires an Enterprise license. As well, synthetic `_source` is supported only on non-TSDS data streams.
+Note that in versions 8.17.0 and later, Synthetic `_source` requires an Enterprise license. As well, disabling synthetic `_source` is supported only on non-TSDS data streams.
 
 NOTE: If you are already making use of `@custom` component templates for ingest or retention customization (as shown for example in <<data-streams-ilm-tutorial,Tutorial: Customize data retention policies>>), exercise care to ensure you don't overwrite your customizations when making these requests.
 
@@ -863,21 +863,8 @@ For example, the following payload disables TSDS on `nginx.stubstatus`:
 [[data-streams-advanced-synthetic-enable]]
 == Enable synthetic `_source`
 
-Note that synthetic `_source` is supported only on non-TSDS data streams.
-
 [source,json]
 ----
-PUT _component_template/<NAME>@custom
-{
-  "template": {
-    "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      }
-    }
-  }
-}
-
 PUT _component_template/<NAME>@custom
 {
   "settings": {
@@ -897,7 +884,7 @@ PUT _component_template/<NAME>@custom
 [[data-streams-advanced-synthetic-disable]]
 == Disable synthetic `_source`
 
-Note that synthetic `_source` is supported only on non-TSDS data streams.
+Note that disabling synthetic `_source` is supported only on non-TSDS data streams.
 
 [source,json]
 ----
@@ -906,7 +893,7 @@ PUT _component_template/<NAME>@custom
   "settings": {
     "index": {
       "mapping": {
-        "source": {}
+        "source": {"mode": "stored"}
       }
     }
   }

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -704,7 +704,7 @@ Refer to <<data-streams-pipelines>> to learn more.
 * link:{ref}/mapping-source-field.html#synthetic-source[Synthetic `_source`]
 
 These features can be enabled and disabled for {fleet}-managed data streams by using the index template API and a few key settings.
-Note that in versions 8.17.0 and later, Synthetic `_source` requires an Enterprise license. As well, disabling synthetic `_source` is supported only on non-TSDS data streams.
+Note that in versions 8.17.0 and later, Synthetic `_source` requires an Enterprise license.
 
 NOTE: If you are already making use of `@custom` component templates for ingest or retention customization (as shown for example in <<data-streams-ilm-tutorial,Tutorial: Customize data retention policies>>), exercise care to ensure you don't overwrite your customizations when making these requests.
 
@@ -883,8 +883,6 @@ PUT _component_template/<NAME>@custom
 [discrete]
 [[data-streams-advanced-synthetic-disable]]
 == Disable synthetic `_source`
-
-Note that disabling synthetic `_source` is supported only on non-TSDS data streams.
 
 [source,json]
 ----

--- a/docs/en/ingest-management/data-streams.asciidoc
+++ b/docs/en/ingest-management/data-streams.asciidoc
@@ -691,22 +691,6 @@ You can modify your pipeline API request as needed to apply custom processing at
 Refer to <<data-streams-pipelines>> to learn more.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 [[data-streams-advanced-features]]
 == Enabling and disabling advanced indexing features for {fleet}-managed data streams
 
@@ -720,6 +704,7 @@ Refer to <<data-streams-pipelines>> to learn more.
 * link:{ref}/mapping-source-field.html#synthetic-source[Synthetic `_source`]
 
 These features can be enabled and disabled for {fleet}-managed data streams by using the index template API and a few key settings.
+Note that in versions 8.17.0 and later, Synthetic `_source` requires an Enterprise license. As well, synthetic `_source` is supported only on non-TSDS data streams.
 
 NOTE: If you are already making use of `@custom` component templates for ingest or retention customization (as shown for example in <<data-streams-ilm-tutorial,Tutorial: Customize data retention policies>>), exercise care to ensure you don't overwrite your customizations when making these requests.
 
@@ -878,10 +863,11 @@ For example, the following payload disables TSDS on `nginx.stubstatus`:
 [[data-streams-advanced-synthetic-enable]]
 == Enable synthetic `_source`
 
+Note that synthetic `_source` is supported only on non-TSDS data streams.
+
 [source,json]
 ----
 PUT _component_template/<NAME>@custom
-
 {
   "template": {
     "mappings": {
@@ -891,20 +877,37 @@ PUT _component_template/<NAME>@custom
     }
   }
 }
+
+PUT _component_template/<NAME>@custom
+{
+  "settings": {
+    "index": {
+      "mapping": {
+        "source": {
+          "mode": "synthetic"
+        }
+      }
+    }
+  }
+}
+
 ----
 
 [discrete]
 [[data-streams-advanced-synthetic-disable]]
 == Disable synthetic `_source`
 
+Note that synthetic `_source` is supported only on non-TSDS data streams.
+
 [source,json]
 ----
 PUT _component_template/<NAME>@custom
-
 {
-  "template": {
-    "mappings": {
-      "_source": {}
+  "settings": {
+    "index": {
+      "mapping": {
+        "source": {}
+      }
     }
   }
 }


### PR DESCRIPTION
This adds the restrictions described in https://github.com/elastic/ingest-docs/issues/1618 to the [Enabling and disabling advanced indexing features for Fleet-managed data streams](https://www.elastic.co/guide/en/fleet/current/data-streams-advanced-features.html) page.

I also removed some extra spacing which I must have added earlier by accident.

@lucabelluccini and @martijnvg, please check that I have the `enable` and `disable` code examples right, since I'm kind of guessing. 

Closes: https://github.com/elastic/ingest-docs/issues/1618

**Previews:**

--- 

<img width="949" alt="Screenshot 2025-01-21 at 9 40 23 AM" src="https://github.com/user-attachments/assets/a71a7927-43bd-4172-ac67-2fff13ca9ab6" />

---

<img width="982" alt="Screenshot 2025-01-21 at 9 40 03 AM" src="https://github.com/user-attachments/assets/67407314-d792-4b10-b404-577b8699f6df" />



