### PR TITLE
[8.19] Add a known issue for missing "Agent logging level" setting

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -42,6 +42,21 @@ Review important information about the {fleet} and {agent} 8.19.0 release.
 [[known-issues-8.19.0]]
 === Known issues
 
+[[known-issue-2444-8.19.0]]
+.Setting the log level on individual {agents} is not possible
+[%collapsible]
+====
+
+*Details* +
+
+There is a known issue where it is not possible to set the log level on individual {agents} as the *Agent logging level* setting is not available on the {agent}'s details page.
+
+*Impact* +
+
+No workaround is available at the moment, but a fix is expected to be available in a future patch release.
+
+====
+
 [[known-issue-2398-8.19.0]]
 .{agent} does not process Windows security events
 [%collapsible]

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -53,7 +53,7 @@ There is a known issue where it is not possible to set the log level on individu
 
 *Impact* +
 
-No workaround is available at the moment, but a fix is expected to be available in a future patch release.
+No workaround is available at the moment, but a fix is expected to be available in a future patch release. Note that the agent logging level can still be set on a per-policy basis in the agent policy's *Settings* tab.
 
 ====
 


### PR DESCRIPTION
This PR adds a known issue for the missing **Agent logging level** setting on the Elastic Agent's details page.

Closes https://github.com/elastic/docs-content/issues/2444