### PR TITLE
Add page for enrollment handling in containerized environments

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
@@ -30,3 +30,5 @@ To learn how to run {agent}s in a containerized environment, see:
 
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 
+NOTE: Enrollment handling for {agent} in a containerized environment has some special nuances.
+For details refer to <<containers-agent-enrollment-handling>>.

--- a/docs/en/ingest-management/fleet/enrollment-handling-containerized-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/enrollment-handling-containerized-agent.asciidoc
@@ -1,0 +1,12 @@
+[[containers-agent-enrollment-handling]]
+= Enrollment handing for containerized {fleet}-managed agents
+++++
+<titleabbrev>Enrollment handing for containerized agents</titleabbrev>
+++++
+
+Beginning with version 8.18, for {fleet}-managed {agents} that run in a containerized environment (including Docker, Kubernetes, and others), enrollment handling is managed as follows:
+
+* **Enrollment Verification:** The agent checks stored enrollment conditions stored in the container environment and re-enrolls only when necessary.
+* **Unenrollment Handling:** If an {agent} is unenrolled through the {fleet} UI but still has a valid enrollment token provided via environment variables, the next container restart will cause it to re-enroll automatically.
+
+In versions lower than 8.18, an unenrolled agent remains unenrolled and does not re-enroll, even if a valid enrollment token is still available.

--- a/docs/en/ingest-management/fleet/unenroll-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/unenroll-elastic-agent.asciidoc
@@ -2,6 +2,8 @@
 = Unenroll {agent}s
 
 You can unenroll {agent}s to invalidate the API key used to connect to {es}.
+For {agents} installed in a containerized environment, see <<containers-agent-enrollment-handling>>
+for details about how enrollment handling is managed.
 
 . In {fleet}, select *Agents*.
 
@@ -21,3 +23,6 @@ will show this error instead: `invalid api key to authenticate with fleet`.
 TIP: If unenrollment hangs, select *Force unenroll* to invalidate all API
 keys related to the agent and change the status to `inactive` so that the agent
 no longer appears in {fleet}.
+
+NOTE: Enrollment handling for {agent} in a containerized environment has some special nuances.
+For details refer to <<containers-agent-enrollment-handling>>.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -143,6 +143,8 @@ include::fleet/agent-health-status.asciidoc[leveloffset=+3]
 
 include::fleet/filter-agent-list-by-tags.asciidoc[leveloffset=+3]
 
+include::fleet/enrollment-handling-containerized-agent.asciidoc[leveloffset=+3]
+
 include::agent-policies.asciidoc[leveloffset=+2]
 
 include::create-agent-policies-no-UI.asciidoc[leveloffset=+3]


### PR DESCRIPTION
This adds a new page about enrollment handling to the Fleet & Agent "Manage Elastic Agents in Fleet" → "Elastic Agents" section. @pkoutsovasilis This seemed to me the most logical spot, but let me know if you think the new content should go elsewhere.

<img width="702" alt="screen2" src="https://github.com/user-attachments/assets/ab7d1122-967d-47ed-850d-91382d81ae36" />

---

I've also put a note linking to the above section on the [Install Elastic Agents in a containerized environment](https://www.elastic.co/guide/en/fleet/current/install-elastic-agents-in-containers.html) page and the [Unenroll Elastic Agents page](https://www.elastic.co/guide/en/fleet/current/unenroll-elastic-agent.html).

<img width="708" alt="scree4" src="https://github.com/user-attachments/assets/9c520447-63ef-4715-88e4-7461ecb90e2d" />

---

Closes: https://github.com/elastic/ingest-docs/issues/1662
Targets: 8.18 and 9.0+