### PR TITLE
[Elastic-Agent] Remove flag --non-interactive from the enroll documentation

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -209,7 +209,6 @@ elastic-agent enroll --fleet-server-es <string>
                      [--force]
                      [--header <strings>]
                      [--help]
-                     [--non-interactive]
                      [--proxy-disabled]
                      [--proxy-header <strings>]
                      [--proxy-url <string>]
@@ -351,11 +350,6 @@ verified. The content is encrypted, but the certificate is not verified.
 --
 +
 We strongly recommend that you use a secure connection.
-
-`--non-interactive`::
-Install {agent} in a non-interactive mode. This flag is helpful when
-using automation software or scripted deployments. If {agent} is
-already installed on the host, the installation will terminate.
 
 `--proxy-disabled`::
 Disable proxy support including environment variables.


### PR DESCRIPTION
### Problem

The documentation page https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html erroneously reports that the flag `--non-interactive` can be used with the the `elastic-agent enroll` command.

This is not the case. If we execute enroll with this flag, we receive the following error:

> unknown flag: --non-interactive

This is also confirmed by the execution of `elastic-agent enroll --help`:

<details>
  <summary>COMMAND OUTPUT</summary>

```
MYSHELL$ ./elastic-agent enroll --help
This command will enroll the Elastic Agent into Fleet.

Usage:
  elastic-agent enroll [flags]

Flags:
  -p, --ca-sha256 string                                Comma-separated list of certificate authority hash pins for server verification used by Elastic Agent and Fleet Server
  -a, --certificate-authorities string                  Comma-separated list of root certificates for server verification used by Elastic Agent and Fleet Server
      --daemon-timeout duration                         Timeout waiting for Elastic Agent daemon
      --delay-enroll                                    Delays enrollment to occur on first start of the Elastic Agent service
      --elastic-agent-cert string                       Elastic Agent client certificate to use with Fleet Server during mTLS authentication
      --elastic-agent-cert-key string                   Elastic Agent client private key to use with Fleet Server during mTLS authentication
      --elastic-agent-cert-key-passphrase string        Path for private key passphrase file used to decrypt Elastic Agent client certificate key
  -t, --enrollment-token string                         Enrollment token to use to enroll Agent into Fleet
      --fleet-server-cert string                        Certificate for Fleet Server to use for exposed HTTPS endpoint
      --fleet-server-cert-key string                    Private key for the certificate used by Fleet Server for exposed HTTPS endpoint
      --fleet-server-cert-key-passphrase string         Path for private key passphrase file used to decrypt Fleet Server certificate key
      --fleet-server-client-auth string                 Fleet Server mTLS client authentication for connecting Elastic Agents. Must be one of [none, optional, required] (default "none")
      --fleet-server-es string                          Start and run a Fleet Server alongside this Elastic Agent connecting to the provided Elasticsearch
      --fleet-server-es-ca string                       Path to certificate authority for Fleet Server to use to communicate with Elasticsearch
      --fleet-server-es-ca-trusted-fingerprint string   Elasticsearch certificate authority's SHA256 fingerprint for Fleet Server to use
      --fleet-server-es-cert string                     Client certificate for Fleet Server to use when connecting to Elasticsearch
      --fleet-server-es-cert-key string                 Client private key for Fleet Server to use when connecting to Elasticsearch
      --fleet-server-es-insecure                        Disables validation of Elasticsearch certificates for Fleet Server
      --fleet-server-host string                        Fleet Server HTTP binding host (overrides the policy)
      --fleet-server-insecure-http                      Expose Fleet Server over HTTP (not recommended; insecure)
      --fleet-server-policy string                      Start and run a Fleet Server on this specific policy
      --fleet-server-port uint16                        Fleet Server HTTP binding port (overrides the policy)
      --fleet-server-service-token string               Service token for Fleet Server to use for communication with Elasticsearch
      --fleet-server-service-token-path string          Filepath for the service token secret file used by Fleet Server for communication with Elasticsearch
      --fleet-server-timeout duration                   When bootstrapping Fleet Server, timeout waiting for Fleet Server to be ready to start enrollment
  -f, --force                                           Force overwrite the current and do not prompt for confirmation
      --header strings                                  Headers used by Fleet Server when communicating with Elasticsearch
  -h, --help                                            help for enroll
  -i, --insecure                                        Allow insecure connection made by the Elastic Agent. It's also required to use a Fleet Server on a HTTP endpoint
      --proxy-disabled                                  Disable proxy support including environment variables: when bootstrapping Fleet Server, it's the proxy used by Fleet Server to connect to Elasticsearch; when enrolling the Elastic Agent to Fleet Server, it's the proxy used by the Elastic Agent to connect to Fleet Server
      --proxy-header strings                            Proxy headers used with CONNECT request: when bootstrapping Fleet Server, it's the proxy used by Fleet Server to connect to Elasticsearch; when enrolling the Elastic Agent to Fleet Server, it's the proxy used by the Elastic Agent to connect to Fleet Server
      --proxy-url string                                Configures the proxy URL: when bootstrapping Fleet Server, it's the proxy used by Fleet Server to connect to Elasticsearch; when enrolling the Elastic Agent to Fleet Server, it's the proxy used by the Elastic Agent to connect to Fleet Server
      --staging string                                  Configures Elastic Agent to download artifacts from a staging build
      --tag strings                                     User-set tags
      --url string                                      URL to enroll Agent into Fleet

Global Flags:
  -c, --c string                     Configuration file, relative to path.config (default "elastic-agent.yml")
      --config string                Configuration file, relative to path.config (default "elastic-agent.yml")
  -d, --d string                     Enable certain debug selectors
  -e, --e                            Log to stderr and disable syslog/file output
      --environment environmentVar   set environment being ran in (default default)
      --path.config string           Config path is the directory Agent looks for its config file (default "/home/mirko/elastic-agent-8.17.1-linux-x86_64")
      --path.downloads string        Downloads path contains binaries Agent downloads (default "/home/mirko/elastic-agent-8.17.1-linux-x86_64/data/elastic-agent-b46c28/downloads")
      --path.home string             Agent root path (default "/home/mirko/elastic-agent-8.17.1-linux-x86_64")
      --path.install string          DEPRECATED, setting this flag has no effect since v8.6.0
      --path.logs string             Logs path contains Agent log output (default "/home/mirko/elastic-agent-8.17.1-linux-x86_64")
      --path.socket string           Control protocol socket path for the Agent (default "unix:///home/mirko/elastic-agent-8.17.1-linux-x86_64/elastic-agent.sock")
  -v, --v                            Log at INFO level
```
</details>

### Fix

In this PR I remove the `--non-interactive` flag from the `elastic-agent enroll` command documentation. 

**Related Issues/PR**

- https://github.com/elastic/ingest-docs/issues/290
- https://github.com/elastic/ingest-docs/pull/860


