### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.16

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.16>>
 * <<release-notes-8.19.15>>
 * <<release-notes-8.19.14>>
 * <<release-notes-8.19.13>>
@@ -35,6 +36,50 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.16 relnotes
+
+[[release-notes-8.19.16]]
+== {fleet} and {agent} 8.19.16
+
+[discrete]
+[[security-updates-8.19.16]]
+=== Security updates
+
+* Upgrade npm to v11 in non-wolfi `elastic-agent-complete` Docker images. https://github.com/elastic/elastic-agent/pull/14167[#14167]
+* Fix missing `authAgent` in `UploadChunk`. https://github.com/elastic/fleet-server/pull/7020[#7020]
+
+[discrete]
+[[new-features-8.19.16]]
+=== New features
+
+* Add Azure encoding extension to EDOT Collector. https://github.com/elastic/elastic-agent/pull/13583[#13583]
+
+[discrete]
+[[enhancements-8.19.16]]
+=== Enhancements
+
+* Update Go to v1.26.3. https://github.com/elastic/elastic-agent/pull/14168[#14168]
+* Update EDOT SDK Kubernetes auto-instrumentation images to their latest versions. https://github.com/elastic/elastic-agent/pull/12685[#12685]
+* Update OTel Collector components to v0.152.0. https://github.com/elastic/elastic-agent/pull/14366[#14366] 
+
+[discrete]
+[[bug-fixes-8.19.16]]
+=== Bug fixes
+
+* Make enrollment retry backoff respect context cancellation. https://github.com/elastic/elastic-agent/pull/13698[#13698]
+* Clean up leftover artifacts when `elastic-agent install` fails. https://github.com/elastic/elastic-agent/pull/13705[#13705]
+* Stop the Windows service promptly during enrollment retries. https://github.com/elastic/elastic-agent/pull/13878[#13878]
+* Fix profiling agent DaemonSet deployment on Kubernetes v1.33+. https://github.com/elastic/elastic-agent/pull/13894[#13894]
+* Clamp non-positive `agent.download.retry_sleep_init_duration` values to the default of `30s` to prevent download retry storms. https://github.com/elastic/elastic-agent/pull/13974[#13974]
+* Redact sensitive values in slice maps. https://github.com/elastic/elastic-agent/pull/14007[#14007] https://github.com/elastic/elastic-agent-libs/issues/415[#415]
+* Ship config samples and endpoint resources zip without executable bits. https://github.com/elastic/elastic-agent/pull/14117[#14117] https://github.com/elastic/elastic-agent/issues/13960[#13960]
+* Agent no longer fails to start when the upgrade marker file is corrupt. https://github.com/elastic/elastic-agent/pull/14194[#14194]
+* Fix silent early-return when removing stale enrollment and upgrade artifacts. https://github.com/elastic/elastic-agent/pull/14234[#14234]
+* Fix dangling symlink when rotating to a non-existent target. https://github.com/elastic/elastic-agent/pull/14238[#14238]
+* Prevent upgrade watcher panic when grace period expires. https://github.com/elastic/elastic-agent/pull/14253[#14253]
+
+// end 8.19.16 relnotes
 
 // begin 8.19.15 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.16 release notes for Fleet and Elatic Agent. The content is sourced from these generated changelogs:

- https://github.com/elastic/elastic-agent/pull/14451
- https://github.com/elastic/fleet-server/pull/7091

No additional forward- or backports required.
Source PRs can be closed or merged.