### PR TITLE
Add Fleet & Agent 8.17.5 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -45,7 +45,7 @@ Review important information about the  8.17.5 release.
 === Bug fixes
 
 {fleet}::
-* Enable unenroll inactive agent tasks to unenroll some agents if the first set returned is equal to `UNENROLLMENT_BATCH_SIZE`. ({kibana-pull}216283[#216283])
+* Enable unenroll inactive agent tasks to unenroll some agents if the first set returned is equal to `UNENROLLMENT_BATCH_SIZE`. {kibana-pull}216283[#216283]
 
 {fleet-server}::
 * Fix host parsing in {es} output diagnostics. {fleet-server-pull}4765[#4765]

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
 * <<release-notes-8.17.2>>
@@ -24,6 +25,40 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.17.5 relnotes
+
+[[release-notes-8.17.5]]
+== {fleet} and {agent} 8.17.5
+
+Review important information about the  8.17.5 release.
+
+[discrete]
+[[enhancements-8.17.5]]
+=== Enhancements
+
+{agent}::
+* Ensure consistent input order In self-monitoring configuration. {agent-pull}7724[#7724] 
+
+[discrete]
+[[bug-fixes-8.17.5]]
+=== Bug fixes
+
+{fleet}::
+* Enable unenroll inactive agent tasks to unenroll some agents if the first set returned is equal to `UNENROLLMENT_BATCH_SIZE`. ({kibana-pull}216283[#216283])
+
+{fleet-server}::
+* Fix host parsing in {es} output diagnostics. {fleet-server-pull}4765[#4765]
+* Redact output log lines during bootstrap configuration. {fleet-server-pull}4775[#4775]
+* Fix concurrent access to remote bulker configuration. {fleet-server-pull}4776[#4776]
+
+{agent}::
+* Change how Windows process handles are obtained when assigning sub-processes to job objects. {agent-pull}6825[#6825] 
+* Rework Windows user password generation to meet security policy constraints. {agent-pull}7507[#7507] {agent-issue}7506[#7506]
+* Wait for Windows service to be fully removed before re-installing during agent switch. {agent-pull}7589[#7589] {agent-issue}6970[#6970]
+* Fix panic during shutdown in `Fleetgateway`. {agent-pull}7629[#7629] {agent-issue}7309[#7309]
+
+// end 8.17.5 relnotes
 
 
 


### PR DESCRIPTION
Adds the 8.17.5 Release Notes:

Fleet contents from: https://github.com/elastic/kibana/pull/217919
Fleet Server contents from: [Changelog file](https://github.com/elastic/fleet-server/tree/20f1ee7c3a65fdf500a044112913cea21faa86f6/changelog/fragments)
Elastic Agent contents from: https://github.com/elastic/elastic-agent/pull/7830

Closes: https://github.com/elastic/ingest-docs/issues/1760

---

<img width="1091" alt="Screenshot 2025-04-14 at 9 34 20 AM" src="https://github.com/user-attachments/assets/cc45be34-a9f7-4031-b018-b770ef579698" />

