### PR TITLE
Add Fleet & Agent 8.18.1 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -14,12 +14,35 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.18.1 relnotes
+
+[[release-notes-8.18.1]]
+== {fleet} and {agent} 8.18.1
+
+Review important information about the {fleet} and {agent} 8.18.1 release.
+
+[discrete]
+[[bug-fixes-8.18.1]]
+=== Bug fixes
+
+{fleet-server}::
+* Add `grpcnotrace` build tags and ensure DCE (dead code elimination) is enabled. Reduce binary size by 34%. {fleet-server-pull}4784[#4784]
+
+{agent}::
+
+
+
+
+// end 8.18.1 relnotes
+
 
 // begin 8.18.0 relnotes
 


### PR DESCRIPTION
Adds the 8.18.1 Release Notes:

No Fleet contents in: [(I'll add this when the Kibana release notes PR is ready, if there is anything)](https://github.com/elastic/kibana/pull/219768)
Fleet Server contents from: [Changelog file](https://github.com/elastic/fleet-server/tree/e8447947dea08904b77347107ec48edfa55cf55f/changelog/fragments)
Elastic Agent contents from: TBD