### PR TITLE
Add Fleet Server and Elastic Agent release notes for 8.17.9

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -52,7 +52,7 @@ Fleet::
 
 * Include the base error for JSON decode error responses. {fleet-server-pull}5069[#5069]
 
-// begin 8.17.9 relnotes
+// end 8.17.9 relnotes
 
 // begin 8.17.8 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.9>>
 * <<release-notes-8.17.8>>
 * <<release-notes-8.17.7>>
 * <<release-notes-8.17.6>>
@@ -28,6 +29,30 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.17.9 relnotes
+
+[[release-notes-8.17.9]]
+== {fleet} and {agent} 8.17.9
+
+Review important information about the {fleet} and {agent} 8.17.9 release.
+
+[discrete]
+[[bug-fixes-8.17.9]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Remove incorrect logging that unprivileged installations are in beta. {agent-pull}8715[#8715] {agent-issue}8689[#8689]
+* Ensure standalone Elastic Agent uses log level from configuration instead of persisted state. {agent-pull}8784[#8784] {agent-issue}8137[#8137]
+* Resolve deadlocks in runtime checkin communication. {agent-pull}8881[#8881] {agent-issue}7944[#7944]
+* Remove init.d support from RPM packages. {agent-pull}8896[#8896] {agent-issue}8840[#8840]
+
+Fleet::
+
+* Include the base error for JSON decode error responses. {fleet-server-pull}5069[#5069]
+
+// begin 8.17.9 relnotes
 
 // begin 8.17.8 relnotes
 


### PR DESCRIPTION
Adds Fleet Server and Elastic Agent release notes for 8.17.9 from https://github.com/elastic/elastic-agent/pull/8973 and https://github.com/elastic/fleet-server/pull/5148.

cc @pierrehilbert