### PR TITLE
Update .backportrc.json to include latest releases

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "elastic",
   "repoName": "ingest-docs",
-  "targetBranchChoices": ["main", "8.15","8.14","8.13","8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "7.17"],
+  "targetBranchChoices": ["main", "8.18","8.17","8.16","8.15","8.14","8.13","8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "7.17"],
   "autoMerge": true,
   "autoMergeMethod": "squash",
   "branchLabelMapping": {

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "elastic",
   "repoName": "ingest-docs",
-  "targetBranchChoices": ["main", "8.18","8.17","8.16","8.15","8.14","8.13","8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "7.17"],
+  "targetBranchChoices": ["8.18","8.17","8.16","8.15","8.14","8.13","8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "7.17"],
   "autoMerge": true,
   "autoMergeMethod": "squash",
   "branchLabelMapping": {


### PR DESCRIPTION
Since we're now merging docs changes into the `8.x` branch rather than `main`, we'll need to update the `8.x` version of `.backportrc.json` with the latest branches to backport to.