### PR TITLE
Update CODEOWNERS to change team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/ingest-docs
+* @elastic/ski-docs


### PR DESCRIPTION
Update CODEOWNERS to change team ownership to `@elastic/ski-docs`

Related: https://github.com/elastic/ingest-docs/pull/1917