### PR TITLE
[DOCS] Warn LS pipeline should not modify fields coming from EA

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -32,6 +32,12 @@ To receive the events in {ls}, you also need to create a {ls} configuration pipe
 The {ls} configuration pipeline listens for incoming {agent} connections,
 processes received events, and then sends the events to {es}.
 
+Please be aware the structure of the documents sent from Elastic Agent to {ls} must not be modified by the pipeline.
+We recommend the pipeline doesn’t edit or remove the fields and their contents.
+Editing the structure of the documents coming from {agent} can prevent the {es} ingest pipelines associated to the integrations
+in use to work correctly.
+We cannot guarantee that the {es} ingest pipelines associated to the integrations of {agent} can work with missing or modified fields.
+
 The following {ls} pipeline definition example configures a pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.
 

--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -32,11 +32,10 @@ To receive the events in {ls}, you also need to create a {ls} configuration pipe
 The {ls} configuration pipeline listens for incoming {agent} connections,
 processes received events, and then sends the events to {es}.
 
-Please be aware the structure of the documents sent from Elastic Agent to {ls} must not be modified by the pipeline.
-We recommend the pipeline doesn’t edit or remove the fields and their contents.
-Editing the structure of the documents coming from {agent} can prevent the {es} ingest pipelines associated to the integrations
-in use to work correctly.
-We cannot guarantee that the {es} ingest pipelines associated to the integrations of {agent} can work with missing or modified fields.
+Please be aware that the structure of the documents sent from {agent} to {ls} must not be modified by the pipeline.
+We recommend that the pipeline doesn’t edit or remove the fields and their contents.
+Editing the structure of the documents coming from {agent} can prevent the {es} ingest pipelines associated to the integrations in use to work correctly.
+We cannot guarantee that the {es} ingest pipelines associated to the integrations using {agent} can work with missing or modified fields.
 
 The following {ls} pipeline definition example configures a pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.


### PR DESCRIPTION
Warn LS pipeline should not modify fields coming from EA

Modifying data coming from EA can prevent the ingest pipelines on Elasticsearch side associated to the integrations in use in EA to work correctly.