### PR TITLE
Add note about extended key usage for Logstash output

### DIFF
--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -28,11 +28,15 @@ cluster. For more information, refer to the
 You can use whatever process you typically use to generate PEM-formatted
 certificates. The examples shown here use the `certutil` tool provided by {es}.
 
-TIP: The `certutil` tool is not available on {ecloud}, but you can still use it
+[TIP] 
+==== 
+* The `certutil` tool is not available on {ecloud}, but you can still use it
 to generate certificates for {agent} to {ls} connections. Just
 https://www.elastic.co/downloads/elasticsearch[download an {es} package],
 extract it to a local directory, and run the `elasticsearch-certutil` command.
 There's no need to start {es}!
+* If you choose not to use link:https://www.elastic.co/guide/en/elasticsearch/reference/8.17/certutil.html[certutil], the certificates that you obtain must allow for both clientAuth and serverAuth if the extended key usage extension is present.
+====
 
 . Generate a certificate authority (CA). Skip this step if you want to use an
 existing CA.


### PR DESCRIPTION
This adds the note in green to the [Configure SSL/TLS for the Logstash output](https://www.elastic.co/guide/en/fleet/current/secure-logstash-connections.html#generate-logstash-certs) page.

<img width="756" alt="screen" src="https://github.com/user-attachments/assets/d3969c2a-060b-4d8e-aca6-9f4130e11412" />


In the [docs issue](https://github.com/elastic/ingest-docs/issues/1757) @jguay asked: "Potentially check we use same libbeat code for logstash output managed by fleet so requirements documented for beats would apply equally"

@kpollich  Would you be able to help me with Julien's question, i.e, to verify if this requirement applies to the Fleet Logstash output as it does to Filebeat? 

Assuming that I should merge this PR, I'll then open another one for the 9.0+ docs.



