### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.14

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.14>>
 * <<release-notes-8.19.13>>
 * <<release-notes-8.19.12>>
 * <<release-notes-8.19.11>>
@@ -33,6 +34,42 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.14 relnotes
+
+[[release-notes-8.19.14]]
+== {fleet} and {agent} 8.19.14
+
+[discrete]
+[[new-features-8.19.14]]
+=== New features
+
+Elastic Agent::
+
+* Add Cloud Defend Integration support to the helm chart. https://github.com/elastic/elastic-agent/pull/13074[#13074]
+
+[discrete]
+[[enhancements-8.19.14]]
+=== Enhancements
+
+Elastic Agent::
+
+* Update Go to v1.25.8. https://github.com/elastic/elastic-agent/pull/10156[#10156]
+* Update OTel components to v0.145.0. https://github.com/elastic/elastic-agent/pull/13104[#13104]
+* Update OTel to v1.54.0/v0.148.0. https://github.com/elastic/elastic-agent/pull/13317[#13317]
+
+[discrete]
+[[bug-fixes-8.19.14]]
+=== Bug fixes
+
+Elastic Agent::
+
+* Update Kubernetes example manifests and add `HOSTFS_PROC_PATH` environment variable due to `procfs` fix in `cloud-defend` as well as mount points required for `cloud-defend`. https://github.com/elastic/elastic-agent/pull/12989[#12989]
+* Fix an issue where some components could be missing from the status output. https://github.com/elastic/elastic-agent/pull/13119[#13119] 
+* Prevent zombie processes when component fails to shutdown. https://github.com/elastic/elastic-agent/pull/13188[#13188] https://github.com/elastic/elastic-agent/issues/13272[#13272]
+* Fix container enrollment so it does not re-enroll when the Fleet URL is the same. https://github.com/elastic/elastic-agent/pull/13187[#13187]
+
+// end 8.19.14 relnotes
 
 // begin 8.19.13 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.14 release notes for Fleet and Elatic Agent. The content is sourced from these generated changelogs:

- [Add Elastic Agent 8.19.14 release notes](https://github.com/elastic/elastic-agent/pull/13461)
- [Add Fleet Server 8.19.14 release notes](https://github.com/elastic/fleet-server/pull/6748)

No additional forward- or backports required.
Source PRs can be closed or merged.