### PR TITLE
Doc: Remove note about agent certificate for control plane traffic

### DIFF
--- a/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
+++ b/docs/en/ingest-management/fleet-agent-proxy-managed.asciidoc
@@ -179,6 +179,4 @@ Equally important is the Certificate Authority that the agents need to use to va
 
 image::images/elastic-agent-edit-proxy-secure-settings.png[Screen capture of the Edit Proxy UI, highlighting the Certificate and Certificate key settings]
 
-NOTE: Currently {agents} will not present a certificate for Control Plane traffic to the {fleet-server}. Some proxy servers are setup to mandate that the client setting up a connection presents a certificate to them before allowing that client to connect. This issue will be resolved by link:https://github.com/elastic/elastic-agent/issues/2248[issue #2248]. Our recommendation is to avoid adding a secure proxy as such in a {fleet-server} configuration flyout.
-
 NOTE: In case {kib} is behind a proxy server or is otherwise unable to access the {package-registry} to download package metadata and content, refer to <<epr-proxy-setting>>.


### PR DESCRIPTION
Topic:
- https://www.elastic.co/guide/en/fleet/8.18/fleet-agent-proxy-managed.html

Related: 
- https://github.com/elastic/docs-content/pull/1715/