### PR TITLE
Doc: Add Fleet and Agent release notes for 8.19.17

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.17>>
 * <<release-notes-8.19.16>>
 * <<release-notes-8.19.15>>
 * <<release-notes-8.19.14>>
@@ -36,6 +37,41 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.17 relnotes
+
+[[release-notes-8.19.17]]
+== {fleet} and {agent} 8.19.17
+
+[discrete]
+[[new-features-8.19.17]]
+=== New features
+
+* Add Azure Monitor receiver to EDOT Collector. https://github.com/elastic/elastic-agent/pull/14443[#14443]
+* Change `bulk_response_filter_path` in elasticsearch exporter configurations to match beats. https://github.com/elastic/elastic-agent/pull/14452[#14452] https://github.com/elastic/elastic-agent/issues/12688[#12688]
+* Add Azure auth extension to EDOT Collector. https://github.com/elastic/elastic-agent/pull/14665[#14665]
+
+[discrete]
+[[enhancements-8.19.17]]
+=== Enhancements
+
+* Disable TLS certificate hot-reload by default. https://github.com/elastic/elastic-agent/pull/14599[#14599]
+* Update OTel Collector components to v0.153.0. https://github.com/elastic/elastic-agent/pull/14902[#14902]
+
+[discrete]
+[[bug-fixes-8.19.17]]
+=== Bug fixes
+
+* Preserve live install during upgrade cleanup and report aborted upgrades to Fleet. https://github.com/elastic/elastic-agent/pull/14714[#14714]
+* Apply policy log level changes after an agent restart. https://github.com/elastic/elastic-agent/pull/14430[#14430] https://github.com/elastic/elastic-agent/issues/13196[#13196]
+* Notify endpoint-security just before symlink swap, not before upgrade attempt. https://github.com/elastic/elastic-agent/pull/14481[#14481]
+* Honour `--path.logs` when running `elastic-agent run`. https://github.com/elastic/elastic-agent/pull/14476[#14476] https://github.com/elastic/elastic-agent/issues/13320[#13320]
+* Notify Fleet of agent uninstall before marking the installation directory for removal. https://github.com/elastic/elastic-agent/pull/14581[#14581] https://github.com/elastic/elastic-agent/issues/14142[#14142]
+* Read TLS config from environment variables in container mode. https://github.com/elastic/elastic-agent/pull/14758[#14758]
+* Fix container config override inconsistencies. https://github.com/elastic/elastic-agent/pull/14758[#14758]
+* Fix a bug where an empty request body could be sent after failing over to an alternate Fleet host. https://github.com/elastic/elastic-agent/pull/14844[#14844] https://github.com/elastic/elastic-agent/issues/14773[#14773]
+
+// end 8.19.17 relnotes
 
 // begin 8.19.16 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.17 release notes for Fleet and Elastic Agent. The content is sourced from these generated changelogs:

- https://github.com/elastic/elastic-agent/pull/15078
- https://github.com/elastic/fleet-server/pull/7249

No additional forward- or backports are required.
Source PRs can be closed or merged.