### PR TITLE
[Agent] New serverless config example for Logstash output 8.19

### DIFF
--- a/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
+++ b/docs/en/ingest-management/elastic-agent/configuration/outputs/output-logstash.asciidoc
@@ -37,7 +37,7 @@ We recommend that the pipeline doesn’t edit or remove the fields and their con
 Editing the structure of the documents coming from {agent} can prevent the {es} ingest pipelines associated to the integrations in use to work correctly.
 We cannot guarantee that the {es} ingest pipelines associated to the integrations using {agent} can work with missing or modified fields.
 
-The following {ls} pipeline definition example configures a pipeline that listens on port `5044` for
+This {ls} pipeline definition example configures a pipeline that listens on port `5044` for
 incoming {agent} connections and routes received events to {es}.
 
 

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -117,7 +117,8 @@ The configuration needed on {ecloud} is different from
 self-managed {es} clusters. If you copied the configuration shown in {fleet},
 adjust it as needed.
 
-### {es-serverless} example
+[discrete]
+=== {es-serverless} example
 
 [source,text]
 ----
@@ -143,8 +144,8 @@ output {
 <1> The Elasticsearch endpoint URL for your {es-serverless} project is available in **Application endpoints, cluster and component IDs**. Select **Manage** next to your project to access this information.
 <2> In {fleet}, you can generate this API key when you add a {ls} output.
 
-
-### {ech} example
+[discrete]
+=== {ech} example
 
 [source,text]
 ----
@@ -170,6 +171,7 @@ output {
 <1> Use the `cloud_id` shown on your deployment page in {ecloud}.
 <2> In {fleet}, you can generate this API key when you add a {ls} output.
 
+[discrete]
 === Self-managed {es} cluster example
 
 [source,text]

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -141,7 +141,7 @@ output {
   }
 }
 ----
-<1> The Elasticsearch endpoint URL for your {es-serverless} project is available in **Application endpoints, cluster and component IDs**. Select **Manage** next to your project to access this information.
+<1> The {es} endpoint URL for your {es-serverless} project is available in **Application endpoints, cluster and component IDs**. Select **Manage** next to your project to access this information.
 <2> In {fleet}, you can generate this API key when you add a {ls} output.
 
 [discrete]

--- a/docs/en/ingest-management/security/logstash-certificates.asciidoc
+++ b/docs/en/ingest-management/security/logstash-certificates.asciidoc
@@ -112,12 +112,39 @@ add the following configuration. Replace the path to your file.
   path.config: "/etc/path/to/elastic-agent-pipeline.conf"
 ----
 
-In the `elastic-agent-pipeline.conf` file, add the pipeline configuration. Note
-that the configuration needed for {ess} on {ecloud} is different from
+In the `elastic-agent-pipeline.conf` file, add the pipeline configuration. 
+The configuration needed on {ecloud} is different from
 self-managed {es} clusters. If you copied the configuration shown in {fleet},
 adjust it as needed.
 
-{ess} example:
+### {es-serverless} example
+
+[source,text]
+----
+input {
+  elastic_agent {
+    port => 5044
+    ssl_enabled => true
+    ssl_certificate_authorities => ["/path/to/ca.crt"]
+    ssl_certificate => "/path/to/logstash.crt"
+    ssl_key => "/path/to/logstash.pkcs8.key"
+    ssl_client_authentication => "required"
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "ELASTICSEARCH_ENDPOINT_URL" <1>
+    api_key => "xxxx:xxxx" <2>
+    data_stream => true
+  }
+}
+----
+<1> The Elasticsearch endpoint URL for your {es-serverless} project is available in **Application endpoints, cluster and component IDs**. Select **Manage** next to your project to access this information.
+<2> In {fleet}, you can generate this API key when you add a {ls} output.
+
+
+### {ech} example
 
 [source,text]
 ----
@@ -137,16 +164,13 @@ output {
     cloud_id => "xxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxxxx=" <1>
     api_key => "xxxx:xxxx" <2>
     data_stream => true
-    ssl => true <3>
   }
 }
 ----
 <1> Use the `cloud_id` shown on your deployment page in {ecloud}.
 <2> In {fleet}, you can generate this API key when you add a {ls} output.
-<3> {ess} uses standard publicly trusted certificates, so there's no need
-specify other SSL settings here.
 
-Self-managed {es} cluster example:
+=== Self-managed {es} cluster example
 
 [source,text]
 ----


### PR DESCRIPTION
Provides a Serverless config example, showing Elastic endpoint URL and an API key to establish the connection from Logstash to Serverless. Cloud ID is not viewable in the Cloud console.

Original issue: https://github.com/elastic/docs-content/issues/5192
Parent issue: https://github.com/elastic/docs-content-internal/issues/777

Refactored backport of https://github.com/elastic/docs-content/pull/5193