### PR TITLE
Doc: Add Known issue for 8.18.7: Agent stuck on failed upgrade

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -34,6 +34,45 @@ Also see:
 == {fleet} and {agent} 8.18.7
 
 [discrete]
+[[known-issues-8.18.7]]
+=== Known issues
+
+[[known-issue-2978-8-18-7]]
+.Failed upgrades leave {agent} stuck until restart
+[%collapsible]
+====
+
+This known issue applies to {agent} 8.18.7 and 9.0.7. {agent} versions 8.19.x and 9.1.x are not affected.
+
+On September 17, 2025, a known issue was discovered that can cause {agent} upgrades to get stuck if an upgrade attempt fails early. This happens because the coordinator's overrideState remains set, leaving the agent in a state that appears to be upgrading.
+
+**Conditions**
+
+This issue is triggered if the upgrade fails during one of the early checks inside Coordinator.Upgrade, for example:
+
+- The agent is not upgradeable
+- Capabilities check denies the upgrade
+- Most commonly: When {agent} is tamper-protected and Endpoint returns an error during action proxying, for example, because the upgrade action signature is invalid, missing, or fails verification. This causes the coordinator's override state to be stuck.
+
+**Symptoms**
+
+- {fleet} shows the upgrade action in progress, even though the upgrade remains stuck
+- No further upgrade attempts succeed 
+- Elastic-agent status shows an override state indicating upgrade 
+
+**Workaround**
+
+Restart the {agent} to clear the coordinator's overrideState and allow new upgrade attempts to proceed.
+
+**Resolution**
+
+This issue was fixed in link:https://github.com/elastic/elastic-agent/pull/9992[#9992], which ensures that the coordinator clears its override state whenever an early failure occurs.
+
+This fix will be included in versions 9.1.4, 8.19.4, 9.0.8, and 8.18.8.
+
+====
+
+[discrete]
 [[features-enhancements-8.18.7]]
 === New features and enhancements 
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -44,31 +44,31 @@ Also see:
 
 This known issue applies to {agent} 8.18.7 and 9.0.7. {agent} versions 8.19.x and 9.1.x are not affected.
 
-On September 17, 2025, a known issue was discovered that can cause {agent} upgrades to get stuck if an upgrade attempt fails under specific conditions. This happens because the coordinator's overrideState remains set, leaving the agent in a state that appears to be upgrading.
+On September 17, 2025, a known issue was discovered that can cause {agent} upgrades to get stuck if an upgrade attempt fails under specific conditions. This happens because the coordinator's `overrideState` remains set, leaving the agent in a state that appears to be upgrading.
 
 **Conditions**
 
-This issue is triggered if the upgrade fails during one of the early checks inside Coordinator.Upgrade, for example:
+This issue is triggered if the upgrade fails during one of the early checks inside `Coordinator.Upgrade`, for example:
 
 - The agent is not upgradeable
 - Capabilities check denies the upgrade
-- Most commonly: When {agent} is tamper-protected and Endpoint fails to validate that the upgrade action was correctly signed by Kibana to allow the upgrade, for example, because the signature is missing, invalid, or the connection between {agent} and endpoint was interrupted. This causes the agent coordinator's override state to become stuck until the agent is restarted.
+- When {agent} is tamper-protected, Endpoint must validate that the upgrade action was correctly signed by Kibana to allow the upgrade. If the signature is missing, invalid, or the connection between {agent} and Endpoint was interrupted, the validation fails. This causes the agent coordinator's override state to become stuck until the agent is restarted.
 
 **Symptoms**
 
 - {fleet} shows the upgrade action in progress, even though the upgrade remains stuck
 - No further upgrade attempts succeed 
-- Elastic-agent status shows an override state indicating upgrade 
+- Elastic Agent status shows an override state indicating upgrade 
 
 **Workaround**
 
-Restart the {agent} to clear the coordinator's overrideState and allow new upgrade attempts to proceed.
+Restart the {agent} to clear the coordinator's `overrideState` and allow new upgrade attempts to proceed.
 
 **Resolution**
 
 This issue was fixed in link:https://github.com/elastic/elastic-agent/pull/9992[#9992], which ensures that the coordinator clears its override state whenever an early failure occurs.
 
-This fix will be included in versions 9.1.4, 8.19.4, 9.0.8, and 8.18.8.
+The fix is included in versions 9.1.4 and 8.19.4, and planned for versions 9.0.8 and 8.18.8.
 
 ====
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -44,7 +44,7 @@ Also see:
 
 This known issue applies to {agent} 8.18.7 and 9.0.7. {agent} versions 8.19.x and 9.1.x are not affected.
 
-On September 17, 2025, a known issue was discovered that can cause {agent} upgrades to get stuck if an upgrade attempt fails early. This happens because the coordinator's overrideState remains set, leaving the agent in a state that appears to be upgrading.
+On September 17, 2025, a known issue was discovered that can cause {agent} upgrades to get stuck if an upgrade attempt fails under specific conditions. This happens because the coordinator's overrideState remains set, leaving the agent in a state that appears to be upgrading.
 
 **Conditions**
 
@@ -52,7 +52,7 @@ This issue is triggered if the upgrade fails during one of the early checks insi
 
 - The agent is not upgradeable
 - Capabilities check denies the upgrade
-- Most commonly: When {agent} is tamper-protected and Endpoint returns an error during action proxying, for example, because the upgrade action signature is invalid, missing, or fails verification. This causes the coordinator's override state to be stuck.
+- Most commonly: When {agent} is tamper-protected and Endpoint fails to validate that the upgrade action was correctly signed by Kibana to allow the upgrade, for example, because the signature is missing, invalid, or the connection between {agent} and endpoint was interrupted. This causes the agent coordinator's override state to become stuck until the agent is restarted.
 
 **Symptoms**
 


### PR DESCRIPTION
Closes: https://github.com/elastic/docs-content/issues/2978

Adds known issue to docs: "Failed upgrades leave agent stuck until restart"