### PR TITLE
Doc: Add Fleet Server and Elastic Agent release notes for 8.19.4

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -55,14 +55,9 @@ Elastic Agent::
 
 
 Fleet Server::
-* Restore connection limiter. link:https://github.com/elastic/fleet-server/pull/5372[#5372] 
-
-  Restore connection level limiter to prevent OOM incidents.
-  This limiter is used in addition to the request-level throttle so that once
-  our in-flight requests reaches max_connections a 429 is returned, but if the
-  total connections the server uses is over max_connections*1.1 the server drops
-  the connection before the TLS handshake.
-
+* Restore connection limiter. link:https://github.com/elastic/fleet-server/pull/5372[#5372]
++
+Restore connection level limiter to prevent OOM incidents. This limiter is used in addition to the request-level throttle so that once our in-flight requests reaches max_connections a 429 is returned, but if the total connections the server uses is over max_connections*1.1 the server dropsthe connection before the TLS handshake.
 * Build fleet-server as fully static binary to restore OS matrix compatibility. link:https://github.com/elastic/fleet-server/pull/5392[#5392] link:https://github.com/elastic/fleet-server/issues/5262[#5262]
  
 // end 8.19.4 relnotes

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.4>>
 * <<release-notes-8.19.3>>
 * <<release-notes-8.19.2>>
 * <<release-notes-8.19.1>>
@@ -23,6 +24,46 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.4 relnotes
+
+[[release-notes-8.19.4]]
+== {fleet} and {agent} 8.19.4
+
+[discrete]
+[[features-enhancements-8.19.4]]
+=== New features and enhancements
+
+Elastic Agent::
+* Bump kube-stack Helm Chart to 0.9.1 and enable the cluster collector. [#9535](https://github.com/elastic/elastic-agent/pull/9535) 
+* Enhanced loggers for easier debugging of upgrade related issues. [#9689](https://github.com/elastic/elastic-agent/pull/9689) [#9536](https://github.com/elastic/elastic-agent/issues/9536)
+
+[discrete]
+[[bug-fixes-8.19.4]]
+=== Bug fixes
+
+Elastic Agent::
+* Redact secrets from pre-config, computed-config, components-expected, and components-actual files in diagnostics archive. [#9560](https://github.com/elastic/elastic-agent/pull/9560) 
+* Retry service start command upon failure with 30-second delay. [#9313](https://github.com/elastic/elastic-agent/pull/9313) 
+* Fix reporting of scheduled upgrade details across restarts and cancels. [#9562](https://github.com/elastic/elastic-agent/pull/9562) [#8778](https://github.com/elastic/elastic-agent/issues/8778)
+* Enable root user to re-enroll unprivileged agent for mac and linux. [#9603](https://github.com/elastic/elastic-agent/pull/9603) [#8544](https://github.com/elastic/elastic-agent/issues/8544)
+* Fix missing liveness healthcheck during container enrollment. [#9612](https://github.com/elastic/elastic-agent/pull/9612) [#9611](https://github.com/elastic/elastic-agent/issues/9611)
+* Enable admin user to re-enroll unprivileged agent for windows. [#9623](https://github.com/elastic/elastic-agent/pull/9623) [#8544](https://github.com/elastic/elastic-agent/issues/8544)
+* Treat exit code 284 from Endpoint binary as non-fatal. [#9687](https://github.com/elastic/elastic-agent/pull/9687) 
+* Ensure failed upgrade actions are removed from queue and details are set. [#9634](https://github.com/elastic/elastic-agent/pull/9634) [#9629](https://github.com/elastic/elastic-agent/issues/9629)
+
+Fleet Server::
+* Restore connection limiter. [#5372](https://github.com/elastic/fleet-server/pull/5372) 
+
+  Restore connection level limiter to prevent OOM incidents.
+  This limiter is used in addition to the request-level throttle so that once
+  our in-flight requests reaches max_connections a 429 is returned, but if the
+  total connections the server uses is over max_connections*1.1 the server drops
+  the connection before the TLS handshake.
+
+* Build fleet-server as fully static binary to restore OS matrix compatibility. [#5392](https://github.com/elastic/fleet-server/pull/5392) [#5262](https://github.com/elastic/fleet-server/issues/5262)
+
+// end 8.19.4 relnotes
 
 // begin 8.19.3 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -35,25 +35,27 @@ Also see:
 === New features and enhancements
 
 Elastic Agent::
-* Bump kube-stack Helm Chart to 0.9.1 and enable the cluster collector. [#9535](https://github.com/elastic/elastic-agent/pull/9535) 
-* Enhanced loggers for easier debugging of upgrade related issues. [#9689](https://github.com/elastic/elastic-agent/pull/9689) [#9536](https://github.com/elastic/elastic-agent/issues/9536)
+* Bump kube-stack Helm Chart to 0.9.1 and enable the cluster collector. link:https://github.com/elastic/elastic-agent/pull/9535[#9535] 
+* Enhanced loggers for easier debugging of upgrade related issues. link:https://github.com/elastic/elastic-agent/pull/9689[#9689] link:https://github.com/elastic/elastic-agent/issues/9536[#9536]
+
 
 [discrete]
 [[bug-fixes-8.19.4]]
 === Bug fixes
 
 Elastic Agent::
-* Redact secrets from pre-config, computed-config, components-expected, and components-actual files in diagnostics archive. [#9560](https://github.com/elastic/elastic-agent/pull/9560) 
-* Retry service start command upon failure with 30-second delay. [#9313](https://github.com/elastic/elastic-agent/pull/9313) 
-* Fix reporting of scheduled upgrade details across restarts and cancels. [#9562](https://github.com/elastic/elastic-agent/pull/9562) [#8778](https://github.com/elastic/elastic-agent/issues/8778)
-* Enable root user to re-enroll unprivileged agent for mac and linux. [#9603](https://github.com/elastic/elastic-agent/pull/9603) [#8544](https://github.com/elastic/elastic-agent/issues/8544)
-* Fix missing liveness healthcheck during container enrollment. [#9612](https://github.com/elastic/elastic-agent/pull/9612) [#9611](https://github.com/elastic/elastic-agent/issues/9611)
-* Enable admin user to re-enroll unprivileged agent for windows. [#9623](https://github.com/elastic/elastic-agent/pull/9623) [#8544](https://github.com/elastic/elastic-agent/issues/8544)
-* Treat exit code 284 from Endpoint binary as non-fatal. [#9687](https://github.com/elastic/elastic-agent/pull/9687) 
-* Ensure failed upgrade actions are removed from queue and details are set. [#9634](https://github.com/elastic/elastic-agent/pull/9634) [#9629](https://github.com/elastic/elastic-agent/issues/9629)
+* Redact secrets from pre-config, computed-config, components-expected, and components-actual files in diagnostics archive. link:https://github.com/elastic/elastic-agent/pull/9560[#9560] 
+* Retry service start command upon failure with 30-second delay. link:https://github.com/elastic/elastic-agent/pull/9313[#9313] 
+* Fix reporting of scheduled upgrade details across restarts and cancels. link:https://github.com/elastic/elastic-agent/pull/9562[#9562] link:https://github.com/elastic/elastic-agent/issues/8778[#8778]
+* Enable root user to re-enroll unprivileged agent for mac and linux. link:https://github.com/elastic/elastic-agent/pull/9603[#9603] link:https://github.com/elastic/elastic-agent/issues/8544[#8544]
+* Fix missing liveness healthcheck during container enrollment. link:https://github.com/elastic/elastic-agent/pull/9612[#9612] link:https://github.com/elastic/elastic-agent/issues/9611[#9611]
+* Enable admin user to re-enroll unprivileged agent for windows. link:https://github.com/elastic/elastic-agent/pull/9623[#9623] link:https://github.com/elastic/elastic-agent/issues/8544[#8544]
+* Treat exit code 284 from Endpoint binary as non-fatal. link:https://github.com/elastic/elastic-agent/pull/9687[#9687] 
+* Ensure failed upgrade actions are removed from queue and details are set. link:https://github.com/elastic/elastic-agent/pull/9634[#9634] link:https://github.com/elastic/elastic-agent/issues/9629[#9629]
+
 
 Fleet Server::
-* Restore connection limiter. [#5372](https://github.com/elastic/fleet-server/pull/5372) 
+* Restore connection limiter. link:https://github.com/elastic/fleet-server/pull/5372[#5372] 
 
   Restore connection level limiter to prevent OOM incidents.
   This limiter is used in addition to the request-level throttle so that once
@@ -61,8 +63,8 @@ Fleet Server::
   total connections the server uses is over max_connections*1.1 the server drops
   the connection before the TLS handshake.
 
-* Build fleet-server as fully static binary to restore OS matrix compatibility. [#5392](https://github.com/elastic/fleet-server/pull/5392) [#5262](https://github.com/elastic/fleet-server/issues/5262)
-
+* Build fleet-server as fully static binary to restore OS matrix compatibility. link:https://github.com/elastic/fleet-server/pull/5392[#5392] link:https://github.com/elastic/fleet-server/issues/5262[#5262]
+ 
 // end 8.19.4 relnotes
 
 // begin 8.19.3 relnotes


### PR DESCRIPTION
Adds Fleet Server and Elastic Agent release notes for 8.19.4 

Related:
- https://github.com/elastic/docs-content/issues/2911

Source PRs:
- https://github.com/elastic/elastic-agent/pull/9921
- https://github.com/elastic/fleet-server/pull/5506

No forwardports required. 