### PR TITLE
Update fleet-agent-proxy-package-registry.asciidoc

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
@@ -17,7 +17,7 @@ example:
 xpack.fleet.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
-If your HTTP Proxy requires authentication, you can include the 
+If your HTTP proxy requires authentication, you can include the 
 credentials in the URI, such as `https://username:password@your-nat-gateway.corp.net`, 
 only when using HTTPS.
 

--- a/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-package-registry.asciidoc
@@ -17,6 +17,10 @@ example:
 xpack.fleet.registryProxyUrl: your-nat-gateway.corp.net
 ----
 
+If your HTTP Proxy requires authentication, you can include the 
+credentials in the URI, such as `https://username:password@your-nat-gateway.corp.net`, 
+only when using HTTPS.
+
 == What information is sent to the {package-registry}?
 
 In production environments, {kib}, through the {fleet} plugin, is the only service interacting with the {package-registry}. Communication happens when interacting with the Integrations UI, and when upgrading {kib}. The shared information is about discovery of Elastic packages and their available versions. In general, the only deployment-specific data that is shared is the {kib} version.


### PR DESCRIPTION
I've looked in the code and credentials can be provided via `xpack.fleet.registryProxyUrl: https://username:password@proxyhost:proxyport`. Note for security reasons this is only allowed when using `https`.
On top of this, I've discovered that when using HTTPS Proxy we also ignore invalid certs by default.

https://github.com/elastic/kibana/blob/2a32ed4755c0f4852dc234b72ce5ad278a0ad593/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/proxy.ts#L40C9-L40C20