### PR TITLE
[8.19] Add a known issue for Elastic Agents getting stuck in an `upgrade scheduled` state

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -49,7 +49,7 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 
 *Details* +
 
-There is a known issue where after a scheduled {agent} upgrade is cancelled, {agent} remains in an `Upgrade scheduled` state, and attempting to restart the upgrade on the UI returns an error: `The selected agent is not upgradeable: agent is already being upgraded.`.
+There is a known issue where {agent} remains in an `Upgrade scheduled` state when a scheduled {agent} upgrade is cancelled. Attempting to restart the upgrade on the UI returns an error: `The selected agent is not upgradeable: agent is already being upgraded.`.
 
 *Impact* +
 
@@ -61,7 +61,7 @@ curl --request POST \
   --url https://<KIBANA_HOST>/api/fleet/agents/<AGENT_ID>/upgrade \
   --user "<SUPERUSER_NAME>:<SUPERUSER_PASSWORD>" \
   --header 'Content-Type: application/json' \
-  --header 'kbn-xsrf: as' \
+  --header 'kbn-xsrf: true' \
   --data '{"version": "<VERSION>","force": true}'
 ----
 
@@ -73,7 +73,7 @@ curl --request POST \
   --url https://<KIBANA_HOST>/api/fleet/agents/bulk_upgrade \
   --user "<SUPERUSER_NAME>:<SUPERUSER_PASSWORD>" \
   --header 'Content-Type: application/json' \
-  --header 'kbn-xsrf: as' \
+  --header 'kbn-xsrf: true' \
   --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
 ----
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -42,9 +42,7 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 [[known-issues-8.19.0]]
 === Known issues
 
-{agent}::
-
-[[known-issue-issue#]]
+[[known-issue-2285-8.19.0]]
 .{agents} remain in an "Upgrade scheduled" state
 [%collapsible]
 ====

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -39,6 +39,49 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 * Upgrade golang.org/x/net to v0.34.0 and golang.org/x/crypto to v0.32.0. {fleet-server-pull}4405[#4405]
 
 [discrete]
+[[known-issues-8.19.0]]
+=== Known issues
+
+{agent}::
+
+[[known-issue-issue#]]
+.{agents} remain in an "Upgrade scheduled" state
+[%collapsible]
+====
+
+*Details* +
+
+There is a known issue where after a scheduled {agent} upgrade is cancelled, {agent} remains in an `Upgrade scheduled` state, and attempting to restart the upgrade on the UI returns an error: `The selected agent is not upgradeable: agent is already being upgraded.`.
+
+*Impact* +
+
+Until this issue is fixed in a later patch version, you can call the https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-agents-agentid-upgrade[Upgrade an agent] endpoint of the Kibana Fleet API with the `force` parameter set to `true` to force-upgrade the {agent}:
+
+[source,shell]
+----
+curl --request POST \
+  --url https://<KIBANA_HOST>/api/fleet/agents/<AGENT_ID>/upgrade \
+  --user "<SUPERUSER_NAME>:<SUPERUSER_PASSWORD>" \
+  --header 'Content-Type: application/json' \
+  --header 'kbn-xsrf: as' \
+  --data '{"version": "<VERSION>","force": true}'
+----
+
+To force-upgrade multiple {agents}, call the https://www.elastic.co/docs/api/doc/kibana/operation/operation-post-fleet-agents-bulk-upgrade[Bulk upgrade agents] endpoint of the Kibana Fleet API with the `force` parameter set to `true`:
+
+[source,shell]
+----
+curl --request POST \
+  --url https://<KIBANA_HOST>/api/fleet/agents/bulk_upgrade \
+  --user "<SUPERUSER_NAME>:<SUPERUSER_PASSWORD>" \
+  --header 'Content-Type: application/json' \
+  --header 'kbn-xsrf: as' \
+  --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
+----
+
+====
+
+[discrete]
 [[new-features-8.19.0]]
 === New features
 


### PR DESCRIPTION
This PR adds a known issue for Elastic Agents getting stuck in an `upgrade scheduled` state.

Contributes to closing https://github.com/elastic/docs-content/issues/2285
Related to https://github.com/elastic/docs-content/pull/2324 (PR for the 9.x releases)
Related to https://github.com/elastic/ingest-docs/pull/1842 (PR for the 8.18.x releases)