### PR TITLE
Add Fleet & Agent 8.16.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -237,7 +237,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.17.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.16.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -237,7 +237,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.16.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.17.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.16.4>>
 * <<release-notes-8.16.3>>
 * <<release-notes-8.16.2>>
 * <<release-notes-8.16.1>>

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -24,6 +24,15 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.16.4 relnotes
+
+[[release-notes-8.16.4]]
+== {fleet} and {agent} 8.16.4
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 8.16.4 relnotes
+
 // begin 8.16.3 relnotes
 
 [[release-notes-8.16.3]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -27,10 +27,26 @@ Also see:
 
 // begin 8.16.4 relnotes
 
+Review important information about the {fleet} and {agent} 8.16.4 release.
+
 [[release-notes-8.16.4]]
 == {fleet} and {agent} 8.16.4
 
-There are no bug fixes for {fleet} or {agent} in this release.
+[discrete]
+[[security-updates-8.16.4]]
+=== Security updates
+
+{agent}::
+* Upgrade NodeJS to LTS v18.20.6. {agent-pull}6641[#6641]
+
+[discrete]
+[[bug-fixes-8.16.4]]
+=== Bug fixes
+
+{agent}::
+* Emit vars even if provider data is empty from the start. {agent-pull}6598[#6598]
+* Redact secrets within complex nested paths. {agent-pull}6710[#6710]
+* Improve the CLI output message when `elastic-agent uninstall` runs after the agent has previously been unenrolled. {agent-pull}6735[#6735]
 
 // end 8.16.4 relnotes
 


### PR DESCRIPTION
This adds the 8.16.4 Fleet & Elastic Agent Release Notes:

* No Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/210108)
* Fleet Server [BC3 changelog](https://github.com/elastic/fleet-server/tree/7b13998120181a28537f6192fbe69a9e45a148d7/changelog/fragments)
* Elastic Agent [BC3 changelog](https://github.com/elastic/elastic-agent/tree/7be8f159c3b1eea7d7ac572e4f1dbda75f10aaa4/changelog/fragments)

Rel: https://github.com/elastic/ingest-docs/issues/1666

---

<img width="972" alt="Screenshot 2025-02-10 at 1 24 33 PM" src="https://github.com/user-attachments/assets/eef5d95e-fe82-4383-a0f4-6f761c361326" />





