### PR TITLE
[8.19] Clarify endpoints for checking EPR health/readiness in air-gapped environments

### DIFF
--- a/docs/en/ingest-management/fleet/air-gapped.asciidoc
+++ b/docs/en/ingest-management/fleet/air-gapped.asciidoc
@@ -183,6 +183,9 @@ docker run -it -p 8080:8080 \
     --health-cmd "curl -f -L http://127.0.0.1:8080/health" \
     docker.elastic.co/package-registry/distribution:{version}
 ----
++
+You can use the `/health` or `/health?ready=true` API endpoints to check if EPR is ready to serve requests.
+When either endpoint returns a `200` HTTP status code, the service is ready to handle requests.
 
 [discrete]
 [[air-gapped-diy-epr-kibana]]


### PR DESCRIPTION
This PR is a backport of https://github.com/elastic/docs-content/pull/2130 and clarifies the endpoints for checking EPR health and readiness in air-gapped environments.