### PR TITLE
[8.17] Add Fleet & Agent 8.17.5 Release Notes (#1761)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
 * <<release-notes-8.17.2>>
@@ -24,6 +25,40 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.17.5 relnotes
+
+[[release-notes-8.17.5]]
+== {fleet} and {agent} 8.17.5
+
+Review important information about the  8.17.5 release.
+
+[discrete]
+[[enhancements-8.17.5]]
+=== Enhancements
+
+{agent}::
+* Ensure consistent input order In self-monitoring configuration. {agent-pull}7724[#7724] 
+
+[discrete]
+[[bug-fixes-8.17.5]]
+=== Bug fixes
+
+{fleet}::
+* Enable unenroll inactive agent tasks to unenroll some agents if the first set returned is equal to `UNENROLLMENT_BATCH_SIZE`. {kibana-pull}216283[#216283]
+
+{fleet-server}::
+* Fix host parsing in {es} output diagnostics. {fleet-server-pull}4765[#4765]
+* Redact output log lines during bootstrap configuration. {fleet-server-pull}4775[#4775]
+* Fix concurrent access to remote bulker configuration. {fleet-server-pull}4776[#4776]
+
+{agent}::
+* Change how Windows process handles are obtained when assigning sub-processes to job objects. {agent-pull}6825[#6825] 
+* Rework Windows user password generation to meet security policy constraints. {agent-pull}7507[#7507] {agent-issue}7506[#7506]
+* Wait for Windows service to be fully removed before re-installing during agent switch. {agent-pull}7589[#7589] {agent-issue}6970[#6970]
+* Fix panic during shutdown in `Fleetgateway`. {agent-pull}7629[#7629] {agent-issue}7309[#7309]
+
+// end 8.17.5 relnotes
 
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [Add Fleet & Agent 8.17.5 Release Notes (#1761)](https://github.com/elastic/ingest-docs/pull/1761)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)