### PR TITLE
[8.19] Add a known issue for Elastic Agent not processing Windows security events

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -42,6 +42,21 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 [[known-issues-8.19.0]]
 === Known issues
 
+[[known-issue-2398-8.19.0]]
+.{agent} does not process Windows security events
+[%collapsible]
+====
+
+*Details* +
+
+There is a known issue where {agent} does not process Windows security events on hosts running Windows 10, Windows 11, and Windows Server 2022.
+
+*Impact* +
+
+No workaround is available at the moment, but a fix is expected to be available in {agent} 8.19.1.
+
+====
+
 [[known-issue-2285-8.19.0]]
 .{agents} remain in an "Upgrade scheduled" state
 [%collapsible]


### PR DESCRIPTION
This PR adds a known issue in the release notes for Elastic Agent not processing Windows security events (https://github.com/elastic/beats/issues/45693).

Contributes to closing https://github.com/elastic/docs-content/issues/2398
Related PR: https://github.com/elastic/docs-content/pull/2400 (9.1.0)