### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.11

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.11>>
 * <<release-notes-8.19.10>>
 * <<release-notes-8.19.9>>
 * <<release-notes-8.19.8>>
@@ -30,6 +31,31 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.11 relnotes
+
+[[release-notes-8.19.11]]
+== {fleet} and {agent} 8.19.11
+
+[discrete]
+[[security-updates-8.19.11]]
+=== Security updates
+
+Fleet Server::
+
+* Enforce maximum limits on UploadBegin and UploadComplete request body sizes. https://github.com/elastic/fleet-server/pull/6159[#6159]
+
+[discrete]
+[[bug-fixes-8.19.11]]
+=== Bug fixes
+
+Elastic Agent::
+
+* OSQuery - Add list capabilities to directories for interactive users. https://github.com/elastic/elastic-agent/pull/12189[#12189] 
+* Emit the correct error message when the app lock cannot be acquired. https://github.com/elastic/elastic-agent/pull/12225[#12225]
+* Fix elasticsearch retry behavior in OTEL runtime for reliable delivery. https://github.com/elastic/elastic-agent/pull/12455[#12455]
+
+// end 8.19.11 relnotes
 
 // begin 8.19.10 relnotes
 


### PR DESCRIPTION
#### Content sourced from changelogs: 
- Agent: https://github.com/elastic/elastic-agent/pull/12501
- Fleet: https://github.com/elastic/fleet-server/pull/6252

No additional forward- or backports required. 
Source PRs can be closed or merged.

**PREVIEW:**  https://ingest-docs_bk_1881.docs-preview.app.elstc.co/guide/en/fleet/8.19/release-notes-8.19.11.html