### PR TITLE
Add Fleet & Agent 8.17.6 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.6>>
 * <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -26,6 +26,28 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+
+
+
+// begin 8.17.6 relnotes
+
+[[release-notes-8.17.6]]
+== {fleet} and {agent} 8.17.6
+
+Review important information about the  8.17.6 release.
+
+[discrete]
+[[enhancements-8.17.6]]
+=== Enhancements
+
+{agent}::
+* Set collectors fullnameOverride For Elastic Distribution of OTel Collector kube-stack values. {agent-pull}7754[#7754] {agent-issue}7381[#7381]
+
+// end 8.17.6 relnotes
+
+
+
+
 // begin 8.17.5 relnotes
 
 [[release-notes-8.17.5]]

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -42,7 +42,7 @@ Review important information about the  8.17.6 release.
 === Enhancements
 
 {agent}::
-* Set collectors fullnameOverride For Elastic Distribution of OTel Collector kube-stack values. {agent-pull}7754[#7754] {agent-issue}7381[#7381]
+* Use `fullnameOverride` to set the fully qualified application names in the EDOT Kube-Stack Helm chart. {agent-pull}7754[#7754] {agent-issue}7381[#7381]
 
 // end 8.17.6 relnotes
 


### PR DESCRIPTION
Adds the 8.17.6 Release Notes:

Fleet contents TBD: (I'll add this when the Kibana release notes PR is ready, if there is anything)
No new Fleet Server contents in: [Changelog file](https://github.com/elastic/fleet-server/tree/09a9a5d893f58b0d1f54d5cbb36bee9fe319fb15/changelog/fragments)
Elastic Agent contents from: https://github.com/elastic/elastic-agent/pull/8062

---

<img width="634" alt="screen1" src="https://github.com/user-attachments/assets/e24eec1c-1d75-475e-84cc-ed2f2f3bb31a" />
