### PR TITLE
Add Fleet & Agent 8.17.7 Release Notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -27,8 +27,29 @@ Also see:
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
 
+// begin 8.17.7 relnotes
+
+[[release-notes-8.17.7]]
+== {fleet} and {agent} 8.17.7
+
+Review important information about the  8.17.7 release.
+
+[discrete]
+[[security-updates-8.17.7]]
+=== Security updates
+
+elastic-agent::
+* Upgrade Go version to 1.24.3. {agent-pull}8109[https://github.com/elastic/elastic-agent/pull/8109]
 
 
+[discrete]
+[[bug-fixes-8.17.7]]
+=== Bug fixes
+
+elastic-agent::
+* Preserve Agent run state on DEB and RPM upgrades. {agent-pull}7999[https://github.com/elastic/elastic-agent/pull/7999] {agent-issue}3832[https://github.com/elastic/elastic-agent/issues/3832]
+
+// end 8.17.7 relnotes
 
 // begin 8.17.6 relnotes
 
@@ -61,7 +82,7 @@ Review important information about the  8.17.5 release.
 === Enhancements
 
 {agent}::
-* Ensure consistent input order In self-monitoring configuration. {agent-pull}7724[#7724] 
+* Ensure consistent input order In self-monitoring configuration. {agent-pull}7724[#7724]
 
 [discrete]
 [[bug-fixes-8.17.5]]
@@ -76,7 +97,7 @@ Review important information about the  8.17.5 release.
 * Fix concurrent access to remote bulker configuration. {fleet-server-pull}4776[#4776]
 
 {agent}::
-* Change how Windows process handles are obtained when assigning sub-processes to job objects. {agent-pull}6825[#6825] 
+* Change how Windows process handles are obtained when assigning sub-processes to job objects. {agent-pull}6825[#6825]
 * Rework Windows user password generation to meet security policy constraints. {agent-pull}7507[#7507] {agent-issue}7506[#7506]
 * Wait for Windows service to be fully removed before re-installing during agent switch. {agent-pull}7589[#7589] {agent-issue}6970[#6970]
 * Fix panic during shutdown in `Fleetgateway`. {agent-pull}7629[#7629] {agent-issue}7309[#7309]
@@ -126,7 +147,7 @@ In the 9.x releases, the option that appears in the UI for an upgrade across a m
 The 8.17.4 release adds the following new and notable features.
 
 {agent}::
-* Add managed OTLP endpoint sample configurations. {agent-pull}6630[#6630] 
+* Add managed OTLP endpoint sample configurations. {agent-pull}6630[#6630]
 
 [discrete]
 [[enhancements-8.17.4]]
@@ -134,8 +155,8 @@ The 8.17.4 release adds the following new and notable features.
 
 {agent}::
 * Improve `kubernetes_secrets` provider secret logging. {agent-pull}6841[#6841] {agent-issue}6187[#6187]
-* Include all metadata that is sent to {fleet} in the `agent-info.yaml` file in diagnostics by default. {agent-pull}7029[#7029] 
-* Add API key prefix to managed OTLP endpoint host configurations in EDOT collector kube stack Helm chart. {agent-pull}7063[#7063] 
+* Include all metadata that is sent to {fleet} in the `agent-info.yaml` file in diagnostics by default. {agent-pull}7029[#7029]
+* Add API key prefix to managed OTLP endpoint host configurations in EDOT collector kube stack Helm chart. {agent-pull}7063[#7063]
 
 [discrete]
 [[bug-fixes-8.17.4]]
@@ -144,15 +165,15 @@ The 8.17.4 release adds the following new and notable features.
 {agent}::
 * Add conditions to the `copy_fields` processors used with {agent} self-monitoring to prevent spamming the debug logs. {agent-pull}6730[#6730] {agent-issue}5299[#5299]
 * Improve message when Fleet Server's audit API endpoint returns a 401 Unauthorized response. {agent-pull}6735[#6735] {agent-issue}6711[#6711]
-* Fix `secret_paths` redaction along complex paths in diagnostics. {agent-pull}6710[#6710] 
+* Fix `secret_paths` redaction along complex paths in diagnostics. {agent-pull}6710[#6710]
 * Make enroll command backoff more conservative and add backoff when using `--delay-enroll`. {agent-pull}6983[#6983] {agent-issue}6761[#6761]
 * Fix an issue where `fixpermissions` on Windows incorrectly returned an error message due to improper handling of Windows API return values. {agent-pull}7059[#7059] {agent-issue}6917[#6917]
-* Support IPv6 hosts in enroll URL. {agent-pull}7036[#7036] 
-* Support IPv6 hosts in GRPC configuration. {agent-pull}7035[#7035] 
-* Rotate logger output file when writing to a symbolic link. {agent-pull}6938[#6938] 
+* Support IPv6 hosts in enroll URL. {agent-pull}7036[#7036]
+* Support IPv6 hosts in GRPC configuration. {agent-pull}7035[#7035]
+* Rotate logger output file when writing to a symbolic link. {agent-pull}6938[#6938]
 * Do not fail Windows permission updates on missing files or paths. {agent-pull}7305[#7305] {agent-issue}7301[#7301]
-* Make `otelcol` script executable in the Docker image. {agent-pull}7345[#7345] 
-* Fix {es} exporter configuration in `kube-stack` values. {agent-pull}7380[#7380] 
+* Make `otelcol` script executable in the Docker image. {agent-pull}7345[#7345]
+* Fix {es} exporter configuration in `kube-stack` values. {agent-pull}7380[#7380]
 
 // end 8.17.4 relnotes
 
@@ -267,7 +288,7 @@ impact to your application.
 
 *Details*
 
-{ecloud} deployments that use the smallest available {kib} instance size of 1 GB may crash due to out of memory errors when the Security UI is loaded. 
+{ecloud} deployments that use the smallest available {kib} instance size of 1 GB may crash due to out of memory errors when the Security UI is loaded.
 
 *Impact* +
 


### PR DESCRIPTION
Adds the 8.17.7 release notes including:

- [x] The `changelog/8.17.7.asciidoc` file in https://github.com/elastic/elastic-agent/pull/8237
- [ ] Ask @ebeahan if there are any changes to include from the elastic/fleet-server repo
- [x] ~~Any related content from https://github.com/elastic/kibana/pull/221207~~
