### PR TITLE
Update --delay-enroll option description (retry indefinitely)

### DIFF
--- a/docs/en/ingest-management/commands.asciidoc
+++ b/docs/en/ingest-management/commands.asciidoc
@@ -242,9 +242,11 @@ Comma-separated list of root certificates used for server verification.
 Timeout waiting for {agent} daemon.
 
 `--delay-enroll`::
-Delays enrollment to occur on first start of the {agent} service. This setting
-is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for
-example, when you're preparing an image that includes {agent}.
+Delays enrollment to occur on first start of the {agent} service. This setting 
+is useful when you don't want the {agent} to enroll until the next reboot or manual start of the service, for 
+example, when you're preparing an image that includes {agent} or deploying to environments where network access 
+may not be immediately available. If {fleet-server} is unreachable when the service starts, {agent} will retry
+enrollment indefinitely until it succeeds.
 
 `--elastic-agent-cert`::
 Certificate to use as the client certificate for the {agent}'s connections to {fleet-server}.


### PR DESCRIPTION
asciidoc equivalent of now-merged https://github.com/elastic/docs-content/pull/5779

Expands explanation of the `--delay-enroll` option to include scenarios where network access may not be immediately available to align with indefinite enrollment attempt introduced in elastic/elastic-agent#4727

