### PR TITLE
Add Fleet and Agent release notes for 8.19.19

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.19>>
 * <<release-notes-8.19.18>>
 * <<release-notes-8.19.17>>
 * <<release-notes-8.19.16>>
@@ -38,6 +39,35 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.19 relnotes
+
+[[release-notes-8.19.19]]
+== {fleet} and {agent} 8.19.19
+
+[discrete]
+[[security-updates-8.19.19]]
+=== Security updates
+
+* Redact sensitive HTTP header values embedded in Fleet environment variables in diagnostics archives. https://github.com/elastic/elastic-agent/pull/15284[#15284]  
+* Enforce policy-based access control on artifact downloads. https://github.com/elastic/fleet-server/pull/7164[#7164]
+
+[discrete]
+[[enhancements-8.19.19]]
+=== Enhancements
+
+* Update OTel Collector components to v0.155.0. https://github.com/elastic/elastic-agent/pull/15412[#15412] 
+
+[discrete]
+[[bug-fixes-8.19.19]]
+=== Bug fixes
+
+* Fix duplicate entries, empty unit dirs, and EDOT error handling in OTel diagnostics. https://github.com/elastic/elastic-agent/pull/15108[#15108] 
+* Preserve locally-configured `monitoring.http.host` across Fleet policy check-ins. https://github.com/elastic/elastic-agent/pull/15291[#15291]  
+* Fix "failed to unmarshal checkin actions" error on idle Fleet check-ins. https://github.com/elastic/elastic-agent/pull/15398[#15398] https://github.com/elastic/elastic-agent/issues/15397[#15397] 
+* Override `fleet.ssl.certificate_authorities` from environment variables in container mode. https://github.com/elastic/elastic-agent/pull/15427[#15427]  
+
+// end 8.19.19 relnotes
 
 // begin 8.19.18 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.19 release notes for Fleet and Elastic Agent. The content is sourced from these generated changelogs:

- https://github.com/elastic/elastic-agent/pull/15680
- https://github.com/elastic/fleet-server/pull/7407

No additional forward- or backports are required.
Source PRs can be closed or merged.