### PR TITLE
Add Fleet & Agent 8.17.2 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -37,6 +37,9 @@ Review important information about the {fleet} and {agent} 8.17.2 release.
 {fleet-server}::
 * Upgrade `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}44405[#4405]
 
+{agent}::
+* Update Go version to 1.22.11. {agent-pull}6686[#6686]
+
 [discrete]
 [[enhancements-8.17.2]]
 === Enhancements

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -37,8 +37,6 @@ Review important information about the {fleet} and {agent} 8.17.2 release.
 {fleet-server}::
 * Upgrade `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}44405[#4405]
 
-{agent}::
-* Update Go version to 1.22.11. {agent-pull}6686[#6686]
 
 [discrete]
 [[enhancements-8.17.2]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.2>>
 * <<release-notes-8.17.1>>
 * <<release-notes-8.17.0>>
 
@@ -21,6 +22,36 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.17.2 relnotes
+
+[[release-notes-8.17.2]]
+== {fleet} and {agent} 8.17.2
+
+Review important information about the {fleet} and {agent} 8.17.2 release.
+
+[discrete]
+[[security-updates-8.17.2]]
+=== Security updates
+
+{fleet-server}::
+* Upgrade `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}44405[#4405]
+
+[discrete]
+[[enhancements-8.17.2]]
+=== Enhancements
+
+{agent}::
+* Upgrade NodeJS for Heartbeat to LTS v18.20.6. {agent-pull}6641[#6641]
+
+[discrete]
+[[bug-fixes-8.17.2]]
+=== Bug fixes
+
+{agent}::
+* Emit variables even if provider data is empty from the start. {agent-pull}6598[#6598]
+
+// end 8.17.2 relnotes
 
 // begin 8.17.1 relnotes
 
@@ -71,7 +102,7 @@ The 8.17.1 release Added the following new and notable features.
 
 {agent}::
 * During uninstall, call the audit or unenroll API before components are stopped, if {agent} is running a {fleet-server} instance. {agent-pull}6085[#6085] {agent-issue}5752[#5752]
-* Update OTel components to v0.1156.0. {agent-pull}6391[#6391]
+* Update OTel components to v0.115.0. {agent-pull}6391[#6391]
 * Restore the `cloud-defend` binary which was accidentally removed in version 8.17.0. {agent-pull}6470[#6470] {agent-issue}6469[#6469]
 
 // end 8.17.1 relnotes


### PR DESCRIPTION
This adds the 8.17.2 Fleet & Elastic Agent Release Notes:

* No Fleet content in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/210109)
* Fleet Server contents from [BC1 changelog](https://github.com/elastic/fleet-server/tree/65cfce520ccb7d8884b8c31df883dab1b6ae0e79/changelog/fragments)
* Elastic Agent contents from [BC2 changelog](https://github.com/elastic/elastic-agent/tree/29bc86217c8134c715661f89afb601f0093fc845/changelog/fragments)

---

<img width="909" alt="Screenshot 2025-02-10 at 12 47 09 PM" src="https://github.com/user-attachments/assets/27ce8702-2f20-45a8-b79f-5cfe154d85f1" />

