### PR TITLE
[8.18] Add Fleet & Agent 8.17.6 Release Notes (#1789)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.6>>
 * <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
 * <<release-notes-8.17.3>>
@@ -25,6 +26,28 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+
+
+
+// begin 8.17.6 relnotes
+
+[[release-notes-8.17.6]]
+== {fleet} and {agent} 8.17.6
+
+Review important information about the  8.17.6 release.
+
+[discrete]
+[[enhancements-8.17.6]]
+=== Enhancements
+
+{agent}::
+* Use `fullnameOverride` to set the fully qualified application names in the EDOT Kube-Stack Helm chart. {agent-pull}7754[#7754] {agent-issue}7381[#7381]
+
+// end 8.17.6 relnotes
+
+
+
 
 // begin 8.17.5 relnotes
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [Add Fleet & Agent 8.17.6 Release Notes (#1789)](https://github.com/elastic/ingest-docs/pull/1789)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)