### PR TITLE
Add Fleet Server and Elastic Agent release notes for 8.17.10

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.17.10>>
 * <<release-notes-8.17.9>>
 * <<release-notes-8.17.8>>
 * <<release-notes-8.17.7>>
@@ -29,6 +30,23 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.17.10 relnotes
+
+[[release-notes-8.17.10]]
+==  8.17.10
+
+Review important information about the  8.17.10 release.
+
+[discrete]
+[[bug-fixes-8.17.10]]
+=== Bug fixes
+
+Fleet Server::
+
+* Fix upgrade details download_rate as string handling. {fleet-server-pull}5219[#5219] {fleet-server-pull}5225[#5225] {fleet-server-pull}5176[#5176] {fleet-server-issue}5164[#5164]
+
+// end 8.17.10 relnotes
 
 // begin 8.17.9 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.17.asciidoc
@@ -34,9 +34,9 @@ Also see:
 // begin 8.17.10 relnotes
 
 [[release-notes-8.17.10]]
-==  8.17.10
+== {fleet} and {agent} 8.17.10
 
-Review important information about the  8.17.10 release.
+Review important information about the 8.17.10 release.
 
 [discrete]
 [[bug-fixes-8.17.10]]
@@ -44,7 +44,7 @@ Review important information about the  8.17.10 release.
 
 Fleet Server::
 
-* Fix upgrade details download_rate as string handling. {fleet-server-pull}5219[#5219] {fleet-server-pull}5225[#5225] {fleet-server-pull}5176[#5176] {fleet-server-issue}5164[#5164]
+* Fix upgrade details `download_rate` as string handling. {fleet-server-pull}5219[#5219] {fleet-server-pull}5225[#5225] {fleet-server-pull}5176[#5176] {fleet-server-issue}5164[#5164]
 
 // end 8.17.10 relnotes
 


### PR DESCRIPTION
Adds Fleet Server release notes for 8.17.10 from https://github.com/elastic/fleet-server/pull/5230.

Note: There are no Elastic Agent release notes.