### PR TITLE
Update Elastic Agent binary sizes

### DIFF
--- a/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/install-elastic-agent.asciidoc
@@ -96,15 +96,15 @@ Adding integrations will increase the memory used by the agent and its processes
 [discrete]
 === Size on disk
 
-The disk requirements for {agent} vary by operating system and {stack} version. With version 8.14 we have significantly reduced the size of the {agent} binary. Further reductions are planned to be made in future releases.
+The disk requirements for {agent} vary by operating system and {stack} version.
 
 [options,header]
 |===
-|Operating system |8.13 | 8.14 | 8.15
+|Operating system |8.13 | 8.14 | 8.15 | 8.18 | 9.0 |
 
-| **Linux** | 1800 MB | 1018 MB | 1060 MB
-| **macOS** | 1100 MB | 619 MB | 680 MB
-| **Windows** | 891 MB | 504 MB | 500 MB
+| **Linux** | 1800 MB | 1018 MB | 1060 MB | 1.5 GB | 1.5 GB |
+| **macOS** | 1100 MB | 619 MB | 680 MB | 775 MB | 7755 MB |
+| **Windows** | 891 MB | 504 MB | 500 MB | 678 MB | 705 MB |
 |===
 
 During upgrades, double the disk space is required to store the new {agent} binary. After the upgrade completes, the original {agent} is removed from disk to free up the space.


### PR DESCRIPTION
This updates the install sizings for Elastic Agent. The change has been reviewed by Nima. We're intentionally including 9.0 in the table.

---

<img width="1086" alt="Screenshot 2025-04-25 at 9 53 59 AM" src="https://github.com/user-attachments/assets/9df0b8df-13e0-4874-b212-d7665c53caea" />
