### PR TITLE
[8.18] Add page for enrollment handling in containerized environments (#1728)

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent-in-container.asciidoc
@@ -30,3 +30,5 @@ To learn how to run {agent}s in a containerized environment, see:
 
 * {eck-ref}/k8s-elastic-agent.html[Run {agent} on ECK] -- for {eck} users
 
+NOTE: Enrollment handling for {agent} in a containerized environment has some special nuances.
+For details refer to <<containers-agent-enrollment-handling>>.

--- a/docs/en/ingest-management/fleet/enrollment-handling-containerized-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/enrollment-handling-containerized-agent.asciidoc
@@ -1,0 +1,12 @@
+[[containers-agent-enrollment-handling]]
+= Enrollment handing for containerized {fleet}-managed agents
+++++
+<titleabbrev>Enrollment handing for containerized agents</titleabbrev>
+++++
+
+Beginning with version 8.18, for {fleet}-managed {agents} that run in a containerized environment (including Docker, Kubernetes, and others), enrollment handling is managed as follows:
+
+* **Enrollment Verification:** The {agent} checks the stored enrollment conditions within its container environment and re-enrolls only when necessary.
+* **Unenrollment Handling:** If an {agent} is unenrolled via the {fleet} UI but still references a valid enrollment token provided through environment variables, it will automatically re-enroll on the next container restart.
+
+In versions lower than 8.18, an unenrolled agent remains unenrolled and does not re-enroll, even if a valid enrollment token is still available.

--- a/docs/en/ingest-management/fleet/unenroll-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/unenroll-elastic-agent.asciidoc
@@ -2,6 +2,8 @@
 = Unenroll {agent}s
 
 You can unenroll {agent}s to invalidate the API key used to connect to {es}.
+For {agents} installed in a containerized environment, see <<containers-agent-enrollment-handling>>
+for details about how enrollment handling is managed.
 
 . In {fleet}, select *Agents*.
 
@@ -21,3 +23,6 @@ will show this error instead: `invalid api key to authenticate with fleet`.
 TIP: If unenrollment hangs, select *Force unenroll* to invalidate all API
 keys related to the agent and change the status to `inactive` so that the agent
 no longer appears in {fleet}.
+
+NOTE: Enrollment handling for {agent} in a containerized environment has some special nuances.
+For details refer to <<containers-agent-enrollment-handling>>.

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -143,6 +143,8 @@ include::fleet/agent-health-status.asciidoc[leveloffset=+3]
 
 include::fleet/filter-agent-list-by-tags.asciidoc[leveloffset=+3]
 
+include::fleet/enrollment-handling-containerized-agent.asciidoc[leveloffset=+3]
+
 include::agent-policies.asciidoc[leveloffset=+2]
 
 include::create-agent-policies-no-UI.asciidoc[leveloffset=+3]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [Add page for enrollment handling in containerized environments (#1728)](https://github.com/elastic/ingest-docs/pull/1728)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)