### PR TITLE
Fix link in 8.17.2 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -35,7 +35,7 @@ Review important information about the {fleet} and {agent} 8.17.2 release.
 === Security updates
 
 {fleet-server}::
-* Upgrade `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}44405[#4405]
+* Upgrade `golang.org/x/net` to v0.34.0 and `golang.org/x/crypto` to v0.32.0. {fleet-server-pull}4405[#4405]
 
 
 [discrete]


### PR DESCRIPTION
Fixes a broken link, and also allows me to search for the PR when building RNs manually.