### PR TITLE
[8.19] Docs: Add instructions for deploying Fleet Server behind load balancer

### DIFF
--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -239,6 +239,36 @@ by going to: *Management* -> *{fleet}* -> *Settings*. From there you can:
 ** Specify proxy URLs to use for {fleet-server} or {agent} outputs.
 
 [discrete]
+[[fleet-server-setup-using-a-load-balancer]]
+= {fleet-server} setup using a load balancer
+
+Follow these steps when deploying {fleet-server} behind a load balancer/reverse proxy:
+
+. Create a certificate that contains DNS entries for the agent-facing load balancer,
+and the hostnames it routes to. For example, the load balancer `fleet.example.com`
+will route to hostnames `fleet1.example.com` and `fleet2.example.com`.
+. Configure the load balancer/reverse proxy.
++
+* Ensure the load balancer directs traffic to all {fleet-server} instances.
+* Ensure that timeouts for the load balancer have been raised to support the
+long-polling connections {agent}s create when checking in to {fleet-server}.
++
+By default, the timeout for long-poll in {fleet-server} is 5 minutes, while the
+{fleet-server}'s write timeout and the {agent}'s request timeout are set to 10
+minutes. In this case, the load balancer timeout should be set to 10 minutes.
++
+* (Recommended) Configure the load balancer with TLS pass through.
++
+NOTE: Starting with {stack} version 8.19.13, you can use the {fleet-server}
+`GET /api/status` API endpoint to determine instance health from the load balancer.
++
+. In *{fleet}* > *Settings*, add the load balancer (for example,`https://fleet.example.com:8220`)
+as a {fleet-server} host.
+. Install {fleet-server} on each backing host using the in-product instructions
+which should specify the load balancer as the URL.
+. Enroll other {agent} instances using the load balancer URL.
+
+[discrete]
 [[add-fleet-server-on-prem-troubleshoot]]
 = Troubleshooting
 

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -258,10 +258,10 @@ By default, the timeout for long-poll in {fleet-server} is 5 minutes, while the
 minutes. In this case, the load balancer timeout should be set to 10 minutes.
 +
 * (Recommended) Configure the load balancer with TLS pass through.
-
++
 NOTE: Starting with {stack} version 8.19.13, you can use the {fleet-server}
 `GET /api/status` API endpoint to determine instance health from the load balancer.
-
++
 . In *{fleet}* > *Settings*, add the load balancer (for example,`https://fleet.example.com:8220`)
 as a {fleet-server} host.
 . Install {fleet-server} on each backing host using the in-product instructions

--- a/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
+++ b/docs/en/ingest-management/fleet/add-fleet-server-on-prem.asciidoc
@@ -258,10 +258,10 @@ By default, the timeout for long-poll in {fleet-server} is 5 minutes, while the
 minutes. In this case, the load balancer timeout should be set to 10 minutes.
 +
 * (Recommended) Configure the load balancer with TLS pass through.
-+
+
 NOTE: Starting with {stack} version 8.19.13, you can use the {fleet-server}
 `GET /api/status` API endpoint to determine instance health from the load balancer.
-+
+
 . In *{fleet}* > *Settings*, add the load balancer (for example,`https://fleet.example.com:8220`)
 as a {fleet-server} host.
 . Install {fleet-server} on each backing host using the in-product instructions


### PR DESCRIPTION
This PR is a manual backport of https://github.com/elastic/docs-content/pull/5273.

The note in the added content mentions a functionality that is available from 9.2+ and which was backported to 8.19.13 (based on the changes and comments in https://github.com/elastic/docs-content/pull/5335), so the content is adjusted accordingly.

Contributes to https://github.com/elastic/ingest-docs/issues/323