### PR TITLE
Doc: Add Fleet and Agent release notes for 8.18.8

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -52,7 +52,7 @@ Elastic Agent::
 * Include aggregated agent status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/9673[#9673] https://github.com/elastic/elastic-agent/issues/9576[#9576]
 * Reduce-default-telemetry-frequency. https://github.com/elastic/elastic-agent/pull/9987[#9987]
 * Fix stuck upgrade state by clearing coordinator overridden state after failed upgrade. https://github.com/elastic/elastic-agent/pull/9992[#9992]
-* Include components units status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/10266[#10266] https://github.com/elastic/elastic-agent/pull/10158[#10158] https://github.com/elastic/elastic-agent/pull/10207[#10207] https://github.com/elastic/elastic-agent/pull/10286[#10286] https://github.com/elastic/elastic-agent/pull/10296[#10296] https://github.com/elastic/elastic-agent/pull/10265[#10265] https://github.com/elastic/elastic-agent/pull/10060[#10060] https://github.com/elastic/elastic-agent/issues/8047[#8047]
+* Include components units status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/10060[#10060] https://github.com/elastic/elastic-agent/issues/8047[#8047]
 
 // end 8.18.8 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.18.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.18.8>>
 * <<release-notes-8.18.7>>
 * <<release-notes-8.18.6>>
 * <<release-notes-8.18.5>>
@@ -27,6 +28,33 @@ Also see:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.18.8 relnotes
+
+[[release-notes-8.18.8]]
+== {fleet} and {agent} 8.18.8
+
+[discrete]
+[[features-enhancements-8.18.8]]
+=== New features and enhancements
+
+Elastic Agent::
+
+* Agent cleans up downloads directory and the new versioned home if upgrade fails. https://github.com/elastic/elastic-agent/pull/9386[#9386] https://github.com/elastic/elastic-agent/issues/5235[#5235]
+* When there is a disk space error during an upgrade, agent responds with clean insufficient disk space error message. https://github.com/elastic/elastic-agent/pull/9392[#9392] https://github.com/elastic/elastic-agent/issues/5235[#5235]
+
+[discrete]
+[[bug-fixes-8.18.8]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Include aggregated agent status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/9673[#9673] https://github.com/elastic/elastic-agent/issues/9576[#9576]
+* Reduce-default-telemetry-frequency. https://github.com/elastic/elastic-agent/pull/9987[#9987]
+* Fix stuck upgrade state by clearing coordinator overridden state after failed upgrade. https://github.com/elastic/elastic-agent/pull/9992[#9992]
+* Include components units status in HTTP liveness checks. https://github.com/elastic/elastic-agent/pull/10266[#10266] https://github.com/elastic/elastic-agent/pull/10158[#10158] https://github.com/elastic/elastic-agent/pull/10207[#10207] https://github.com/elastic/elastic-agent/pull/10286[#10286] https://github.com/elastic/elastic-agent/pull/10296[#10296] https://github.com/elastic/elastic-agent/pull/10265[#10265] https://github.com/elastic/elastic-agent/pull/10060[#10060] https://github.com/elastic/elastic-agent/issues/8047[#8047]
+
+// end 8.18.8 relnotes
 
 // begin 8.18.7 relnotes
 


### PR DESCRIPTION
Related: https://github.com/elastic/docs-content/issues/3266

#### Content source from change logs: 
- Agent: https://github.com/elastic/elastic-agent/pull/10266
- Fleet: NO CHANGES

**PREVIEW::** https://ingest-docs_bk_1864.docs-preview.app.elstc.co/guide/en/fleet/8.18/release-notes-8.18.8.html