### PR TITLE
Add 8.18.3 release notes

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.3>>
 * <<release-notes-8.18.2>>
 * <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
@@ -22,6 +23,40 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.18.3 relnotes
+
+[[release-notes-8.18.3]]
+== {fleet} and {agent} 8.18.3
+
+Review important information about the {fleet} and {agent} 8.18.3 release.
+
+[discrete]
+[[new-features-8.18.3]]
+=== New features
+
+The 8.18.3 release adds the following new and notable features.
+
+Elastic Agent::
+
+* Add `Cumulativetodeltaprocessor` To EDOT Collector. {agent-pull}8372[#8372]
+
+[discrete]
+[[bug-fixes-8.18.3]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Ship journalctl in the elastic-agent, elastic-agent-complete, and
+  elastic-otel-collector Docker images to enable reading journald
+  logs. Journalctl is not present on *-slim and all Wolfi images.
+  {agent-pull}7995[#7995] {agent-issue}44040[#44040]
+* Address a race condition that can occur in Agent diagnostics if log rotation runs while logs are being zipped. {agent-pull}8215[#8215]
+* Use `paths.TempDir` for diagnostics actions {agent-pull}8472[#8472]
+* Use Debian 11 to build linux/arm to match linux/amd64. Upgrades linux/arm64's statically linked glibc from 2.28 to 2.31. {agent-pull}8497[#8497]
+* Relax file ownership check to allow admin re-enrollment on Windows. {agent-pull}8503[#8503] {agent-issue}7794[#7794]
+
+// end 8.18.3 relnotes
 
 // begin 8.18.2 relnotes
 


### PR DESCRIPTION
Adds 8.18.3 release notes

- [x] Fleet Server (n/a)
- [x] Elastic Agent (https://github.com/elastic/elastic-agent/pull/8648)
- [x] Kibana (n/a)
