### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.5

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.5>>
 * <<release-notes-8.19.4>>
 * <<release-notes-8.19.3>>
 * <<release-notes-8.19.2>>
@@ -24,6 +25,35 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.5 relnotes
+
+[[release-notes-8.19.5]]
+== {fleet} and {agent} 8.19.5
+
+[discrete]
+[[features-enhancements-8.19.5]]
+=== New features and enhancements
+
+Elastic Agent::
+
+* Agent cleans up downloads directory and the new versioned home if upgrade fails. https://github.com/elastic/elastic-agent/pull/9386[#9386] https://github.com/elastic/elastic-agent/issues/5235[#5235]
+* When there is a disk space error during an upgrade, agent responds with clean insufficient disk space error message. https://github.com/elastic/elastic-agent/pull/9392[#9392] https://github.com/elastic/elastic-agent/issues/5235[#5235]
+* Add Headers Setter extension to EDOT Collector. https://github.com/elastic/elastic-agent/pull/9903[#9903] https://github.com/elastic/elastic-agent/issues/9889[#9889]
+* Update OTel components to v0.132.0. https://github.com/elastic/elastic-agent/pull/9964[#9964]
+
+[discrete]
+[[bug-fixes-8.19.5]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Include aggregated agent status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/9673[#9673] https://github.com/elastic/elastic-agent/issues/9576[#9576]
+* Reduce-default-telemetry-frequency. https://github.com/elastic/elastic-agent/pull/9987[#9987]
+* Fix stuck upgrade state by clearing coordinator overridden state after failed upgrade. https://github.com/elastic/elastic-agent/pull/9992[#9992]
+* Include components units status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/10060[#10060] https://github.com/elastic/elastic-agent/issues/8047[#8047]
+
+// end 8.19.5 relnotes
 
 // begin 8.19.4 relnotes
 


### PR DESCRIPTION
Related: https://github.com/elastic/docs-content/issues/3264

Content source from change logs: 
- Agent: https://github.com/elastic/elastic-agent/pull/10263
- Fleet: NO CHANGES

**PREVIEW:** https://ingest-docs_bk_1863.docs-preview.app.elstc.co/guide/en/fleet/8.19/release-notes-8.19.5.html