### PR TITLE
Add Fleet & Agent 8.17.4 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
 * <<release-notes-8.17.2>>
 * <<release-notes-8.17.1>>
@@ -26,6 +27,49 @@ Also see:
 
 
 
+// begin 8.17.4 relnotes
+
+[[release-notes-8.17.4]]
+== {fleet} and {agent} 8.17.4
+
+Review important information about the  8.17.4 release.
+
+[discrete]
+[[new-features-8.17.4]]
+=== New features
+
+The 8.17.4 release adds the following new and notable features.
+
+{agent}::
+* Add motel sample configurations. {agent-pull}6630[#6630] 
+
+[discrete]
+[[enhancements-8.17.4]]
+=== Enhancements
+
+{agent}::
+* Improve `kubernetes_secrets` provider secret logging. {agent-pull}6841[#6841] {agent-issue}6187[#6187]
+* Include all metadata that is sent to {fleet} in the `agent-info.yaml` file in diagnostics by default. {agent-pull}7029[#7029] 
+* Add API key prefix to motel host configurations. {agent-pull}7063[#7063] 
+
+[discrete]
+[[bug-fixes-8.17.4]]
+=== Bug fixes
+
+{agent}::
+* Add conditions to `copy_fields` processors to prevent spamming the debug logs. {agent-pull}6730[#6730] {agent-issue}5299[#5299]
+* Improve message when audit or uninstall returns 401. {agent-pull}6735[#6735] {agent-issue}6711[#6711]
+* Fix `secret_paths` redaction along complex paths. {agent-pull}6710[#6710] 
+* Make enroll command backoff more conservative. {agent-pull}6983[#6983] {agent-issue}6761[#6761]
+* Fix an issue where `fixpermissions` on Windows incorrectly returned an error message due to improper handling of Windows API return values. {agent-pull}7059[#7059] {agent-issue}6917[#6917]
+* Support IPv6 hosts in enroll URL. {agent-pull}7036[#7036] 
+* Support IPv6 hosts in GRPC configuration. {agent-pull}7035[#7035] 
+* Rotate logger output file when writing to a symbolic link. {agent-pull}6938[#6938] 
+* Do not fail Windows permission updates on missing files or paths. {agent-pull}7305[#7305] {agent-issue}7301[#7301]
+* Make `otelcol` executable in the Docker image. {agent-pull}7345[#7345] 
+* Fix {es} exporter configuration in `kube-stack` values. {agent-pull}7380[#7380] 
+
+// end 8.17.4 relnotes
 
 // begin 8.17.3 relnotes
 


### PR DESCRIPTION
Adds the 8.17.4 Release Notes:

No Fleet contents in: https://github.com/elastic/kibana/pull/215250
Elastic Agent contents from: https://github.com/elastic/elastic-agent/blob/8.17/changelog/8.17.4.asciidoc

---

<img width="1128" alt="Screenshot 2025-03-24 at 11 14 12 AM" src="https://github.com/user-attachments/assets/27dbaed3-6899-4f14-82ea-96f26d83ce8a" />
