### PR TITLE
Update upgrade restrictions for agents in documentation

### DIFF
--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -41,7 +41,7 @@ For a detailed view of the {agent} upgrade process and the interactions between 
 
 Note the following restrictions with upgrading an {agent}:
 
-*{agent} cannot be upgraded to a minor version higher than the currently installed minor version of {fleet-server}. For example, you can enroll 8.18.5 {agents} with an 8.18.0 {fleet-server}, but not 8.19.0 {agents}. So while you can install newer maintenance releases, you cannot install newer minor versions. Before you upgrade {agents} to a newer minor version, you should first upgrade any agents that are acting as {fleet-server} (any agents that have a {fleet-server} policy associated with them).
+* You can upgrade {agent} to a newer patch release within its current minor version, but not to a minor version newer than the {fleet-server} it's enrolled with. For example, an 8.18.0 {fleet-server} supports upgrading {agents} to any 8.18.x release, but not to 8.19.0. Before you upgrade {agents} to a new minor version, first upgrade any agents that are acting as {fleet-server} (any agents that have a {fleet-server} policy associated with them).
 * To be upgradeable, {agent} must not be running inside a container.
 * To be upgradeable in a Linux environment, {agent} must be running as a service. The Linux Tar install instructions for {agent} provided in {fleet} include the commands to run it as a service. {agent} RPM and DEB system packages cannot be upgraded through {fleet}.
 

--- a/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
+++ b/docs/en/ingest-management/fleet/upgrade-elastic-agent.asciidoc
@@ -41,7 +41,7 @@ For a detailed view of the {agent} upgrade process and the interactions between 
 
 Note the following restrictions with upgrading an {agent}:
 
-* {agent} cannot be upgraded to a version higher than the highest currently installed version of {fleet-server}. When you upgrade a set of {agents} that are currently at the same version, you should first upgrade any agents that are acting as {fleet-server} (any agents that have a {fleet-server} policy associated with them).
+*{agent} cannot be upgraded to a minor version higher than the currently installed minor version of {fleet-server}. For example, you can enroll 8.18.5 {agents} with an 8.18.0 {fleet-server}, but not 8.19.0 {agents}. So while you can install newer maintenance releases, you cannot install newer minor versions. Before you upgrade {agents} to a newer minor version, you should first upgrade any agents that are acting as {fleet-server} (any agents that have a {fleet-server} policy associated with them).
 * To be upgradeable, {agent} must not be running inside a container.
 * To be upgradeable in a Linux environment, {agent} must be running as a service. The Linux Tar install instructions for {agent} provided in {fleet} include the commands to run it as a service. {agent} RPM and DEB system packages cannot be upgraded through {fleet}.
 


### PR DESCRIPTION
Fixed outdated restrictions verbiage on upgrading agents with respect to Fleet Server versions and minor version limitations.

I used wording that would match the equivalent 9.x doc:
https://www.elastic.co/docs/reference/fleet/upgrade-elastic-agent#upgrade-agent-restrictions

That said, I think the existing 9.x wording is a bit convoluted. It leads with the restriction, then walks it back with a "so while you can... but you cannot..." to note the permissive case  of maintenance upgrades... which I think is more useful to state up front.  I'd suggest something more straightforward for a future change:

>{agent} can be upgraded to a newer maintenance release within its current minor version, but not to a newer minor version than {fleet-server}. For example, an 8.18.0 {fleet-server} supports upgrading {agents} up to any 8.18.x version, but not to 8.19.0. Before you upgrade {agents} to a newer minor version, you should first upgrade any agents that are acting as {fleet-server} (any agents that have a {fleet-server} policy associated with them).
