### PR TITLE
Add Fleet & Agent 7.17.28 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.28>>
+
 * <<release-notes-7.17.27>>
 
 * <<release-notes-7.17.26>>
@@ -74,6 +76,23 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.28 relnotes
+
+[[release-notes-7.17.28]]
+== {fleet} and {agent} 7.17.28
+
+Review important information about the {fleet} and {agent} 7.17.28 release.
+
+[discrete]
+[[security-updates-7.17.28]]
+=== Security updates
+
+{fleet-server}::
+* Update {fleet-server} Go version to 1.23.5. {fleet-server-pull}4353[#4353]
+* Update `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}4405[#4405]
+
+// end 7.17.28 relnotes
 
 // begin 7.17.27 relnotes
 


### PR DESCRIPTION
This adds the 7.17.27 Fleet & Agent Release Notes:

 - Fleet: (probably) No changes in [Kibana RN PR - TBD]()
 - Fleet Server: Entries from [Fleet Server BC1 changelog](https://github.com/elastic/fleet-server/tree/a780f745ac01af74a5b42e560946f031a9eafb74/changelog/fragments)
 - Elastic Agent: No entries in [agent core BC1 changelog](https://github.com/elastic/elastic-agent/tree/1348b9ca7bff4d9bb7b0507e2524fbdaa8a85358/changelog/fragments)

Closes: https://github.com/elastic/ingest-docs/issues/1686

---

<img width="949" alt="Screenshot 2025-02-20 at 11 13 24 AM" src="https://github.com/user-attachments/assets/0b3a21e1-3ddf-4736-802a-9837bd6a0b54" />
