### PR TITLE
Add known issue for Kibana OOM crashes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -40,9 +40,26 @@ impact to your application.
 {agent}::
 * {agent} Docker images for {ecloud} have been reverted from having been based off of Ubuntu 24.04 to being based off of Ubuntu 20.04. This is to ensure compatibility with {ece}, support for new Wolfi-based images, and for GNU C Library (glibc) compatibility. {agent-pull}6393[#6393]
 
-//*Impact* +
-//<Describe how users should mitigate the change.> For more information, refer to {fleet-guide}/fleet-server.html[Fleet Server].
-//====
+[discrete]
+[[known-issues-8.17.1]]
+=== Known issues
+
+[[known-issue-1671]]
+.{kib} out of memory crashes on 1 GB {ecloud} {kib} instances using {elastic-sec} view
+[%collapsible]
+====
+
+*Details*
+
+{ecloud} deployments that use the smallest available {kib} instance size of 1 GB may crash due to out of memory errors when the Security UI is loaded. 
+
+*Impact* +
+
+The root cause is inefficient memory allocation, and this is exacerbated when the prebuilt security rules package is installed on the initial load of the {elastic-sec} UI.
+
+As a workaround, you can upgrade your deployment to 8.17.1 in which this issue has been resolved by https://github.com/elastic/kibana/pull/208869[#208869] and https://github.com/elastic/kibana/pull/208475[#208475].
+
+====
 
 [discrete]
 [[new-features-8.17.1]]


### PR DESCRIPTION
Adds a known issue to the 8.17.1 release notes.

@kpollich Thanks for the super clear issue! I'll merge this on Tuesday when the 8.17.2 release is live, so that the option to upgrade is available.

Closes: https://github.com/elastic/ingest-docs/issues/1671

---

<img width="1101" alt="Screenshot 2025-02-06 at 1 40 52 PM" src="https://github.com/user-attachments/assets/b5312cce-6950-4b8d-add6-be9f1b42a6e6" />
