### PR TITLE
[8.18] Add Fleet & Agent 8.18.1 Release Notes (#1791)

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -14,12 +14,35 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
 
 Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.18.1 relnotes
+
+[[release-notes-8.18.1]]
+== {fleet} and {agent} 8.18.1
+
+Review important information about the {fleet} and {agent} 8.18.1 release.
+
+[discrete]
+[[bug-fixes-8.18.1]]
+=== Bug fixes
+
+{fleet-server}::
+* Add `grpcnotrace` build tags and ensure DCE (dead code elimination) is enabled. Reduce binary size by 34%. {fleet-server-pull}4784[#4784]
+
+{agent}::
+
+
+
+
+// end 8.18.1 relnotes
+
 
 // begin 8.18.0 relnotes
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [Add Fleet & Agent 8.18.1 Release Notes (#1791)](https://github.com/elastic/ingest-docs/pull/1791)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)