### PR TITLE
Add Fleet and Agent release notes for 8.19.18

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.18>>
 * <<release-notes-8.19.17>>
 * <<release-notes-8.19.16>>
 * <<release-notes-8.19.15>>
@@ -37,6 +38,26 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.18 relnotes
+
+[[release-notes-8.19.18]]
+== {fleet} and {agent} 8.19.18
+
+[discrete]
+[[enhancements-8.19.18]]
+=== Enhancements
+
+* Adds `system.cpu.cores` field to self-monitoring data. https://github.com/elastic/elastic-agent/pull/14885[#14885] https://github.com/elastic/elastic-agent/issues/14862[#14862]
+* Don't forcibly inject the `elasticdiagnostic` extension when running in plain OTel mode. https://github.com/elastic/elastic-agent/pull/15105[#15105] https://github.com/elastic/elastic-agent/issues/14606[#14606]
+
+[discrete]
+[[bug-fixes-8.19.18]]
+=== Bug fixes
+
+* Fix an issue where Beat receiver trace logs were missing from the diagnostics bundle. https://github.com/elastic/elastic-agent/pull/14716[#14716]
+
+// end 8.19.17 relnotes
 
 // begin 8.19.17 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.18 release notes for Fleet and Elastic Agent. The content is sourced from these generated changelogs:

- https://github.com/elastic/elastic-agent/pull/15207
- https://github.com/elastic/fleet-server/pull/7294

No additional forward- or backports are required.
Source PRs can be closed or merged.