### PR TITLE
Backport fleet-server#5515 to 8.18

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -57,8 +57,8 @@ This issue is triggered if the upgrade fails during one of the early checks insi
 **Symptoms**
 
 - {fleet} shows the upgrade action in progress, even though the upgrade remains stuck
-- No further upgrade attempts succeed 
-- Elastic Agent status shows an override state indicating upgrade 
+- No further upgrade attempts succeed
+- Elastic Agent status shows an override state indicating upgrade
 
 **Workaround**
 
@@ -72,9 +72,16 @@ The fix is included in versions 9.1.4 and 8.19.4, and planned for versions 9.0.8
 
 ====
 
+[[known-issue-5515-8.18.7]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
+====
+
 [discrete]
 [[features-enhancements-8.18.7]]
-=== New features and enhancements 
+=== New features and enhancements
 
 Elastic Agent::
 * Bump kube-stack Helm Chart to 0.9.1 and enable the cluster collector. link:https://github.com/elastic/elastic-agent/pull/9535[#9535]
@@ -113,6 +120,17 @@ the connection before the TLS handshake.
 == {fleet} and {agent} 8.18.6
 
 Review important information about the 8.18.6 release.
+
+[discrete]
+[[known-issues-8.18.6]]
+=== Known issues
+
+[[known-issue-5515-8.18.6]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
+====
 
 [discrete]
 [[security-updates-8.18.6]]
@@ -158,6 +176,17 @@ Fleet Server::
 == {fleet} and {agent} 8.18.5
 
 Review important information about the 8.18.5 release.
+
+[discrete]
+[[known-issues-8.18.5]]
+=== Known issues
+
+[[known-issue-5515-8.18.5]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
+====
 
 [discrete]
 [[bug-fixes-8.18.5]]
@@ -215,6 +244,13 @@ curl --request POST \
   --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
 ----
 
+====
+
+[[known-issue-5515-8.18.4]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
 ====
 
 [discrete]
@@ -280,6 +316,13 @@ curl --request POST \
   --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
 ----
 
+====
+
+[[known-issue-5515-8.18.3]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
 ====
 
 [discrete]
@@ -392,6 +435,13 @@ curl --request POST \
 
 ====
 
+[[known-issue-5515-8.18.2]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
+====
+
 // end 8.18.2 relnotes
 
 // begin 8.18.1 relnotes
@@ -465,6 +515,13 @@ curl --request POST \
   --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
 ----
 
+====
+
+[[known-issue-5515-8.18.1]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+include::release-notes-8.18.asciidoc[tag=known-issue-5515-8.18]
 ====
 
 [discrete]
@@ -570,6 +627,39 @@ curl --request POST \
   --data '{"version": "<VERSION>","force": true,"agents":["<AGENT_IDS>"]}'
 ----
 
+====
+
+[[known-issue-5515-8.18.0]]
+.fleet-agents template is missing mappings
+[%collapsible]
+====
+// tag::known-issue-5515-8.18[]
+*Details* +
+
+On May 2, 2025 a known issue was discovered that the `.fleet-agents` index template was missing a mapping for the `local_metadata.complete` attribute. This may cause agent checkins to be rejected and the agents to appear as offline.
+
+In this {fleet}'s logs this will appear as:
+[source,shell]
+----
+elastic fail 400: document_parsing_exception: [1:209] object mapping for [local_metadata] tried to parse field [local_metadata] as object, but found a concrete value
+Eat bulk checkin error; Keep on truckin'
+----
+And in the {agent} logs it will appear as:
+[source,shell]
+----
+"log.level":"error","@timestamp":"2025-04-22:12:35:25.295Z","message":"Eat bulk checkin error; Keep on truckin'","component":{"binary":"fleet-server","dataset":"elastic_agent.fleet_server","id":"fleet-server-es-containerhost","type":"fleet-server"},"log":{"source":"fleet-server-es-containerhost"},"service.type":"fleet-server","error.message":"elastic fail 400: document_parsing_exception: [1:209] object mapping for [local_metadata] tried to parse field [local_metadata] as object, but found a concrete value","ecs.version":"1.6.0","service.name":"fleet-server","ecs.version":"1.6.0"
+----
+This attribute was added to the template in versions: 8.17.11 8.18.3, and 8.19.3.
+
+Further investigation revealed that the `.fleet-agents` index template was not correctly applied due to an unchanged `_meta.managed_index_mappings_version` number.
+This change also affects other attributes as well, such as `upgrade_attempts`, `namespaces`, `unprivileged`, and `unhealthy_reason`.
+If there is an error related to any of these attributes, there will be a similar error message in the logs.
+
+*Impact* +
+
+Updating to a version with a fixed `_meta.managed_index_mappings_version` will correctly apply the new index template.
+The fixed versions are 8.18.8, 8.19.4, 9.0.8, 9.1.4.
+// end::known-issue-5515-8.18[]
 ====
 
 [discrete]


### PR DESCRIPTION
Backport https://github.com/elastic/fleet-server/pull/5515 for 8.18.

Add a known-issue for the missing local_metadata.complete mapping.
This issue is still ongoing (even though the attribute has been added to the template) as we have missed updating managed_index_mappings_version, see [this discussion](https://github.com/elastic/elasticsearch/pull/134711#issuecomment-3291957962).