### PR TITLE
Add Fleet & Agent 8.16.5 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.16.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.16.5>>
 * <<release-notes-8.16.4>>
 * <<release-notes-8.16.3>>
 * <<release-notes-8.16.2>>
@@ -25,9 +26,14 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
-// begin 8.16.4 relnotes
+// begin 8.16.5 relnotes
 
-Review important information about the {fleet} and {agent} 8.16.4 release.
+[[release-notes-8.16.5]]
+== {fleet} and {agent} 8.16.5
+
+There are no bug fixes for {fleet} or {agent} in this release.
+
+// end 8.16.5 relnotes
 
 [[release-notes-8.16.4]]
 == {fleet} and {agent} 8.16.4


### PR DESCRIPTION
This adds the 8.16.5 Fleet & Elastic Agent Release Notes:

* No Fleet contents in [Kibana Release Notes PR](https://github.com/elastic/kibana/pull/212688)
* No new contents in Fleet Server [BC1 changelog](https://github.com/elastic/fleet-server/tree/922b5fb21812dd3bc368802131c55afb4da87741/changelog/fragments)
* No new contents in Elastic Agent [BC1 changelog](https://github.com/elastic/elastic-agent/tree/9608fdf8972c5e43b7007105a030107b15ceb936/changelog/fragments)

Rel: https://github.com/elastic/ingest-docs/issues/1699

---

<img width="732" alt="Screenshot 2025-02-28 at 10 33 24 AM" src="https://github.com/user-attachments/assets/d0da0368-aee8-4597-bb6f-4579290113dc" />
