### PR TITLE
Typo fix in air-gapped.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -305,7 +305,7 @@ Where:
 +
 * `<artifact_type>` is in the format `beats/elastic-agent`, `fleet-server`, `endpoint-dev`, and so on.
 * `<artifict_name>` is in the format `elastic-agent`, `endpoint-security`, or `fleet-server` and so on.
-* `arch-package-type` is in the format `linux-x86_64`, `linux-arm64`, `windows_x86_64`, `darwin_x86_64`, or 
+* `arch-package-type` is in the format `linux-x86_64`, `linux-arm64`, `windows-x86_64`, `darwin_x86_64`, or 
 darwin_aarch64`.
 * If you're using the DEB package manager:
 +


### PR DESCRIPTION
Small PR to replace `windows_x86_64` with `windows-x86_64`

```diff
$ curl -I https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.12.1-windows_x86_64.zip          
-HTTP/2 404 
date: Tue, 11 Feb 2025 21:29:27 GMT
strict-transport-security: max-age=31536000; includeSubDomains
via: 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

```diff
$ curl -I https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-8.12.1-windows-x86_64.zip
+HTTP/2 200 
date: Tue, 11 Feb 2025 21:30:57 GMT
content-type: application/zip
content-length: 294014409
accept-ranges: bytes
last-modified: Tue, 06 Feb 2024 09:25:28 GMT
etag: "078e7b61ea7aecc867bd8ceb81a986e2"
cache-control: public, max-age=600
strict-transport-security: max-age=31536000; includeSubDomains
via: 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```