### PR TITLE
Add tip about dynamic inputs to install page

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -66,6 +66,12 @@ If you are using {agent} with link:{serverless-docs}[{serverless-full}], note th
 * The minimum supported version of {agent} supported for use with {serverless-full} is 8.11.0.
 ====
 
+[TIP]
+.Applying {agent} configurations dynamically
+====
+When you set up {agent}, you might not yet have all input configuration details available. To solve this problem, the input configuration accepts variables and conditions that get evaluated at runtime using information from the running environment, allowing you to apply configurations dynamically. To learn more, refer to <<dynamic-input-configuration>>.
+====
+
 [discrete]
 [[elastic-agent-installation-resource-requirements]]
 == Resource requirements


### PR DESCRIPTION
The [Variables and conditions in input configurations](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) is important for users and not easy to find. I think the location makes sense, but for better discoverability perhaps adding a prominent note to the [Install Elastic Agents](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html) main page can help:


<img width="1092" alt="Screenshot 2025-03-13 at 12 49 10 PM" src="https://github.com/user-attachments/assets/559a45cc-db31-4a32-a4be-5927bd3ca4a2" />


We can add this note elsewhere as well, if that makes sense.

Rel: https://github.com/elastic/elastic-agent/issues/7284#issuecomment-2716079450


