### PR TITLE
Update warning for Elastic Defend with Remote ES cluster

### DIFF
--- a/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
+++ b/docs/en/ingest-management/fleet/fleet-settings-remote-elasticsearch.asciidoc
@@ -7,7 +7,16 @@ Beginning in version 8.12.0, you can send {agent} data to a remote {es} cluster.
 
 A remote {es} cluster supports the same <<es-output-settings,output settings>> as your main {es} cluster.
 
-WARNING: A bug has been found that causes {elastic-defend} response actions to stop working when a remote {es} output is configured for an agent. This bug is currently being investigated and is expected to be resolved in an upcoming release.
+[WARNING] 
+==== 
+There are currently some limitations with using {elastic-defend} when a remote {es} output is configured for an agent. These issues are currently being investigated and are expected to be resolved in an upcoming release:
+
+* {elastic-defend} response actions do not display results in the management cluster, instead the results go to the output cluster.
+* Restrictions on workflows for Endpoint with the {security-app}:
+
+** Endpoint list page - Elastic Endpoint state documents go to the output cluster so the management cluster doesn't have access to their status.
+** Endpoint exceptions - Endpoint exceptions need to be added in the management cluster. Alerts are sent to the output cluster but "Add Endpoint Exception" workflows don't currently work there.
+====
 
 NOTE: Using a remote {es} output with a target cluster that has {cloud}/ec-traffic-filtering-deployment-configuration.html[traffic filters] enabled is not currently supported.
 


### PR DESCRIPTION
This updates the warning on the [Remote Elasticsearch output](https://www.elastic.co/guide/en/fleet/current/remote-elasticsearch-output.html) page about using Elastic Defend. 

Closes: https://github.com/elastic/security-docs/issues/6711

**original**

<img width="958" alt="Screenshot 2025-04-11 at 11 53 31 AM" src="https://github.com/user-attachments/assets/65c192eb-49d0-47f5-92b6-e19c45f0a3af" />

**updated**
<img width="960" alt="Screenshot 2025-04-11 at 11 53 38 AM" src="https://github.com/user-attachments/assets/58c4b695-fca3-4aca-a0c3-ed224180e468" />
