### PR TITLE
Add Fleet Server and Elastic Agent release notes for 8.19.0

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -239,7 +239,7 @@ include::troubleshooting/troubleshooting.asciidoc[leveloffset=+2]
 
 include::troubleshooting/faq.asciidoc[leveloffset=+2]
 
-include::release-notes/release-notes-8.18.asciidoc[leveloffset=+1]
+include::release-notes/release-notes-8.19.asciidoc[leveloffset=+1]
 
 include::elastic-agent/install-fleet-managed-agent.asciidoc[leveloffset=+2]
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -33,7 +33,7 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 === Security updates
 
 {agent}::
-* Upgrade To Go 1.24.3. {elastic-agent-pull}8109[#8109]
+* Upgrade To Go 1.24.3. {agent-pull}8109[#8109]
 
 {fleet-server}::
 * Upgrade golang.org/x/net to v0.34.0 and golang.org/x/crypto to v0.32.0. {fleet-server-pull}4405[#4405]
@@ -45,13 +45,13 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 The 8.19.0 release Added the following new and notable features.
 
 {agent}::
-* Set replicas for Gateway Collector. {elastic-agent-pull}7011[#7011]
+* Set replicas for Gateway Collector. {agent-pull}7011[#7011]
 * Add nopexporter to EDOT Collector.
-* Set collectors fullnameOverride for EDOT kube-stack values. {elastic-agent-pull}7754[#7754] {elastic-agent-issue}7381[#7381]
+* Set collectors fullnameOverride for EDOT kube-stack values. {agent-pull}7754[#7754] {agent-issue}7381[#7381]
 * Add cumulativetodeltaprocessor to EDOT Collector.
 * Add apmconfig and apikeyauth OTel extensions.
 * Add bearertokenauth OTel extension.
-* Remove resource/k8s processor and use k8sattributes processor for service attributes. {elastic-agent-pull}8599[#8599]
+* Remove resource/k8s processor and use k8sattributes processor for service attributes. {agent-pull}8599[#8599]
 +
 This PR removes the `resource/k8s` processor in honour of the k8sattributes processor that
 provides native support for the service attributes:
@@ -69,22 +69,22 @@ https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#servic
 === Enhancements
 
 {agent}::
-* Allow upgrading deb or rpm agents when using Elastic Defend with tamper protection. {elastic-agent-pull}6907[#6907] {elastic-agent-issue}6394[#6394]
-* Include all metadata that is sent to Fleet in the agent-info.yaml file in diagnostics by default. {elastic-agent-pull}7029[#7029]
-* Add ApiKey prefix to Motel host configurations. {elastic-agent-pull}7063[#7063]
-* Add elastic.agent.fips to local_metadata. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7112[#7112] {elastic-agent-issue}7112[#7112]
-* Validate pbkdf2 settings when in FIPS mode. {elastic-agent-pull}7187[#7187]
-* FIPS compliant agent file vault. {elastic-agent-pull}7360[#7360]
-* With this change FIPS compliant agents will only be able to upgrade to other FIPS compliant agents. This change also restricts non-FIPS to FIPS upgrades as well. {elastic-agent-pull}7312[#7312]
-* Updated the error messages returned for FIPS upgrades. {elastic-agent-pull}7453[#7453]
+* Allow upgrading deb or rpm agents when using Elastic Defend with tamper protection. {agent-pull}6907[#6907] {agent-issue}6394[#6394]
+* Include all metadata that is sent to Fleet in the agent-info.yaml file in diagnostics by default. {agent-pull}7029[#7029]
+* Add ApiKey prefix to Motel host configurations. {agent-pull}7063[#7063]
+* Add elastic.agent.fips to local_metadata. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}7112[#7112] {agent-issue}7112[#7112]
+* Validate pbkdf2 settings when in FIPS mode. {agent-pull}7187[#7187]
+* FIPS compliant agent file vault. {agent-pull}7360[#7360]
+* With this change FIPS compliant agents will only be able to upgrade to other FIPS compliant agents. This change also restricts non-FIPS to FIPS upgrades as well. {agent-pull}7312[#7312]
+* Updated the error messages returned for FIPS upgrades. {agent-pull}7453[#7453]
 * Update OTel components to v0.121.0.
-* Update OTel components to v0.122.0. {elastic-agent-pull}7725[#7725]
-* Update OTel components to v0.123.0. {elastic-agent-pull}7996[#7996]
-* Retry enrollment requests on any error. {elastic-agent-pull}8056[#8056]
+* Update OTel components to v0.122.0. {agent-pull}7725[#7725]
+* Update OTel components to v0.123.0. {agent-pull}7996[#7996]
+* Retry enrollment requests on any error. {agent-pull}8056[#8056]
 * Update OTel components to v0.125.0.
 * Update OTel components to v0.127.0.
-* Remove deprecated OTel Elasticsearch exporter config `*_dynamic_index` from code and samples. {elastic-agent-pull}8592[#8592]
-* Include the forwardconnector as an EDOT collector component. {elastic-agent-pull}8753[#8753]
+* Remove deprecated OTel Elasticsearch exporter config `*_dynamic_index` from code and samples. {agent-pull}8592[#8592]
+* Include the forwardconnector as an EDOT collector component. {agent-pull}8753[#8753]
 * Update OTel components to v0.129.0.
 * Update apm config extension to v0.4.0.
 * Update Elastic trace processor to v0.7.0.
@@ -112,28 +112,28 @@ https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#servic
 === Bug fixes
 
 {agent}::
-* Fix TSDB version_conflict_engine_exception caused by incorrect kube-stack Helm values. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}6928[#6928]
-* Make enroll command backoff more conservative. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}6983[#6983] {elastic-agent-issue}6761[#6761]
-* Add missing null checks to AST methods. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7009[#7009] {elastic-agent-issue}6999[#6999]
-* Fixes an issue where `fixpermissions` on Windows incorrectly returned an error message due to improper handling of Windows API return values. {elastic-agent-pull}7059[#7059] {elastic-agent-issue}6917[#6917]
-* Support IPv6 hosts in enroll URL. {elastic-agent-pull}7036[#7036]
-* Support IPv6 host in gRPC config. {elastic-agent-pull}7035[#7035]
-* Support IPv6 host in agent monitoring HTTP config. {elastic-agent-pull}7073[#7073]
+* Fix TSDB version_conflict_engine_exception caused by incorrect kube-stack Helm values. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}6928[#6928]
+* Make enroll command backoff more conservative. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}6983[#6983] {agent-issue}6761[#6761]
+* Add missing null checks to AST methods. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}7009[#7009] {agent-issue}6999[#6999]
+* Fixes an issue where `fixpermissions` on Windows incorrectly returned an error message due to improper handling of Windows API return values. {agent-pull}7059[#7059] {agent-issue}6917[#6917]
+* Support IPv6 hosts in enroll URL. {agent-pull}7036[#7036]
+* Support IPv6 host in gRPC config. {agent-pull}7035[#7035]
+* Support IPv6 host in agent monitoring HTTP config. {agent-pull}7073[#7073]
 * Rotate logger output file when writing to a symbolic link. elastic-agent-pull}6938[#6938]
-* Do not fail Windows permission updates on missing files/paths. {elastic-agent-pull}7305[#7305] {elastic-agent-issue}7301[#7301]
-* Make `otelcol` executable in the Docker image. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7345[#7345]
-* Fix Elasticsearch exporter configuration in kube-stack values. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7380[#7380]
-* Ship journalctl in the elastic-agent, elastic-agent-complete, and elastic-agent-ubi Docker images to enable reading journald logs. Journalctl is not present on Wolfi images. {elastic-agent-pull}8492[#8492] https://github.com/elastic/beats/issues/44040[#44040]
-* Preserve agent run state on DEB and RPM upgrades. {elastic-agent-pull}7999[#7999] {elastic-agent-issue}3832[#3832]
-* Use --header from enrollment when communicating with Fleet Server. {elastic-agent-pull}8071[#8071] {elastic-agent-issue}6823[#6823]
+* Do not fail Windows permission updates on missing files/paths. {agent-pull}7305[#7305] {agent-issue}7301[#7301]
+* Make `otelcol` executable in the Docker image. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}7345[#7345]
+* Fix Elasticsearch exporter configuration in kube-stack values. {agent-pull}9159[#9159] {agent-pull}8939[#8939] {agent-pull}9029[#9029] {agent-pull}9095[#9095] {agent-pull}8671[#8671] {agent-pull}8672[#8672] {agent-pull}9143[#9143] {agent-pull}7380[#7380]
+* Ship journalctl in the elastic-agent, elastic-agent-complete, and elastic-agent-ubi Docker images to enable reading journald logs. Journalctl is not present on Wolfi images. {agent-pull}8492[#8492] https://github.com/elastic/beats/issues/44040[#44040]
+* Preserve agent run state on DEB and RPM upgrades. {agent-pull}7999[#7999] {agent-issue}3832[#3832]
+* Use --header from enrollment when communicating with Fleet Server. {agent-pull}8071[#8071] {agent-issue}6823[#6823]
 * Address a race condition that can occur in agent diagnostics if log rotation runs while logs are being zipped.
-* Use paths.tempdir for diagnostics actions. {elastic-agent-pull}8472[#8472]
-* Use Debian 11 to build Linux/ARM to match Linux/AMD64. Upgrades Linux/ARM64's statically linked glibc from 2.28 to 2.31. {elastic-agent-pull}8497[#8497]
-* Relax file ownership check to allow admin re-enrollment on Windows. {elastic-agent-pull}8503[#8503] {elastic-agent-issue}7794[#7794]
-* Remove incorrect logging that unprivileged installations are in beta. {elastic-agent-pull}8715[#8715] {elastic-agent-issue}8689[#8689]
-* Ensure standalone Elastic Agent uses log level from configuration instead of persisted state. {elastic-agent-pull}8784[#8784] {elastic-agent-issue}8137[#8137]
-* Resolve deadlocks in runtime checkin communication. {elastic-agent-pull}8881[#8881] {elastic-agent-issue}7944[#7944]
-* Removed init.d support from RPM packages. {elastic-agent-pull}8896[#8896] {elastic-agent-issue}8840[#8840]
+* Use paths.tempdir for diagnostics actions. {agent-pull}8472[#8472]
+* Use Debian 11 to build Linux/ARM to match Linux/AMD64. Upgrades Linux/ARM64's statically linked glibc from 2.28 to 2.31. {agent-pull}8497[#8497]
+* Relax file ownership check to allow admin re-enrollment on Windows. {agent-pull}8503[#8503] {agent-issue}7794[#7794]
+* Remove incorrect logging that unprivileged installations are in beta. {agent-pull}8715[#8715] {agent-issue}8689[#8689]
+* Ensure standalone Elastic Agent uses log level from configuration instead of persisted state. {agent-pull}8784[#8784] {agent-issue}8137[#8137]
+* Resolve deadlocks in runtime checkin communication. {agent-pull}8881[#8881] {agent-issue}7944[#7944]
+* Removed init.d support from RPM packages. {agent-pull}8896[#8896] {agent-issue}8840[#8840]
 
 {fleet-server}::
 * Added context deadline around flush bulk queue. {fleet-server-pull}5179[#5179] {fleet-server-pull}5043[#5043] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}3986[#3986]

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -1,0 +1,151 @@
+// Use these for links to issue and pulls.
+:kibana-issue: https://github.com/elastic/kibana/issues/
+:kibana-pull: https://github.com/elastic/kibana/pull/
+:beats-issue: https://github.com/elastic/beats/issues/
+:beats-pull: https://github.com/elastic/beats/pull/
+:agent-libs-pull: https://github.com/elastic/elastic-agent-libs/pull/
+:agent-issue: https://github.com/elastic/elastic-agent/issues/
+:agent-pull: https://github.com/elastic/elastic-agent/pull/
+:fleet-server-issue: https://github.com/elastic/fleet-server/issues/
+:fleet-server-pull: https://github.com/elastic/fleet-server/pull/
+
+[[release-notes]]
+= Release notes
+
+This section summarizes the changes in each release.
+
+* <<release-notes-8.19.0>>
+
+Also see:
+
+* {kibana-ref}/release-notes.html[{kib} release notes]
+* {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.0 relnotes
+
+[[release-notes-8.19.0]]
+== {fleet} and {agent} 8.19.0
+
+Review important information about the {fleet} and {agent} 8.19.0 release.
+
+[discrete]
+[[security-updates-8.19.0]]
+=== Security updates
+
+{agent}::
+* Upgrade To Go 1.24.3. {elastic-agent-pull}8109[#8109]
+
+{fleet-server}::
+* Upgrade golang.org/x/net to v0.34.0 and golang.org/x/crypto to v0.32.0. {fleet-server-pull}4405[#4405]
+
+[discrete]
+[[new-features-8.19.0]]
+=== New features
+
+The 8.19.0 release Added the following new and notable features.
+
+{agent}::
+* Set replicas for Gateway Collector. {elastic-agent-pull}7011[#7011]
+* Add nopexporter to EDOT Collector.
+* Set collectors fullnameOverride for EDOT kube-stack values. {elastic-agent-pull}7754[#7754] {elastic-agent-issue}7381[#7381]
+* Add cumulativetodeltaprocessor to EDOT Collector.
+* Add apmconfig and apikeyauth OTel extensions.
+* Add bearertokenauth OTel extension.
+* Remove resource/k8s processor and use k8sattributes processor for service attributes. {elastic-agent-pull}8599[#8599]
++
+This PR removes the `resource/k8s` processor in honour of the k8sattributes processor that
+provides native support for the service attributes:
+https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.127.0/processor/k8sattributesprocessor#configuring-recommended-resource-attributes
++
+This change is aligned with the respective semantic conventions' guidance:
+https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes
+* Rename OTel collector config file in diagnostics from otel-final.yaml to otel-merged.yaml.
+
+{fleet-server}::
+* Add ability for enrollment to take an agent id. {fleet-server-pull}4290[#4290] {fleet-server-issue}4226[#4226]
+
+[discrete]
+[[enhancements-8.19.0]]
+=== Enhancements
+
+{agent}::
+* Allow upgrading deb or rpm agents when using Elastic Defend with tamper protection. {elastic-agent-pull}6907[#6907] {elastic-agent-issue}6394[#6394]
+* Include all metadata that is sent to Fleet in the agent-info.yaml file in diagnostics by default. {elastic-agent-pull}7029[#7029]
+* Add ApiKey prefix to Motel host configurations. {elastic-agent-pull}7063[#7063]
+* Add elastic.agent.fips to local_metadata. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7112[#7112] {elastic-agent-issue}7112[#7112]
+* Validate pbkdf2 settings when in FIPS mode. {elastic-agent-pull}7187[#7187]
+* FIPS compliant agent file vault. {elastic-agent-pull}7360[#7360]
+* With this change FIPS compliant agents will only be able to upgrade to other FIPS compliant agents. This change also restricts non-FIPS to FIPS upgrades as well. {elastic-agent-pull}7312[#7312]
+* Updated the error messages returned for FIPS upgrades. {elastic-agent-pull}7453[#7453]
+* Update OTel components to v0.121.0.
+* Update OTel components to v0.122.0. {elastic-agent-pull}7725[#7725]
+* Update OTel components to v0.123.0. {elastic-agent-pull}7996[#7996]
+* Retry enrollment requests on any error. {elastic-agent-pull}8056[#8056]
+* Update OTel components to v0.125.0.
+* Update OTel components to v0.127.0.
+* Remove deprecated OTel Elasticsearch exporter config `*_dynamic_index` from code and samples. {elastic-agent-pull}8592[#8592]
+* Include the forwardconnector as an EDOT collector component. {elastic-agent-pull}8753[#8753]
+* Update OTel components to v0.129.0.
+* Update apm config extension to v0.4.0.
+* Update Elastic trace processor to v0.7.0.
+* Update Elastic APM connector to v0.4.0.
+* Update API key auth extension to v0.2.0.
+* Update Elastic infra metrics processor to v0.16.0.
+
+{fleet-server}::
+* Bump Go to v1.23.5. {fleet-server-pull}4353[#4353]
+* Clear agent.upgrade_attempts when upgrade is complete. {fleet-server-pull}4528[#4528]
+* Pbkdf2 settings validation is FIPS compliant. {fleet-server-pull}4542[#4542]
+* Update to Go v1.24.0. {fleet-server-pull}4543[#4543]
+* Add version metadata to version command output. {fleet-server-pull}4820[#4820]
+* Update Go to v1.24.3. {fleet-server-pull}4891[#4891]
+
+[discrete]
+[[upgrades-8.19.0]]
+=== Upgrades
+
+{agent}::
+* Bump apmconfig extension to v0.3.0.
+
+[discrete]
+[[bug-fixes-8.19.0]]
+=== Bug fixes
+
+{agent}::
+* Fix TSDB version_conflict_engine_exception caused by incorrect kube-stack Helm values. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}6928[#6928]
+* Make enroll command backoff more conservative. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}6983[#6983] {elastic-agent-issue}6761[#6761]
+* Add missing null checks to AST methods. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7009[#7009] {elastic-agent-issue}6999[#6999]
+* Fixes an issue where `fixpermissions` on Windows incorrectly returned an error message due to improper handling of Windows API return values. {elastic-agent-pull}7059[#7059] {elastic-agent-issue}6917[#6917]
+* Support IPv6 hosts in enroll URL. {elastic-agent-pull}7036[#7036]
+* Support IPv6 host in gRPC config. {elastic-agent-pull}7035[#7035]
+* Support IPv6 host in agent monitoring HTTP config. {elastic-agent-pull}7073[#7073]
+* Rotate logger output file when writing to a symbolic link. elastic-agent-pull}6938[#6938]
+* Do not fail Windows permission updates on missing files/paths. {elastic-agent-pull}7305[#7305] {elastic-agent-issue}7301[#7301]
+* Make `otelcol` executable in the Docker image. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7345[#7345]
+* Fix Elasticsearch exporter configuration in kube-stack values. {elastic-agent-pull}9159[#9159] {elastic-agent-pull}8939[#8939] {elastic-agent-pull}9029[#9029] {elastic-agent-pull}9095[#9095] {elastic-agent-pull}8671[#8671] {elastic-agent-pull}8672[#8672] {elastic-agent-pull}9143[#9143] {elastic-agent-pull}7380[#7380]
+* Ship journalctl in the elastic-agent, elastic-agent-complete, and elastic-agent-ubi Docker images to enable reading journald logs. Journalctl is not present on Wolfi images. {elastic-agent-pull}8492[#8492] https://github.com/elastic/beats/issues/44040[#44040]
+* Preserve agent run state on DEB and RPM upgrades. {elastic-agent-pull}7999[#7999] {elastic-agent-issue}3832[#3832]
+* Use --header from enrollment when communicating with Fleet Server. {elastic-agent-pull}8071[#8071] {elastic-agent-issue}6823[#6823]
+* Address a race condition that can occur in agent diagnostics if log rotation runs while logs are being zipped.
+* Use paths.tempdir for diagnostics actions. {elastic-agent-pull}8472[#8472]
+* Use Debian 11 to build Linux/ARM to match Linux/AMD64. Upgrades Linux/ARM64's statically linked glibc from 2.28 to 2.31. {elastic-agent-pull}8497[#8497]
+* Relax file ownership check to allow admin re-enrollment on Windows. {elastic-agent-pull}8503[#8503] {elastic-agent-issue}7794[#7794]
+* Remove incorrect logging that unprivileged installations are in beta. {elastic-agent-pull}8715[#8715] {elastic-agent-issue}8689[#8689]
+* Ensure standalone Elastic Agent uses log level from configuration instead of persisted state. {elastic-agent-pull}8784[#8784] {elastic-agent-issue}8137[#8137]
+* Resolve deadlocks in runtime checkin communication. {elastic-agent-pull}8881[#8881] {elastic-agent-issue}7944[#7944]
+* Removed init.d support from RPM packages. {elastic-agent-pull}8896[#8896] {elastic-agent-issue}8840[#8840]
+
+{fleet-server}::
+* Added context deadline around flush bulk queue. {fleet-server-pull}5179[#5179] {fleet-server-pull}5043[#5043] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}3986[#3986]
+* Fix server.address field in HTTP logs. {fleet-server-pull}5179[#5179] {fleet-server-pull}5043[#5043] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}4142[#4142]
+* Remove race in remote bulker access. {fleet-server-pull}5179[#5179] {fleet-server-pull}5043[#5043] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}4171[#4171] {fleet-server-issue}4170[#4170]
+* Audit/unenroll should not set unenrolled_at attribute. {fleet-server-pull}4221[#4221] {fleet-server-issue}6213[#6213]
+* Remove auth requirement from PGP key endpoint. {fleet-server-pull}5179[#5179] {fleet-server-pull}5043[#5043] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}4256[#4256] {fleet-server-issue}4255[#4255]
+* Return HTTP 429 when connection limit is reached. {fleet-server-pull}5179[#5179] {fleet-server-pull}5062[#5062] {fleet-server-pull}5063[#5063] {fleet-server-pull}4402[#4402] {fleet-server-issue}4200[#4200]
+* Fix host parsing in Elasticsearch output diagnostics. {fleet-server-pull}4765[#4765]
+* Redact output in bootstrap config logs. {fleet-server-pull}4775[#4775]
+* Mutex protection for remote bulker config. {fleet-server-pull}4776[#4776]
+* Enable dead code elimination. {fleet-server-pull}4784[#4784]
+* Include the base error for JSON decode error responses. {fleet-server-pull}5069[#5069]
+
+// end 8.19.0 relnotes


### PR DESCRIPTION
Adds Fleet Server and Elastic Agent release notes for 8.19.0 from https://github.com/elastic/elastic-agent/pull/9159 and https://github.com/elastic/fleet-server/pull/5179.

cc @ebeahan 