### PR TITLE
Add Fleet and Agent release notes for 8.19.21

### DIFF
--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -47,6 +47,12 @@ Also check:
 [[release-notes-8.19.21]]
 == {fleet} and {agent} 8.19.21
 
+[IMPORTANT]
+====
+The 8.19.21 release contains fixes for potential security vulnerabilities.
+For details, go to the https://discuss.elastic.co/c/announcements/security-announcements/31[security announcements].
+====
+
 [discrete]
 [[security-updates-8.19.21]]
 === Security updates

--- a/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
+++ b/docs/en/ingest-management/release-notes/release-notes-8.19.asciidoc
@@ -14,6 +14,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.19.21>>
 * <<release-notes-8.19.20>>
 * <<release-notes-8.19.19>>
 * <<release-notes-8.19.18>>
@@ -40,6 +41,38 @@ Also check:
 
 * {kibana-ref}/release-notes.html[{kib} release notes]
 * {beats-ref}/release-notes.html[{beats} release notes]
+
+// begin 8.19.21 relnotes
+
+[[release-notes-8.19.21]]
+== {fleet} and {agent} 8.19.21
+
+[discrete]
+[[security-updates-8.19.21]]
+=== Security updates
+
+* Fix local privilege escalation via binary tampering on Windows unprivileged installs. https://github.com/elastic/elastic-agent/pull/16058[#16058]
+
+[discrete]
+[[enhancements-8.19.21]]
+=== Enhancements
+
+* Update Go to 1.26.6. https://github.com/elastic/fleet-server/pull/7644[#7644] https://github.com/elastic/elastic-agent/pull/16203[#16203]
+* Prevent ghost agent documents caused by concurrent enrollment retries. https://github.com/elastic/fleet-server/pull/7662[#7662]
+* Bump `github.com/kardianos/service` to v1.3.0 and update Linux `systemd` template for new mini template engine. https://github.com/elastic/elastic-agent/pull/15976[#15976]
+
+[discrete]
+[[bug-fixes-8.19.21]]
+=== Bug fixes
+
+* Reject stale policy revisions before secret resolution in the policy monitor. https://github.com/elastic/fleet-server/pull/7572[#7572] https://github.com/elastic/fleet-server/issues/7570[#7570]
+* Read `cgroup` memory limit for cache sizing when `GOMEMLIMIT` is not set. https://github.com/elastic/fleet-server/pull/7573[#7573]
+* Fix Windows FIPS upgrade failure caused by mismatched directory name. https://github.com/elastic/elastic-agent/pull/16065[#16065] 
+* Align OTel Elasticsearch exporter request and document retry behavior with Beats Elasticsearch output. https://github.com/elastic/elastic-agent/pull/16089[#16089] https://github.com/elastic/elastic-agent/issues/14531[#14531]
+* Allow the current Windows Agent user to write component executables. https://github.com/elastic/elastic-agent/pull/16173[#16173] 
+* Diagnostics now collects component trace logs in container deployments. https://github.com/elastic/elastic-agent/pull/16177[#16177] 
+
+// end 8.19.21 relnotes
 
 // begin 8.19.20 relnotes
 


### PR DESCRIPTION
This PR adds the 8.19.21 release notes for Fleet and Elastic Agent. The content is sourced from these generated changelogs:

- https://github.com/elastic/elastic-agent/pull/16400
- https://github.com/elastic/fleet-server/pull/7707

No additional forward- or backports are required.
Source PRs can be closed or merged.