### PR TITLE
Add  7.17.29 release notes 

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-7.17.asciidoc
@@ -14,6 +14,8 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.29>>
+
 * <<release-notes-7.17.28>>
 
 * <<release-notes-7.17.27>>
@@ -76,6 +78,22 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 7.17.29 relnotes
+
+[[release-notes-7.17.29]]
+== {fleet} and {agent} 7.17.29
+
+Review important information about the {fleet} and {agent} 7.17.29 release.
+
+[discrete]
+[[enhancements-7.17.29]]
+=== Enhancements
+
+{fleet-server}::
+* Update Go to v1.24.4. {fleet-server-pull}5021[#5021]
+
+// end 7.17.29 relnotes
 
 // begin 7.17.28 relnotes
 
@@ -188,7 +206,7 @@ Review important information about the {fleet} and {agent} 7.17.22 release.
 [[release-notes-7.17.21]]
 == {fleet} and {agent} 7.17.21
 
-The <<known-issue-3435,known issue>> introduced in version 7.17.20, that was causing {fleet-server} to fail to bootstrap with self-signed certificates, is resolved in this release. {fleet-server-pull}3473[#3473]  
+The <<known-issue-3435,known issue>> introduced in version 7.17.20, that was causing {fleet-server} to fail to bootstrap with self-signed certificates, is resolved in this release. {fleet-server-pull}3473[#3473]
 
 // end 7.17.21 relnotes
 


### PR DESCRIPTION
Adds  7.17.29 release notes:

- [x] Fleet Server (https://github.com/elastic/fleet-server/pull/5058)
- [x] Elastic Agent (n/a)
- [x] Kibana (n/a)