### PR TITLE
github-action: add supported GitHub commands

### DIFF
--- a/.github/workflows/github-commands-comment.yml
+++ b/.github/workflows/github-commands-comment.yml
@@ -1,0 +1,18 @@
+---
+name: github-commands-comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: elastic/oblt-actions/elastic/github-commands@v1


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Explicitly explain what GitHub commands are supported.

## Why

We want to improve our user experience and make it easier for those GitHub commands
that are supported by the Elastic CI Ecosystem.

It uses https://github.com/elastic/oblt-actions/tree/main/elastic/github-commands

If there are any questions, please reach out to the @elastic/observablt-ci
