### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.12

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -48,7 +48,7 @@ Elastic Agent::
 
 Fleet Server::
 
-* Update Go version to v1.25.7. https://github.com/elastic/fleet-server/pull/6322[#6322] 
+* Update Go to v1.25.7. https://github.com/elastic/fleet-server/pull/6322[#6322] 
 
 
 [discrete]
@@ -57,8 +57,8 @@ Fleet Server::
 
 Elastic Agent::
 
-* Adds a missing dependency for Synthetics on wolfi docker image. https://github.com/elastic/elastic-agent/pull/12453[#12453]
-* Ensure otel collector health check requests reuse the TCP connection. https://github.com/elastic/elastic-agent/pull/12517[#12517]
+* Adds a missing dependency for Synthetics on Wolfi Docker image. https://github.com/elastic/elastic-agent/pull/12453[#12453]
+* Ensure OTel Collector health check requests reuse the TCP connection. https://github.com/elastic/elastic-agent/pull/12517[#12517]
 
 // end 8.19.12 relnotes
 

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.12>>
 * <<release-notes-8.19.11>>
 * <<release-notes-8.19.10>>
 * <<release-notes-8.19.9>>
@@ -31,6 +32,35 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.12 relnotes
+
+[[release-notes-8.19.12]]
+== {fleet} and {agent} 8.19.12
+
+[discrete]
+[[features-enhancements-8.19.12]]
+=== New features and enhancements
+
+Elastic Agent::
+
+* Update OTel Collector components to v0.144.0/v1.50.0. https://github.com/elastic/elastic-agent/pull/12735[#12735]
+
+Fleet Server::
+
+* Update Go version to v1.25.7. https://github.com/elastic/fleet-server/pull/6322[#6322] 
+
+
+[discrete]
+[[bug-fixes-8.19.12]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Adds a missing dependency for Synthetics on wolfi docker image. https://github.com/elastic/elastic-agent/pull/12453[#12453]
+* Ensure otel collector health check requests reuse the TCP connection. https://github.com/elastic/elastic-agent/pull/12517[#12517]
+
+// end 8.19.12 relnotes
 
 // begin 8.19.11 relnotes
 


### PR DESCRIPTION
#### Content sourced from changelogs: 
- Agent: https://github.com/elastic/elastic-agent/pull/12861
- Fleet: https://github.com/elastic/fleet-server/pull/6395

No additional forward- or backports required. 
Source PRs can be closed or merged.




**PREVIEW:**  https://ingest-docs_bk_1896.docs-preview.app.elstc.co/guide/en/fleet/8.19/release-notes-8.19.12.html