### PR TITLE
Add warning about Elastic Defend with remote ES output

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
@@ -7,6 +7,8 @@ Beginning in version 8.12.0, you can send {agent} data to a remote {es} cluster.
 
 A remote {es} cluster supports the same <<es-output-settings,output settings>> as your main {es} cluster.
 
+WARNING: A bug has been found that causes {elastic-defend} response actions to stop working when a remote {es} output is configured for an agent. This bug is currently being investigated and is expected to be resolved in an upcoming release.
+
 NOTE: Using a remote {es} output with a target cluster that has {cloud}/ec-traffic-filtering-deployment-configuration.html[traffic filters] enabled is not currently supported.
 
 To configure a remote {es} cluster for your {agent} data:


### PR DESCRIPTION
This updates the [Remote Elasticsearch output](https://www.elastic.co/guide/en/fleet/current/remote-elasticsearch-output.html) page with the following warning:

<img width="961" alt="Screenshot 2025-01-21 at 10 56 02 AM" src="https://github.com/user-attachments/assets/340c6ba5-811a-44ce-a8a8-627f2a86bc89" />

---

Closes: https://github.com/elastic/ingest-docs/issues/1638
